### PR TITLE
Fix vim dot-repeat dropping inserted text of change/insert commands (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Kodemirror will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Vim dot-repeat (`.`) dropped the inserted text of change/insert commands (`c`, `cw`, `s`, `i`, `a`, `o`, …) — the insert-mode change event was never wired up, so `lastInsertModeChanges` stayed empty and `.` replayed only the operator/delete (#21)
+
 ## [0.2.0] - 2026-04-10
 
 ### Highlights

--- a/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/Vim.kt
+++ b/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/Vim.kt
@@ -244,12 +244,14 @@ object Vim : VimApiInterface {
     }
 
     internal val cursorActivityHandlers = mutableMapOf<VimEditor, (Array<out Any?>) -> Unit>()
+    internal val changeHandlers = mutableMapOf<VimEditor, (Array<out Any?>) -> Unit>()
 
     fun enterVimMode(cm: VimEditor) {
         cm.signal("vim-mode-change", mapOf("mode" to "normal"))
         val handler: (Array<out Any?>) -> Unit = { onCursorActivity(cm) }
         cursorActivityHandlers[cm] = handler
         cm.events.on("cursorActivity", handler)
+        registerChangeHandler(cm)
         maybeInitVimState(cm)
     }
 
@@ -257,7 +259,23 @@ object Vim : VimApiInterface {
         cursorActivityHandlers.remove(cm)?.let { handler ->
             cm.events.off("cursorActivity", handler)
         }
+        changeHandlers.remove(cm)?.let { handler ->
+            cm.events.off("change", handler)
+        }
         cm.vim = null
+    }
+
+    // Records insert-mode input into lastInsertModeChanges so that dot-repeat
+    // (`.`) and macros can replay the text typed during a change/insert command.
+    // The recorder itself only acts while in insert mode (see onChange), so the
+    // handler can stay registered for the lifetime of vim mode.
+    internal fun registerChangeHandler(cm: VimEditor) {
+        if (changeHandlers.containsKey(cm)) return
+        val handler: (Array<out Any?>) -> Unit = { args ->
+            onChange(cm, args.getOrNull(1) as? Change)
+        }
+        changeHandlers[cm] = handler
+        cm.events.on("change", handler)
     }
 
     fun exitVisualMode(cm: VimEditor, moveHead: Boolean = true) {
@@ -540,6 +558,7 @@ internal fun maybeInitVimState(cm: VimEditor): VimState {
             Vim.cursorActivityHandlers[cm] = handler
             cm.events.on("cursorActivity", handler)
         }
+        Vim.registerChangeHandler(cm)
     }
 }
 

--- a/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimHelpers.kt
+++ b/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimHelpers.kt
@@ -2306,6 +2306,11 @@ internal fun logSearchQuery(cm: VimEditor, macroModeState: MacroModeState, query
 // ---------------------------------------------------------------------------
 
 internal fun onChange(cm: VimEditor, changeObj: Change?) {
+    // Only capture document changes that happen while editing in insert mode.
+    // Normal-mode edits (e.g. p, x, dd) are replayed by re-running the command
+    // on dot-repeat, not by replaying inserted text, so recording them here
+    // would double-apply on `.`.
+    if (cm.vim?.insertMode != true) return
     val macroModeState = cm.vimContext.macroModeState
     val lastChange = macroModeState.lastInsertModeChanges
     if (!macroModeState.isPlaying) {

--- a/vim/src/jvmTest/kotlin/com/monkopedia/kodemirror/vim/VimMiscTest.kt
+++ b/vim/src/jvmTest/kotlin/com/monkopedia/kodemirror/vim/VimMiscTest.kt
@@ -227,6 +227,20 @@ class VimMiscTest {
     }
 
     @Test
+    fun dot_insert_cw_issue21() = testVim(value = "one two three") { h ->
+        // Regression for #21: `.` after `cw<text><Esc>` must re-insert the
+        // typed text, not merely delete the word. Previously the inserted text
+        // was dropped because insert-mode input was never recorded into
+        // lastInsertModeChanges (the change-event handler was never wired up).
+        h.doKeys("c", "w")
+        h.doKeys("X", "Y")
+        h.doKeys("<Esc>")
+        h.doKeys("w")
+        h.doKeys(".")
+        assertEquals("XY XY three", h.cm.getValue())
+    }
+
+    @Test
     fun dot_delete() = testVim(value = "zabcde") { h ->
         h.cm.setCursor(0, 5)
         h.doKeys("i")

--- a/vim/src/jvmTest/kotlin/com/monkopedia/kodemirror/vim/VimTestHarness.kt
+++ b/vim/src/jvmTest/kotlin/com/monkopedia/kodemirror/vim/VimTestHarness.kt
@@ -172,7 +172,11 @@ internal fun typeKey(cm: VimEditor, key: String) {
                         last.next = next
                         last = next
                     }
-                    onChange(cm, first)
+                    // Drive recording through the registered "change" handlers,
+                    // exactly as the editor's operation pipeline does, rather
+                    // than calling the recorder directly. Calling onChange here
+                    // masked the missing change-event wiring behind #21.
+                    cm.events.getHandlers("change")?.forEach { it(arrayOf(cm, first)) }
                 }
                 key == "Enter" || key == "Return" -> {
                     // Simulate Enter in insert mode: insert newline with


### PR DESCRIPTION
## Summary
Fixes #21. Vim dot-repeat (`.`) dropped the inserted text of change/insert commands (`c`, `cw`, `s`, `i`, `a`, `o`, …): it replayed only the operator/delete and lost the typed text.

## Root cause
The insert-mode `onChange` recorder (which appends typed text to `lastInsertModeChanges`) was **never registered** on the `change` event. `enterVimMode`/`maybeInitVimState` wired the `cursorActivity` handler but not `change`, so `lastInsertModeChanges` stayed empty and `repeatInsert` had nothing to replay.

## Fix
- `Vim.kt`: register the change recorder for the lifetime of vim mode (mirroring the `cursorActivity` handler) via a `changeHandlers` map + `registerChangeHandler`, wired in both `enterVimMode` (production) and `maybeInitVimState` (init/test path); unregistered in `leaveVimMode`.
- `VimHelpers.kt`: guard the recorder to insert mode only, so always-on registration does not record normal-mode edits (`p`, `x`, `dd`) and double-apply them on `.`.
- `VimTestHarness.kt`: the harness previously called the recorder directly, which **masked** the missing wiring (dot-insert tests passed despite the real bug). It now records via the registered `change` handlers, exactly like the editor operation pipeline.
- `CHANGELOG.md`: Unreleased → Fixed entry (#21).

## Verification
- `:vim:jvmTest` green; `:vim:apiCheck` passes (changes are `internal`, no public API delta); spotless clean.
- **Faithfulness proven**: temporarily disabling the wiring made all 8 dot-insert tests (incl. the new `dot_insert_cw_issue21`) fail, confirming the harness no longer masks the bug.

## Not included
The issue also noted `cw` taking two undos (undo-chain atomicity). That is a separate history-grouping concern, tracked separately — out of scope here.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :vim:jvmTest`
- [ ] Manual: `cw foo<Esc>` then `.` replaces the next word with `foo`; `i bar<Esc>` then `.` re-inserts `bar`