### PR TITLE
Fix vim change/insert command not being a single undo unit (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Vim dot-repeat (`.`) dropped the inserted text of change/insert commands (`c`, `cw`, `s`, `i`, `a`, `o`, …) — the insert-mode change event was never wired up, so `lastInsertModeChanges` stayed empty and `.` replayed only the operator/delete (#21)
+- Vim change/insert commands (`c`, `cw`, `s`, …) were not a single undo unit — `u` took two steps to revert because the insert-entry cursor selection stamped a history boundary on the operator-delete event (#23)
 
 ## [0.2.0] - 2026-04-10
 

--- a/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimEditor.kt
+++ b/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimEditor.kt
@@ -42,6 +42,7 @@ import com.monkopedia.kodemirror.state.LineNumber
 import com.monkopedia.kodemirror.state.MapMode
 import com.monkopedia.kodemirror.state.SelectionSpec
 import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.kodemirror.state.Transaction
 import com.monkopedia.kodemirror.state.TransactionSpec
 import com.monkopedia.kodemirror.state.asInsert
 import com.monkopedia.kodemirror.state.endPos
@@ -792,7 +793,11 @@ internal fun VimEditor.setCursor(line: Int, ch: Int = 0) {
 
 internal fun VimEditor.setCursor(pos: LinePos) = setCursor(pos.line, pos.ch)
 
-internal fun VimEditor.setSelections(selections: List<LinePosRange>, primIndex: Int? = null) {
+internal fun VimEditor.setSelections(
+    selections: List<LinePosRange>,
+    primIndex: Int? = null,
+    addToHistory: Boolean = true
+) {
     val doc = session.state.doc
     val ranges = selections.map { x ->
         val head = indexFromPos(doc, x.head)
@@ -807,7 +812,12 @@ internal fun VimEditor.setSelections(selections: List<LinePosRange>, primIndex: 
         TransactionSpec(
             selection = SelectionSpec.EditorSelectionSpec(
                 EditorSelection.create(ranges, primIndex ?: 0)
-            )
+            ),
+            annotations = if (addToHistory) {
+                emptyList()
+            } else {
+                listOf(Transaction.addToHistory.of(false))
+            }
         )
     )
 }

--- a/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimHelpers.kt
+++ b/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimHelpers.kt
@@ -385,7 +385,12 @@ internal fun selectForInsert(cm: VimEditor, head: LinePos, height: Int) {
         val lineHead = offsetCursor(head, i, 0)
         sel.add(LinePosRange(anchor = lineHead, head = lineHead))
     }
-    cm.setSelections(sel, 0)
+    // Position the cursor for insert mode without recording a history boundary.
+    // A history-recorded selection here would stamp `selectionsAfter` on the
+    // preceding operator-delete event, preventing the subsequent inserted text
+    // from grouping with it — so `u` would take two steps to revert a single
+    // change command (c/cw/s/…). See #23.
+    cm.setSelections(sel, 0, addToHistory = false)
 }
 
 // ---------------------------------------------------------------------------

--- a/vim/src/jvmTest/kotlin/com/monkopedia/kodemirror/vim/VimMiscTest.kt
+++ b/vim/src/jvmTest/kotlin/com/monkopedia/kodemirror/vim/VimMiscTest.kt
@@ -227,6 +227,21 @@ class VimMiscTest {
     }
 
     @Test
+    fun cw_insert_is_single_undo_unit_issue23() = testVim(value = "word1 word2") { h ->
+        // Regression for #23: a change command (cw) plus the text typed in its
+        // insert session must be ONE undo unit, matching vim. Previously the
+        // operator-delete and the insert were separate undo steps because the
+        // insert-entry cursor selection stamped a history boundary on the
+        // delete event.
+        h.doKeys("c", "w")
+        h.doKeys("t", "e", "s", "t")
+        h.doKeys("<Esc>")
+        assertEquals("test word2", h.cm.getValue())
+        h.doKeys("u")
+        assertEquals("word1 word2", h.cm.getValue())
+    }
+
+    @Test
     fun dot_insert_cw_issue21() = testVim(value = "one two three") { h ->
         // Regression for #21: `.` after `cw<text><Esc>` must re-insert the
         // typed text, not merely delete the word. Previously the inserted text


### PR DESCRIPTION
## Summary
Fixes #23. A vim change/insert command and the text typed in its insert session (`c`, `cw`, `s`, `i`, `a`, `o`, …) should be a single undo unit, but `u` took two steps — one for the inserted text, one for the operator/delete.

## Root cause
Entering insert mode dispatches a cursor-positioning selection (`selectForInsert` → `setSelections`). That selection-only transaction was recorded in history, stamping `selectionsAfter` on the preceding operator-delete event. History's `addChanges` only groups a new change with the previous event when `lastEvent.selectionsAfter.isEmpty()` (`commands/.../History.kt:267`), so the inserted text started a *new* undo event instead of joining the delete.

## Fix
Mark the insert-entry cursor selection `addToHistory = false` so it no longer forms a history boundary; the inserted text then groups with the operator-delete into one undo unit. `setSelections` gains an optional `addToHistory` flag (default `true`, so all other callers are unaffected). Internal-only — no public API change.

## Verification
- Full `:vim:jvmTest` green (no undo regressions across the suite); `:vim:apiCheck` passes; spotless clean.
- New regression test `cw_insert_is_single_undo_unit_issue23`: `cw test<Esc>` then a single `u` restores `word1 word2`. This is the same assertion that failed before the fix (confirmed via a throwaway probe on the issue), so it genuinely guards the behavior.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :vim:jvmTest`
- [ ] Manual: `cw foo<Esc>` then `u` restores the original word in one step (and `.` still works, from #21)