### PR TITLE
LSP document sync + position/workspace mapping (#36)

### DIFF
--- a/lsp-client/api/android/lsp-client.api
+++ b/lsp-client/api/android/lsp-client.api
@@ -1,15 +1,42 @@
+public final class com/monkopedia/kodemirror/lsp/DocumentSyncKt {
+	public static final fun fromPosition (Lcom/monkopedia/lsp/Position;Lcom/monkopedia/kodemirror/state/Text;)I
+	public static final fun toPosition (ILcom/monkopedia/kodemirror/state/Text;)Lcom/monkopedia/lsp/Position;
+}
+
+public final class com/monkopedia/kodemirror/lsp/DocumentSyncMode {
+	public static final field $stable I
+	public static final field Companion Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode$Companion;
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2-5s_-5QQ ()I
+	public final fun copy-wpA5XIQ (ZI)Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode;
+	public static synthetic fun copy-wpA5XIQ$default (Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode;ZIILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChange-5s_-5QQ ()I
+	public final fun getOpenClose ()Z
+	public final fun getSyncsChanges ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/monkopedia/kodemirror/lsp/DocumentSyncMode$Companion {
+	public final fun forCapabilities (Lcom/monkopedia/lsp/ServerCapabilities;)Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode;
+}
+
 public final class com/monkopedia/kodemirror/lsp/LSPClient {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/lsp/LanguageServer;Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;)V
 	public synthetic fun <init> (Lcom/monkopedia/lsp/LanguageServer;Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConfig ()Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;
 	public final fun getInitializeResult ()Lcom/monkopedia/lsp/InitializeResult;
+	public final fun getScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getServer ()Lcom/monkopedia/lsp/LanguageServer;
 	public final fun getServerCapabilities ()Lcom/monkopedia/lsp/ServerCapabilities;
 	public final fun getWorkspace ()Lcom/monkopedia/kodemirror/lsp/Workspace;
 	public final fun initialize (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun isInitialized ()Z
 	public final fun shutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun sync (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/monkopedia/kodemirror/lsp/LSPClientConfig {
@@ -66,20 +93,50 @@ public class com/monkopedia/kodemirror/lsp/Workspace {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/kodemirror/lsp/LSPClient;)V
 	public fun closeFile (Ljava/lang/String;)V
+	public fun didCloseFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun didOpenFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getClient ()Lcom/monkopedia/kodemirror/lsp/LSPClient;
 	public final fun getFile (Ljava/lang/String;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
+	public final fun getMapping (Ljava/lang/String;)Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;
 	public final fun getOpenFiles ()Ljava/util/List;
 	public fun openFile (Ljava/lang/String;Ljava/lang/String;Lcom/monkopedia/kodemirror/view/EditorSession;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
+	public final fun releaseMapping (Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;)V
+	public fun syncFiles ()Ljava/util/List;
+	public fun updateFile (Ljava/lang/String;Lcom/monkopedia/kodemirror/state/ChangeSet;)V
 }
 
 public final class com/monkopedia/kodemirror/lsp/WorkspaceFile {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/monkopedia/kodemirror/view/EditorSession;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/monkopedia/kodemirror/view/EditorSession;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDoc ()Lcom/monkopedia/kodemirror/state/Text;
 	public final fun getLanguageId ()Ljava/lang/String;
 	public final fun getSession ()Lcom/monkopedia/kodemirror/view/EditorSession;
 	public final fun getText ()Ljava/lang/String;
 	public final fun getUri ()Ljava/lang/String;
 	public final fun getVersion ()I
+}
+
+public final class com/monkopedia/kodemirror/lsp/WorkspaceFileUpdate {
+	public static final field $stable I
+	public fun <init> (Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;Lcom/monkopedia/kodemirror/state/Text;Lcom/monkopedia/kodemirror/state/ChangeSet;)V
+	public final fun component1 ()Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
+	public final fun component2 ()Lcom/monkopedia/kodemirror/state/Text;
+	public final fun component3 ()Lcom/monkopedia/kodemirror/state/ChangeSet;
+	public final fun copy (Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;Lcom/monkopedia/kodemirror/state/Text;Lcom/monkopedia/kodemirror/state/ChangeSet;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFileUpdate;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/lsp/WorkspaceFileUpdate;Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;Lcom/monkopedia/kodemirror/state/Text;Lcom/monkopedia/kodemirror/state/ChangeSet;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFileUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChanges ()Lcom/monkopedia/kodemirror/state/ChangeSet;
+	public final fun getFile ()Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
+	public final fun getPrevDoc ()Lcom/monkopedia/kodemirror/state/Text;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/monkopedia/kodemirror/lsp/WorkspaceMapping {
+	public static final field $stable I
+	public final fun getUri ()Ljava/lang/String;
+	public final fun mapPos (II)I
+	public static synthetic fun mapPos$default (Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;IIILjava/lang/Object;)I
+	public final fun mapPosition (Lcom/monkopedia/lsp/Position;Lcom/monkopedia/kodemirror/state/Text;I)I
+	public static synthetic fun mapPosition$default (Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;Lcom/monkopedia/lsp/Position;Lcom/monkopedia/kodemirror/state/Text;IILjava/lang/Object;)I
 }
 

--- a/lsp-client/api/jvm/lsp-client.api
+++ b/lsp-client/api/jvm/lsp-client.api
@@ -1,15 +1,42 @@
+public final class com/monkopedia/kodemirror/lsp/DocumentSyncKt {
+	public static final fun fromPosition (Lcom/monkopedia/lsp/Position;Lcom/monkopedia/kodemirror/state/Text;)I
+	public static final fun toPosition (ILcom/monkopedia/kodemirror/state/Text;)Lcom/monkopedia/lsp/Position;
+}
+
+public final class com/monkopedia/kodemirror/lsp/DocumentSyncMode {
+	public static final field $stable I
+	public static final field Companion Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode$Companion;
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2-5s_-5QQ ()I
+	public final fun copy-wpA5XIQ (ZI)Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode;
+	public static synthetic fun copy-wpA5XIQ$default (Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode;ZIILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChange-5s_-5QQ ()I
+	public final fun getOpenClose ()Z
+	public final fun getSyncsChanges ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/monkopedia/kodemirror/lsp/DocumentSyncMode$Companion {
+	public final fun forCapabilities (Lcom/monkopedia/lsp/ServerCapabilities;)Lcom/monkopedia/kodemirror/lsp/DocumentSyncMode;
+}
+
 public final class com/monkopedia/kodemirror/lsp/LSPClient {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/lsp/LanguageServer;Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;)V
 	public synthetic fun <init> (Lcom/monkopedia/lsp/LanguageServer;Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConfig ()Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;
 	public final fun getInitializeResult ()Lcom/monkopedia/lsp/InitializeResult;
+	public final fun getScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getServer ()Lcom/monkopedia/lsp/LanguageServer;
 	public final fun getServerCapabilities ()Lcom/monkopedia/lsp/ServerCapabilities;
 	public final fun getWorkspace ()Lcom/monkopedia/kodemirror/lsp/Workspace;
 	public final fun initialize (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun isInitialized ()Z
 	public final fun shutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun sync (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/monkopedia/kodemirror/lsp/LSPClientConfig {
@@ -66,20 +93,50 @@ public class com/monkopedia/kodemirror/lsp/Workspace {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/kodemirror/lsp/LSPClient;)V
 	public fun closeFile (Ljava/lang/String;)V
+	public fun didCloseFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun didOpenFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getClient ()Lcom/monkopedia/kodemirror/lsp/LSPClient;
 	public final fun getFile (Ljava/lang/String;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
+	public final fun getMapping (Ljava/lang/String;)Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;
 	public final fun getOpenFiles ()Ljava/util/List;
 	public fun openFile (Ljava/lang/String;Ljava/lang/String;Lcom/monkopedia/kodemirror/view/EditorSession;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
+	public final fun releaseMapping (Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;)V
+	public fun syncFiles ()Ljava/util/List;
+	public fun updateFile (Ljava/lang/String;Lcom/monkopedia/kodemirror/state/ChangeSet;)V
 }
 
 public final class com/monkopedia/kodemirror/lsp/WorkspaceFile {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/monkopedia/kodemirror/view/EditorSession;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/monkopedia/kodemirror/view/EditorSession;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDoc ()Lcom/monkopedia/kodemirror/state/Text;
 	public final fun getLanguageId ()Ljava/lang/String;
 	public final fun getSession ()Lcom/monkopedia/kodemirror/view/EditorSession;
 	public final fun getText ()Ljava/lang/String;
 	public final fun getUri ()Ljava/lang/String;
 	public final fun getVersion ()I
+}
+
+public final class com/monkopedia/kodemirror/lsp/WorkspaceFileUpdate {
+	public static final field $stable I
+	public fun <init> (Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;Lcom/monkopedia/kodemirror/state/Text;Lcom/monkopedia/kodemirror/state/ChangeSet;)V
+	public final fun component1 ()Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
+	public final fun component2 ()Lcom/monkopedia/kodemirror/state/Text;
+	public final fun component3 ()Lcom/monkopedia/kodemirror/state/ChangeSet;
+	public final fun copy (Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;Lcom/monkopedia/kodemirror/state/Text;Lcom/monkopedia/kodemirror/state/ChangeSet;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFileUpdate;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/lsp/WorkspaceFileUpdate;Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;Lcom/monkopedia/kodemirror/state/Text;Lcom/monkopedia/kodemirror/state/ChangeSet;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFileUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChanges ()Lcom/monkopedia/kodemirror/state/ChangeSet;
+	public final fun getFile ()Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
+	public final fun getPrevDoc ()Lcom/monkopedia/kodemirror/state/Text;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/monkopedia/kodemirror/lsp/WorkspaceMapping {
+	public static final field $stable I
+	public final fun getUri ()Ljava/lang/String;
+	public final fun mapPos (II)I
+	public static synthetic fun mapPos$default (Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;IIILjava/lang/Object;)I
+	public final fun mapPosition (Lcom/monkopedia/lsp/Position;Lcom/monkopedia/kodemirror/state/Text;I)I
+	public static synthetic fun mapPosition$default (Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;Lcom/monkopedia/lsp/Position;Lcom/monkopedia/kodemirror/state/Text;IILjava/lang/Object;)I
 }
 

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/DocumentSync.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/DocumentSync.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.ChangeSet
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.LineNumber
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.TextDocumentContentChangeEvent
+import com.monkopedia.lsp.TextDocumentContentChangeEventRange
+import com.monkopedia.lsp.TextDocumentContentChangeEventVariant
+import com.monkopedia.lsp.TextDocumentSyncKind
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+
+/**
+ * Convert a kodemirror document offset to an LSP [Position].
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `LSPPlugin.toPosition`. LSP
+ * positions are `{line, character}` pairs where `line` is 0-based and
+ * `character` is a 0-based UTF-16 code-unit offset within that line. Kotlin
+ * [String]/[Char] are already UTF-16 code units, so within a line the offset is
+ * a direct character index.
+ *
+ * @param offset The document offset (a 0-based character offset).
+ * @param doc The document the offset refers to.
+ */
+fun toPosition(offset: Int, doc: Text): Position {
+    val line = doc.lineAt(DocPos(offset.coerceIn(0, doc.length)))
+    return Position(
+        line = (line.number.value - 1).toUInt(),
+        character = (offset - line.from.value).coerceAtLeast(0).toUInt()
+    )
+}
+
+/**
+ * Convert an LSP [Position] to a kodemirror document offset.
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `LSPPlugin.fromPosition`. The line
+ * is 1-based in kodemirror but 0-based in LSP, and `character` is a UTF-16
+ * code-unit offset within the line. Out-of-range line/character values are
+ * clamped to the document, mirroring the LSP spec.
+ *
+ * @param pos The LSP position to convert.
+ * @param doc The document the position refers to.
+ */
+fun fromPosition(pos: Position, doc: Text): Int {
+    val lineNumber = (pos.line.toInt() + 1).coerceIn(1, doc.lines)
+    val line = doc.line(LineNumber(lineNumber))
+    val character = pos.character.toInt().coerceIn(0, line.length)
+    return line.from.value + character
+}
+
+/** Build an LSP [Range] from two offsets in [doc]. */
+internal fun toRange(from: Int, to: Int, doc: Text): Range =
+    Range(start = toPosition(from, doc), end = toPosition(to, doc))
+
+/**
+ * How a document's changes should be synchronized to the server, as negotiated
+ * through the server's [textDocumentSync][ServerCapabilities.textDocumentSync]
+ * capability.
+ *
+ * Mirrors the semantics upstream `@codemirror/lsp-client` derives from the same
+ * capability: whether open/close notifications are sent, and whether content is
+ * synced incrementally, in full, or not at all.
+ *
+ * @param openClose Whether `textDocument/didOpen` and `textDocument/didClose`
+ *   notifications should be sent.
+ * @param change How content changes are synced ([TextDocumentSyncKind.NONE],
+ *   [TextDocumentSyncKind.FULL], or [TextDocumentSyncKind.INCREMENTAL]).
+ */
+data class DocumentSyncMode(
+    val openClose: Boolean,
+    val change: TextDocumentSyncKind
+) {
+    /** True when content changes should be synchronized at all. */
+    val syncsChanges: Boolean
+        get() = change != TextDocumentSyncKind.NONE
+
+    companion object {
+        /**
+         * Resolve the [DocumentSyncMode] from a server's [capabilities].
+         *
+         * The `textDocumentSync` capability is, per the LSP spec, either the
+         * [TextDocumentSyncKind] number (legacy form) or a
+         * `TextDocumentSyncOptions` object (`{openClose, change}`). When it is
+         * absent the spec defaults to no syncing; we follow upstream and still
+         * advertise open/close while defaulting [change] to
+         * [TextDocumentSyncKind.NONE].
+         */
+        fun forCapabilities(capabilities: ServerCapabilities?): DocumentSyncMode {
+            val sync = capabilities?.textDocumentSync
+                ?: return DocumentSyncMode(openClose = true, change = TextDocumentSyncKind.NONE)
+            return when (sync) {
+                is JsonPrimitive -> {
+                    val kind = sync.intOrNull?.toUInt()?.let { TextDocumentSyncKind(it) }
+                        ?: TextDocumentSyncKind.NONE
+                    DocumentSyncMode(openClose = true, change = kind)
+                }
+                is JsonObject -> {
+                    val openClose = (sync["openClose"] as? JsonPrimitive)
+                        ?.booleanOrNull ?: false
+                    val change = (sync["change"] as? JsonPrimitive)?.intOrNull
+                        ?.toUInt()?.let { TextDocumentSyncKind(it) }
+                        ?: TextDocumentSyncKind.NONE
+                    DocumentSyncMode(openClose = openClose, change = change)
+                }
+                else -> DocumentSyncMode(openClose = true, change = TextDocumentSyncKind.NONE)
+            }
+        }
+    }
+}
+
+/**
+ * Build the list of [TextDocumentContentChangeEvent]s for a `textDocument/didChange`
+ * notification, honoring the negotiated [mode].
+ *
+ * Mirrors upstream's incremental-vs-full decision: when the server supports
+ * [incremental][TextDocumentSyncKind.INCREMENTAL] sync, each changed range from
+ * [changes] is emitted as a ranged content change (computed against [prevDoc]);
+ * otherwise the whole [newDoc] is sent as a single full-content change.
+ *
+ * Incremental changes are emitted highest-offset-first so that the
+ * [prevDoc]-relative ranges of earlier (lower) edits are not invalidated by the
+ * application of later (higher) edits, matching the sequential-application
+ * semantics the LSP spec requires within a single notification.
+ *
+ * @param changes The document changes (in [prevDoc] coordinates).
+ * @param prevDoc The document as the server last saw it.
+ * @param newDoc The document after [changes] are applied.
+ * @param mode The negotiated synchronization mode.
+ */
+internal fun buildContentChanges(
+    changes: ChangeSet,
+    prevDoc: Text,
+    newDoc: Text,
+    mode: DocumentSyncMode
+): List<TextDocumentContentChangeEvent> {
+    if (mode.change == TextDocumentSyncKind.INCREMENTAL) {
+        val events = mutableListOf<TextDocumentContentChangeEventRange>()
+        changes.iterChanges(
+            { fromA, toA, _, _, inserted ->
+                events.add(
+                    TextDocumentContentChangeEventRange(
+                        range = toRange(fromA.value, toA.value, prevDoc),
+                        text = inserted.toString()
+                    )
+                )
+            },
+            individual = true
+        )
+        // Apply higher offsets first so earlier ranges remain valid.
+        return events.asReversed().toList()
+    }
+    return listOf(TextDocumentContentChangeEventVariant(text = newDoc.toString()))
+}

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LSPClient.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LSPClient.kt
@@ -26,6 +26,8 @@ import com.monkopedia.lsp.InitializedParams
 import com.monkopedia.lsp.LanguageServer
 import com.monkopedia.lsp.ServerCapabilities
 import com.monkopedia.lsp.WorkspaceFolder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -79,6 +81,14 @@ class LSPClient(
     val config: LSPClientConfig = LSPClientConfig()
 ) {
     private val initMutex = Mutex()
+    private val syncMutex = Mutex()
+
+    /**
+     * Client-lifetime coroutine scope, used for work that must outlive any
+     * single editor session (e.g. sending `textDocument/didClose` as a plugin
+     * tears down its own scope).
+     */
+    val scope: CoroutineScope = CoroutineScope(SupervisorJob())
 
     /** The full result of the `initialize` request, or null until initialized. */
     var initializeResult: InitializeResult? = null
@@ -118,6 +128,24 @@ class LSPClient(
         initializeResult = result
         server.initialized(InitializedParams())
         result
+    }
+
+    /**
+     * Flush any pending document changes to the server.
+     *
+     * Mirrors upstream `@codemirror/lsp-client`'s `LSPClient.sync()`: it asks the
+     * [workspace] for the set of files with unsynced changes
+     * ([Workspace.syncFiles]) and emits a `textDocument/didChange` notification
+     * for each, honoring the negotiated [DocumentSyncMode]. Calls are serialized
+     * so notifications go out in version order.
+     *
+     * No-op when the client has not been initialized yet.
+     */
+    suspend fun sync(): Unit = syncMutex.withLock {
+        if (!isInitialized) return
+        for (update in workspace.syncFiles()) {
+            workspace.sendChange(update)
+        }
     }
 
     /**

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LSPPlugin.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LSPPlugin.kt
@@ -62,18 +62,31 @@ class LSPPlugin internal constructor(
             // Ensure the server handshake has completed before any feature
             // wiring attempts to use it.
             client.initialize()
-            // TODO(#36): send textDocument/didOpen once document sync lands.
+            // Announce the document, then flush anything that changed while the
+            // handshake was in flight.
+            client.workspace.didOpenFile(uri)
+            client.sync()
         }
     }
 
     override fun update(update: ViewUpdate) {
-        // TODO(#36): forward document changes as textDocument/didChange.
+        if (update.docChanged) {
+            // Record the changes against the workspace file and schedule a flush.
+            client.workspace.updateFile(uri, update.changes)
+            scope.launch {
+                client.initialize()
+                client.sync()
+            }
+        }
         // TODO(#37..#45): trigger feature updates (diagnostics, signature help, ...).
     }
 
     override fun destroy() {
-        // TODO(#36): send textDocument/didClose before unregistering.
+        // Detach synchronously, then notify the server that the file closed.
         client.workspace.closeFile(uri)
+        client.scope.launch {
+            client.workspace.didCloseFile(uri)
+        }
         job.cancel()
     }
 

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
@@ -40,8 +40,9 @@ fun languageServerSupport(client: LSPClient, uri: String, languageId: String): E
     val plugin = LSPPlugin.define(client, uri, languageId)
     return ExtensionList(
         listOf(
+            // The plugin owns document sync (didOpen/didChange/didClose,
+            // version tracking, and position mapping) — see #36.
             plugin.asExtension()
-            // TODO(#36): document sync extension
             // TODO(#37): publishDiagnostics -> lint integration
             // TODO(#38): hover tooltips
             // TODO(#39): completion source

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/Workspace.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/Workspace.kt
@@ -18,45 +18,120 @@
  */
 package com.monkopedia.kodemirror.lsp
 
+import com.monkopedia.kodemirror.state.ChangeSet
+import com.monkopedia.kodemirror.state.Text
 import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.lsp.DidChangeTextDocumentParams
+import com.monkopedia.lsp.DidCloseTextDocumentParams
+import com.monkopedia.lsp.DidOpenTextDocumentParams
+import com.monkopedia.lsp.TextDocumentIdentifier
+import com.monkopedia.lsp.TextDocumentItem
+import com.monkopedia.lsp.VersionedTextDocumentIdentifier
+
+/**
+ * A pending update for a file, produced by [Workspace.syncFiles].
+ *
+ * Mirrors upstream `@codemirror/lsp-client`'s `WorkspaceFileUpdate`. It carries
+ * the file along with the document as the server last saw it ([prevDoc]) and the
+ * accumulated [changes] to send. [LSPClient.sync] consumes these to emit
+ * `textDocument/didChange` notifications.
+ *
+ * @param file The file being updated.
+ * @param prevDoc The document as last synchronized with the server.
+ * @param changes The changes to apply to [prevDoc] to reach [WorkspaceFile.doc].
+ */
+data class WorkspaceFileUpdate(
+    val file: WorkspaceFile,
+    val prevDoc: Text,
+    val changes: ChangeSet
+)
 
 /**
  * Represents a single document tracked by a [Workspace].
  *
- * Mirrors upstream `@codemirror/lsp-client`'s `WorkspaceFile`. For now this is a
- * minimal skeleton holding the file's identity and the editor session bound to
- * it; document synchronization (open/change/close notifications, version
- * tracking) is added in a later issue.
+ * Mirrors upstream `@codemirror/lsp-client`'s `WorkspaceFile`. It holds the
+ * file's identity, the editor session bound to it, the document text last
+ * synchronized to the server, the synced [version], and any pending changes that
+ * have not yet been flushed via [Workspace.syncFiles].
  *
  * @param uri The document URI, as understood by the language server.
  * @param languageId The LSP language identifier (e.g. `"kotlin"`, `"json"`).
  * @param session The editor session displaying this file, if any.
  */
-class WorkspaceFile(
+class WorkspaceFile internal constructor(
     val uri: String,
     val languageId: String,
-    val session: EditorSession? = null
+    val session: EditorSession?,
+    initialDoc: Text
 ) {
     /**
-     * The document version last synchronized with the server. Incremented as
-     * changes are sent.
-     *
-     * TODO(#36): drive this from document-sync notifications.
+     * The document version last synchronized with the server. Incremented each
+     * time changes are flushed to the server.
      */
-    var version: Int = 0
+    var version: Int = 1
         internal set
+
+    /** The document text as the server last saw it. */
+    var doc: Text = initialDoc
+        internal set
+
+    /** Pending, not-yet-synchronized changes (relative to [doc]), or null. */
+    internal var pendingChanges: ChangeSet? = null
+
+    /** Live mappings handed out for in-flight requests against this file. */
+    private val mappings = mutableListOf<WorkspaceMapping>()
 
     /** Get the current document text, or null if no session is attached. */
     fun getText(): String? = session?.state?.doc?.toString()
+
+    /**
+     * Record that the document changed by [change]. Accumulates onto any pending
+     * changes and updates outstanding [WorkspaceMapping]s so in-flight requests
+     * can be remapped.
+     */
+    internal fun applyChange(change: ChangeSet) {
+        if (change.empty) return
+        val pending = pendingChanges
+        pendingChanges = if (pending == null) change else pending.compose(change)
+        for (mapping in mappings) mapping.addChanges(change.desc)
+    }
+
+    /** Create and register a live [WorkspaceMapping] for this file. */
+    internal fun createMapping(): WorkspaceMapping {
+        val mapping = WorkspaceMapping(uri)
+        mappings.add(mapping)
+        return mapping
+    }
+
+    /** Stop tracking [mapping], so it no longer receives change updates. */
+    internal fun releaseMapping(mapping: WorkspaceMapping) {
+        mappings.remove(mapping)
+    }
+
+    /**
+     * Take any pending changes as a [WorkspaceFileUpdate], advancing [version]
+     * and [doc] to the post-change state, or null when there is nothing to sync.
+     */
+    internal fun takeUpdate(): WorkspaceFileUpdate? {
+        val pending = pendingChanges ?: return null
+        pendingChanges = null
+        val prevDoc = doc
+        val newDoc = pending.apply(prevDoc)
+        doc = newDoc
+        version += 1
+        return WorkspaceFileUpdate(this, prevDoc, pending)
+    }
 }
 
 /**
- * Tracks the set of open files for an [LSPClient].
+ * Tracks the set of open files for an [LSPClient] and synchronizes their
+ * contents with the language server.
  *
- * Mirrors upstream `@codemirror/lsp-client`'s `Workspace`, kept intentionally
- * minimal (effectively single-file) for the scaffold. The richer multi-file
- * behavior — syncing files, requesting/connecting files, and handling server
- * notifications — is layered on in later feature issues.
+ * Mirrors upstream `@codemirror/lsp-client`'s `Workspace`. Files are registered
+ * via [openFile] (which sends `textDocument/didOpen`) and removed via [closeFile]
+ * (which sends `textDocument/didClose`). Editor changes are recorded with
+ * [updateFile] and later flushed with [syncFiles] / [LSPClient.sync], honoring
+ * the server's negotiated [DocumentSyncMode].
  *
  * @param client The owning [LSPClient].
  */
@@ -73,24 +148,114 @@ open class Workspace(
     fun getFile(uri: String): WorkspaceFile? = files[uri]
 
     /**
-     * Register a file as open in the workspace.
-     *
-     * TODO(#36): send `textDocument/didOpen` to the server here once document
-     * sync is implemented.
+     * Obtain a live [WorkspaceMapping] for [uri] that tracks edits applied after
+     * this call, or null if no such file is open. A feature that issues an LSP
+     * request should capture a mapping when it sends the request and use it to
+     * remap the response's positions; call [releaseMapping] when done.
+     */
+    fun getMapping(uri: String): WorkspaceMapping? = files[uri]?.createMapping()
+
+    /** Release a [mapping] previously obtained from [getMapping]. */
+    fun releaseMapping(mapping: WorkspaceMapping) {
+        files[mapping.uri]?.releaseMapping(mapping)
+    }
+
+    /**
+     * Register a file as open in the workspace, snapshotting its current text as
+     * the version-1 baseline. Synchronous so it can run from a plugin's
+     * constructor; the `textDocument/didOpen` notification is sent separately by
+     * [didOpenFile] once the server handshake has completed.
      */
     open fun openFile(uri: String, languageId: String, session: EditorSession?): WorkspaceFile {
-        val file = WorkspaceFile(uri, languageId, session)
+        val initialDoc = session?.state?.doc ?: Text.empty
+        val file = WorkspaceFile(uri, languageId, session, initialDoc)
         files[uri] = file
         return file
     }
 
     /**
-     * Remove a file from the workspace.
+     * Send the `textDocument/didOpen` notification for [uri], if it is open and
+     * the server's sync capability advertises open/close notifications
+     * ([DocumentSyncMode.openClose]).
+     */
+    open suspend fun didOpenFile(uri: String) {
+        val file = files[uri] ?: return
+        val mode = DocumentSyncMode.forCapabilities(client.serverCapabilities)
+        if (!mode.openClose) return
+        client.server.textDocumentDidOpen(
+            DidOpenTextDocumentParams(
+                textDocument = TextDocumentItem(
+                    uri = file.uri,
+                    languageId = file.languageId,
+                    version = file.version,
+                    text = file.doc.toString()
+                )
+            )
+        )
+    }
+
+    /**
+     * Record an editor [change] against the file [uri].
      *
-     * TODO(#36): send `textDocument/didClose` to the server here once document
-     * sync is implemented.
+     * Pending changes accumulate until flushed by [syncFiles] / [LSPClient.sync].
+     */
+    open fun updateFile(uri: String, change: ChangeSet) {
+        files[uri]?.applyChange(change)
+    }
+
+    /**
+     * Take all pending file updates, advancing each file's version/doc. Returns
+     * the updates that should be sent to the server as `textDocument/didChange`.
+     *
+     * Mirrors upstream `Workspace.syncFiles()`.
+     */
+    open fun syncFiles(): List<WorkspaceFileUpdate> = files.values.mapNotNull { it.takeUpdate() }
+
+    /**
+     * Remove a file from the workspace. Synchronous so it can run from a
+     * plugin's `destroy`; the `textDocument/didClose` notification is sent
+     * separately by [didCloseFile].
      */
     open fun closeFile(uri: String) {
         files.remove(uri)
+    }
+
+    /**
+     * Send the `textDocument/didClose` notification for [uri], if the server's
+     * sync capability advertises open/close notifications
+     * ([DocumentSyncMode.openClose]).
+     */
+    open suspend fun didCloseFile(uri: String) {
+        val mode = DocumentSyncMode.forCapabilities(client.serverCapabilities)
+        if (!mode.openClose) return
+        client.server.textDocumentDidClose(
+            DidCloseTextDocumentParams(
+                textDocument = TextDocumentIdentifier(uri = uri)
+            )
+        )
+    }
+
+    /**
+     * Send the `textDocument/didChange` notification for a single file [update],
+     * honoring the negotiated [DocumentSyncMode].
+     */
+    internal suspend fun sendChange(update: WorkspaceFileUpdate) {
+        val mode = DocumentSyncMode.forCapabilities(client.serverCapabilities)
+        if (!mode.syncsChanges) return
+        val contentChanges = buildContentChanges(
+            changes = update.changes,
+            prevDoc = update.prevDoc,
+            newDoc = update.file.doc,
+            mode = mode
+        )
+        client.server.textDocumentDidChange(
+            DidChangeTextDocumentParams(
+                textDocument = VersionedTextDocumentIdentifier(
+                    uri = update.file.uri,
+                    version = update.file.version
+                ),
+                contentChanges = contentChanges
+            )
+        )
     }
 }

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/WorkspaceMapping.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/WorkspaceMapping.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.ChangeDesc
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.lsp.Position
+
+/**
+ * Maps positions from the document version a request was issued against to the
+ * current document version.
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `WorkspaceMapping`. An LSP request
+ * is sent against a particular document version; by the time the response comes
+ * back the editor may have moved on through further edits. Positions returned
+ * by the server are expressed against the version the request saw, so they must
+ * be mapped through the edits that happened in the meantime before they are used
+ * in the (now-current) editor.
+ *
+ * Obtain one via [Workspace.getMapping]. The mapping is a live view: it tracks
+ * edits applied to the file after it was created, so a request handler can
+ * capture the mapping when it issues the request and use it once the response
+ * arrives.
+ *
+ * @param uri The URI of the file whose positions this mapping translates.
+ */
+class WorkspaceMapping internal constructor(
+    val uri: String
+) {
+    private var changes: ChangeDesc? = null
+
+    /**
+     * Record that [change] was applied to the file after this mapping was
+     * created. Composed onto any previously-recorded changes.
+     */
+    internal fun addChanges(change: ChangeDesc) {
+        if (change.empty) return
+        val existing = changes
+        changes = if (existing == null) change else existing.composeDesc(change)
+    }
+
+    /**
+     * Map a document offset issued against the request-time document to the
+     * current document.
+     *
+     * @param pos The offset in the request-time document.
+     * @param assoc Which side of an insertion the position prefers
+     *   (negative biases left, positive biases right). Defaults to `-1`.
+     */
+    fun mapPos(pos: Int, assoc: Int = -1): Int = changes?.mapPos(DocPos(pos), assoc)?.value ?: pos
+
+    /**
+     * Map an LSP [Position] from the request-time document to a current-document
+     * offset.
+     *
+     * The [lspPos] is interpreted against [prevDoc] (the document as the request
+     * saw it), converted to an offset, then mapped through any edits recorded
+     * since this mapping was created.
+     *
+     * @param lspPos The LSP position from the request-time document.
+     * @param prevDoc The document the request was issued against.
+     * @param assoc Association bias for the mapping. Defaults to `-1`.
+     */
+    fun mapPosition(lspPos: Position, prevDoc: Text, assoc: Int = -1): Int =
+        mapPos(fromPosition(lspPos, prevDoc), assoc)
+}

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/DocumentSyncTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/DocumentSyncTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.ChangeSet
+import com.monkopedia.kodemirror.state.ChangeSpec
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.InsertContent
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.TextDocumentContentChangeEventRange
+import com.monkopedia.lsp.TextDocumentContentChangeEventVariant
+import com.monkopedia.lsp.TextDocumentSyncKind
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+class DocumentSyncTest {
+    private fun doc(vararg lines: String): Text = Text.of(lines.toList())
+
+    private fun insertion(from: Int, to: Int, text: String, docLength: Int): ChangeSet =
+        ChangeSet.of(
+            ChangeSpec.Single(
+                from = DocPos(from),
+                to = DocPos(to),
+                insert = InsertContent.StringContent(text)
+            ),
+            docLength
+        )
+
+    @Test
+    fun toPositionMapsLineAndCharacter() {
+        val d = doc("hello", "world")
+        assertEquals(Position(0u, 0u), toPosition(0, d))
+        assertEquals(Position(0u, 3u), toPosition(3, d))
+        // offset 5 is end of line 0 (before the newline).
+        assertEquals(Position(0u, 5u), toPosition(5, d))
+        // offset 6 is start of line 1 (newline is at offset 5).
+        assertEquals(Position(1u, 0u), toPosition(6, d))
+        assertEquals(Position(1u, 2u), toPosition(8, d))
+    }
+
+    @Test
+    fun fromPositionInvertsToPosition() {
+        val d = doc("hello", "world")
+        for (offset in 0..d.length) {
+            assertEquals(offset, fromPosition(toPosition(offset, d), d))
+        }
+    }
+
+    @Test
+    fun positionRoundTripsAcrossUtf16SurrogatePair() {
+        // An emoji is two UTF-16 code units; LSP character offsets are code units.
+        val d = doc("a😀b")
+        assertEquals(Position(0u, 1u), toPosition(1, d))
+        // After the surrogate pair the character offset is 3.
+        assertEquals(Position(0u, 3u), toPosition(3, d))
+        assertEquals(3, fromPosition(Position(0u, 3u), d))
+    }
+
+    @Test
+    fun fromPositionClampsOutOfRange() {
+        val d = doc("hi")
+        // Character past the line clamps to line length.
+        assertEquals(2, fromPosition(Position(0u, 99u), d))
+        // Line past the document clamps to the last line; character 0 -> its start.
+        assertEquals(0, fromPosition(Position(99u, 0u), d))
+    }
+
+    @Test
+    fun syncModeFromNumberCapability() {
+        val caps = ServerCapabilities(textDocumentSync = JsonPrimitive(2))
+        val mode = DocumentSyncMode.forCapabilities(caps)
+        assertEquals(TextDocumentSyncKind.INCREMENTAL, mode.change)
+        assertTrue(mode.openClose)
+    }
+
+    @Test
+    fun syncModeFromOptionsCapability() {
+        val caps = ServerCapabilities(
+            textDocumentSync = buildJsonObject {
+                put("openClose", JsonPrimitive(true))
+                put("change", JsonPrimitive(1))
+            }
+        )
+        val mode = DocumentSyncMode.forCapabilities(caps)
+        assertEquals(TextDocumentSyncKind.FULL, mode.change)
+        assertTrue(mode.openClose)
+    }
+
+    @Test
+    fun syncModeDefaultsToNone() {
+        val mode = DocumentSyncMode.forCapabilities(ServerCapabilities())
+        assertEquals(TextDocumentSyncKind.NONE, mode.change)
+    }
+
+    @Test
+    fun fullSyncSendsWholeDocument() {
+        val prev = doc("abc")
+        val change = insertion(1, 1, "X", prev.length)
+        val next = change.apply(prev)
+        val events = buildContentChanges(
+            change,
+            prev,
+            next,
+            DocumentSyncMode(openClose = true, change = TextDocumentSyncKind.FULL)
+        )
+        assertEquals(1, events.size)
+        assertEquals("aXbc", (events[0] as TextDocumentContentChangeEventVariant).text)
+    }
+
+    @Test
+    fun incrementalSyncSendsRangedChange() {
+        val prev = doc("abc")
+        val change = insertion(1, 2, "XY", prev.length)
+        val next = change.apply(prev)
+        assertEquals("aXYc", next.toString())
+        val events = buildContentChanges(
+            change,
+            prev,
+            next,
+            DocumentSyncMode(openClose = true, change = TextDocumentSyncKind.INCREMENTAL)
+        )
+        assertEquals(1, events.size)
+        val ranged = events[0] as TextDocumentContentChangeEventRange
+        assertEquals("XY", ranged.text)
+        assertEquals(Position(0u, 1u), ranged.range.start)
+        assertEquals(Position(0u, 2u), ranged.range.end)
+    }
+
+    @Test
+    fun incrementalMultiChangeEmittedHighestOffsetFirst() {
+        val prev = doc("0123456789")
+        // Two non-overlapping edits in old-doc coordinates.
+        val change = ChangeSet.of(
+            ChangeSpec.Multi(
+                listOf(
+                    ChangeSpec.Single(DocPos(1), DocPos(2), InsertContent.StringContent("A")),
+                    ChangeSpec.Single(DocPos(5), DocPos(6), InsertContent.StringContent("B"))
+                )
+            ),
+            prev.length
+        )
+        val next = change.apply(prev)
+        val events = buildContentChanges(
+            change,
+            prev,
+            next,
+            DocumentSyncMode(openClose = true, change = TextDocumentSyncKind.INCREMENTAL)
+        ).map { it as TextDocumentContentChangeEventRange }
+        assertEquals(2, events.size)
+        // Highest offset first so earlier ranges stay valid when applied in order.
+        assertEquals(5u, events[0].range.start.character)
+        assertEquals(1u, events[1].range.start.character)
+        // Applying the events sequentially to prev reproduces next.
+        var result = prev.toString()
+        for (e in events) {
+            val from = fromPosition(e.range.start, Text.of(listOf(result)))
+            val to = fromPosition(e.range.end, Text.of(listOf(result)))
+            result = result.substring(0, from) + e.text + result.substring(to)
+        }
+        assertEquals(next.toString(), result)
+    }
+
+    @Test
+    fun workspaceMappingMapsThroughInFlightEdits() {
+        val mapping = WorkspaceMapping("file:///x")
+        val prev = doc("hello world")
+        // A request returned position at offset 6 ("world"). Meanwhile, "AB" was
+        // inserted at offset 0, shifting everything right by 2.
+        val edit = insertion(0, 0, "AB", prev.length)
+        mapping.addChanges(edit.desc)
+        assertEquals(8, mapping.mapPos(6))
+        // Mapping an LSP position interpreted against the request-time doc.
+        assertEquals(8, mapping.mapPosition(Position(0u, 6u), prev))
+    }
+
+    @Test
+    fun workspaceMappingIsIdentityWithoutEdits() {
+        val mapping = WorkspaceMapping("file:///x")
+        assertEquals(4, mapping.mapPos(4))
+    }
+}


### PR DESCRIPTION
## Summary
Second sub-issue of the LSP port epic #26. Closes #36. Implements document synchronization and position/workspace mapping on top of the #35 scaffold (replaces its `TODO(#36)` stubs). No diagnostics/hover/completion yet (those are #37+).

## What it does (matches upstream `@codemirror/lsp-client`)
- **Lifecycle**: `textDocument/didOpen` (v1, full text) on open, `didChange` on edits (per-file version increment), `didClose` on close — wired into `LSPPlugin` + `Workspace`.
- **Sync model — honors `textDocumentSync` capability**: incremental ranged `TextDocumentContentChangeEvent`s (from the `ChangeSet`, in prevDoc coords, **emitted highest-offset-first** so sequential application is correct) when the server advertises INCREMENTAL; full-document otherwise; nothing when NONE. No "full-only for simplicity" shortcut — mirrors upstream's decision (`DocumentSyncMode.forCapabilities` parses both the legacy-number and `{openClose,change}` object forms of the capability).
- **Position mapping**: `toPosition`/`fromPosition` (0-based LSP line vs 1-based kodemirror; UTF-16 char offset within line; clamped per spec).
- **In-flight mapping**: `WorkspaceMapping` (`mapPos`/`mapPosition`) so #37+ requests can map results through edits that landed while a request was in flight.

## Public API added/changed (please review — tier-2)
- `fun toPosition(offset: Int, doc: Text): Position` / `fun fromPosition(pos: Position, doc: Text): Int`
- `data class DocumentSyncMode(openClose, change)` + `syncsChanges` + `companion forCapabilities(caps)`
- `class WorkspaceMapping(uri)` — `mapPos(pos, assoc=-1)`, `mapPosition(lspPos, prevDoc, assoc=-1)`
- `data class WorkspaceFileUpdate(file, prevDoc, changes)`
- `WorkspaceFile`: `internal constructor` now; `version` starts at 1; `var doc`; `getText()`
- `Workspace`: `getMapping`/`releaseMapping`, `openFile` (now non-suspend register) + `didOpenFile` (suspend), `updateFile`, `syncFiles()`, `closeFile` + `didCloseFile`
- `LSPClient`: `val scope: CoroutineScope`, `suspend fun sync()`
(These refine the brand-new, unreleased #35 module — additive, no released surface affected.)

## Deviation (documented)
Upstream sends didOpen/didClose inline from `openFile`/`closeFile`; since kodemirror's plugin `init`/`destroy` are synchronous and `didOpen` needs post-`initialize()` capabilities, open/close are split into synchronous register + suspend `didOpenFile`/`didCloseFile`. The plugin runs `initialize() → didOpenFile → sync()` in its launch block; `didClose` is sent on a client-lifetime scope so it survives plugin-scope cancellation.

## Verification
`:lsp-client:compileKotlinJvm`, `compileKotlinWasmJs`, `compileDebugKotlinAndroid`, `apiCheck`, and `:jvmTest` (12 tests, incl. a sequential-application check for incremental ordering) all green. spotless/ktlint applied; apiDump committed. Apple/native not cross-compiled on Linux (commonMain-only).

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :lsp-client:jvmTest :lsp-client:compileKotlinWasmJs :lsp-client:compileDebugKotlinAndroid :lsp-client:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`