### PR TITLE
Default the task workflow to automated PR review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,29 +4,37 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Workflow
 
-### Task Workflow: Work → Review → Merge
+### Task Workflow: implement → automated review → merge
 
-All implementation work follows a two-phase agent workflow. See `docs/post-task-workflow.md`
-for the full pattern with prompt templates.
+By default, route implementation work through the **automated review process** rather than
+committing or pushing directly to `main`. An independent reviewer pass produces better code.
 
-**Phase 1 — Work agent** (worktree, can run in parallel):
-- Implements the change in an isolated worktree branch
-- Commits on its branch. Does NOT fix style, run tests, or push.
-
-**Phase 2 — Review agent** (foreground, one at a time):
-- Reviews the diff for correctness
-- Merges to main
-- Fixes style (spotlessApply, ktlintFormat)
-- Updates API dumps (apiDump)
-- Runs tests — fixes failures if clear, reports if not
-- Pushes to remote
+1. **Implement** on a branch (a worktree is fine for parallel work). Before opening review,
+   verify locally — this preserves the verification spirit of the older two-phase flow:
+   - tests green: `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :<module>:jvmTest`
+   - style: `spotlessApply` / `ktlintFormat`
+   - API: `apiCheck` (run `apiDump` only for an *intended* public-API change)
+   - update `CHANGELOG.md` (Unreleased) with the issue/PR number
+2. **Open a PR via the coderbot wrapper** (`/home/jmonk/git/urithiru/coder-bot/coderbot`),
+   authored by `monkopedia-coder`, requesting the reviewer on creation:
+   - `coderbot git push -u origin <branch>`
+   - `coderbot gh pr create --base main --reviewer monkopedia-reviewer --title "…" --body "…Fixes #<n>…"`
+3. **Automated review.** Opening the PR triggers the `monkopedia-reviewer` webhook: a reviewer
+   subagent classifies the change by tier, independently re-verifies it (tests / format /
+   apiCheck green, per the CI-must-be-green policy), and for tier-1 changes approves and
+   squash-merges. Tier-2/3 changes are surfaced to the user instead of auto-merging.
 
 **Key constraints:**
-- Multiple work agents can run in parallel (each in its own worktree)
-- Only ONE review agent runs at a time (serialized by the main agent)
-- Review agents fix minor issues (style, imports, small bugs) directly
-- Review agents reject and report substantive problems — don't rewrite implementations
-```
+- Do NOT push directly to `main`, and do NOT self-merge — `monkopedia-reviewer` merges.
+- Author PRs as `monkopedia-coder` via coderbot and always pass `--reviewer monkopedia-reviewer`;
+  PRs opened outside this flow sit unreviewed.
+- Keep each PR to one focused change and reference the issue (`Fixes #<n>`).
+- CI must be green before merge — fix ALL CI issues, don't just report them.
+- Implementation branches may proceed in parallel; the reviewer serializes merges.
+
+The legacy two-phase pattern (work agent in a worktree → separate review agent merges to `main`
+without a PR) in `docs/post-task-workflow.md` is superseded by this automated PR review for
+routine work.
 
 ### Screenshot Compare & Fix
 
@@ -37,11 +45,11 @@ When the user asks to compare screenshots or fix visual differences, follow the 
 2. **Compare** by reading both PNGs for each scenario
 3. **Build a fix list** — one `TaskCreate` per visual difference, with scenario/description/severity
 4. **Report the list** to the user before starting fixes
-5. **Fix loop** — for each item: fix code via Work → Review → Merge workflow, then re-capture and re-compare
+5. **Fix loop** — for each item: fix code via the automated review workflow (see Task Workflow above), then re-capture and re-compare
 6. **Repeat** until all scenarios match or a blocker is hit
 7. **Report final status** — what was fixed, what still differs, any blockers
 
-Each fix should be a single focused commit via the Work → Review → Merge workflow.
+Each fix should be a single focused PR via the automated review workflow.
 
 ### TODO Loop
 
@@ -63,11 +71,11 @@ loop for each item in `docs/TODO.md`:
 4. **If actionable:** Implement the change. Keep changes focused to what the item describes — do
    not scope-creep into adjacent items.
 
-5. **After implementing:** Follow the Work → Review → Merge workflow (see above). The work
-   agent implements in a worktree, then a review agent merges to main. If tests fail during
-   review and can't be fixed, mark the item `[BLOCKED]` with the failure info.
+5. **After implementing:** Follow the automated review workflow (see Task Workflow above) —
+   open a coderbot PR requesting `monkopedia-reviewer`. If the reviewer requests changes you
+   can't resolve, or CI can't be made green, mark the item `[BLOCKED]` with the failure info.
 
-6. **Mark the item `[DONE]`** in `docs/TODO.md` after a successful commit+push.
+6. **Mark the item `[DONE]`** in `docs/TODO.md` after the PR is merged.
 
 7. **Report** a brief summary of what was done (or why it was blocked), then **continue to the
    next item**. Do not stop between items unless the user asks to stop or a blocker needs user input.


### PR DESCRIPTION
## Summary
Amends the kodemirror `CLAUDE.md` workflow to default to the **automated review process** (coderbot PR authored by `monkopedia-coder` + `--reviewer monkopedia-reviewer`) instead of committing/pushing directly to `main`, per the maintainer's instruction that automated review "produces better code in general."

## Changes (docs only)
- Rewrites **Task Workflow** to: implement on a branch → verify locally → open a coderbot PR requesting the reviewer → reviewer subagent classifies by tier, re-verifies, and merges tier-1 (tier-2/3 surfaced to the user).
- Preserves the **verification spirit** of the old two-phase flow: implementers still run `:<module>:jvmTest`, `spotlessApply`/`ktlintFormat`, `apiCheck`, and update the CHANGELOG before review.
- Updates the Screenshot-Compare and TODO-loop sections to reference the new flow.
- Marks the legacy two-phase pattern in `docs/post-task-workflow.md` as superseded for routine work (that doc itself left unchanged for now).

No code changes.

## Test plan
- [ ] Doc-only — read-through for accuracy; no build impact.