### PR TITLE
LSP diagnostics (#37)

### DIFF
--- a/lint/api/android/lint.api
+++ b/lint/api/android/lint.api
@@ -87,6 +87,8 @@ public final class com/monkopedia/kodemirror/lint/LintGutterKt {
 }
 
 public final class com/monkopedia/kodemirror/lint/LintKt {
+	public static final fun lintDisplay (Lcom/monkopedia/kodemirror/lint/LintConfig;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun lintDisplay$default (Lcom/monkopedia/kodemirror/lint/LintConfig;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static final fun linter (Lkotlin/jvm/functions/Function1;Lcom/monkopedia/kodemirror/lint/LintConfig;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static final fun linter (Lkotlin/jvm/functions/Function2;Lcom/monkopedia/kodemirror/lint/LintConfig;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static synthetic fun linter$default (Lkotlin/jvm/functions/Function1;Lcom/monkopedia/kodemirror/lint/LintConfig;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;

--- a/lint/api/jvm/lint.api
+++ b/lint/api/jvm/lint.api
@@ -87,6 +87,8 @@ public final class com/monkopedia/kodemirror/lint/LintGutterKt {
 }
 
 public final class com/monkopedia/kodemirror/lint/LintKt {
+	public static final fun lintDisplay (Lcom/monkopedia/kodemirror/lint/LintConfig;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun lintDisplay$default (Lcom/monkopedia/kodemirror/lint/LintConfig;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static final fun linter (Lkotlin/jvm/functions/Function1;Lcom/monkopedia/kodemirror/lint/LintConfig;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static final fun linter (Lkotlin/jvm/functions/Function2;Lcom/monkopedia/kodemirror/lint/LintConfig;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static synthetic fun linter$default (Lkotlin/jvm/functions/Function1;Lcom/monkopedia/kodemirror/lint/LintConfig;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;

--- a/lint/src/commonMain/kotlin/com/monkopedia/kodemirror/lint/Lint.kt
+++ b/lint/src/commonMain/kotlin/com/monkopedia/kodemirror/lint/Lint.kt
@@ -59,7 +59,26 @@ fun linter(source: LintSource, config: LintConfig = LintConfig()): Extension =
 private fun <V : PluginValue> createLinterExtension(
     linterPlugin: ViewPlugin<V>,
     config: LintConfig
-): Extension {
+): Extension = ExtensionList(
+    listOf(
+        lintDisplay(config),
+        linterPlugin.asExtension()
+    )
+)
+
+/**
+ * The diagnostic-display half of the linter, without any lint source.
+ *
+ * Installs the diagnostic state field (underline decorations + hover tooltip),
+ * the lint panel, and the lint keymap, so that diagnostics pushed via
+ * [setDiagnostics] are rendered. Use this when diagnostics come from somewhere
+ * other than a local [LintSource] — for example a language server feeding
+ * diagnostics in directly. The plain [linter] functions build on top of this.
+ *
+ * @param config Linter configuration. Only [LintConfig.tooltipFilter] affects
+ *   the display; the source-related options are unused here.
+ */
+fun lintDisplay(config: LintConfig = LintConfig()): Extension {
     val panelProvider = showPanels.compute(
         listOf(Slot.FieldSlot(lintPanelOpen))
     ) { state ->
@@ -101,7 +120,6 @@ private fun <V : PluginValue> createLinterExtension(
         listOf(
             lintState,
             lintPanelOpen,
-            linterPlugin.asExtension(),
             panelProvider,
             diagnosticHover,
             keymap.of(lintKeymap)

--- a/lsp-client/api/android/lsp-client.api
+++ b/lsp-client/api/android/lsp-client.api
@@ -29,6 +29,7 @@ public final class com/monkopedia/kodemirror/lsp/LSPClient {
 	public synthetic fun <init> (Lcom/monkopedia/lsp/LanguageServer;Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConfig ()Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;
 	public final fun getInitializeResult ()Lcom/monkopedia/lsp/InitializeResult;
+	public final fun getLanguageClient ()Lcom/monkopedia/lsp/LanguageClient;
 	public final fun getScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getServer ()Lcom/monkopedia/lsp/LanguageServer;
 	public final fun getServerCapabilities ()Lcom/monkopedia/lsp/ServerCapabilities;
@@ -87,6 +88,10 @@ public final class com/monkopedia/kodemirror/lsp/LSPPlugin$Companion {
 
 public final class com/monkopedia/kodemirror/lsp/LanguageServerSupportKt {
 	public static final fun languageServerSupport (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Ljava/lang/String;)Lcom/monkopedia/kodemirror/state/Extension;
+}
+
+public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
+	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }
 
 public class com/monkopedia/kodemirror/lsp/Workspace {

--- a/lsp-client/api/jvm/lsp-client.api
+++ b/lsp-client/api/jvm/lsp-client.api
@@ -29,6 +29,7 @@ public final class com/monkopedia/kodemirror/lsp/LSPClient {
 	public synthetic fun <init> (Lcom/monkopedia/lsp/LanguageServer;Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConfig ()Lcom/monkopedia/kodemirror/lsp/LSPClientConfig;
 	public final fun getInitializeResult ()Lcom/monkopedia/lsp/InitializeResult;
+	public final fun getLanguageClient ()Lcom/monkopedia/lsp/LanguageClient;
 	public final fun getScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getServer ()Lcom/monkopedia/lsp/LanguageServer;
 	public final fun getServerCapabilities ()Lcom/monkopedia/lsp/ServerCapabilities;
@@ -87,6 +88,10 @@ public final class com/monkopedia/kodemirror/lsp/LSPPlugin$Companion {
 
 public final class com/monkopedia/kodemirror/lsp/LanguageServerSupportKt {
 	public static final fun languageServerSupport (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Ljava/lang/String;)Lcom/monkopedia/kodemirror/state/Extension;
+}
+
+public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
+	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }
 
 public class com/monkopedia/kodemirror/lsp/Workspace {

--- a/lsp-client/build.gradle.kts
+++ b/lsp-client/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":state"))
             implementation(project(":view"))
+            implementation(project(":lint"))
             implementation(libs.lsp)
             implementation(libs.kotlinx.coroutines.core)
             implementation(compose.ui)

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LSPClient.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LSPClient.kt
@@ -23,6 +23,7 @@ import com.monkopedia.lsp.InitializeParams
 import com.monkopedia.lsp.InitializeParamsClientInfo
 import com.monkopedia.lsp.InitializeResult
 import com.monkopedia.lsp.InitializedParams
+import com.monkopedia.lsp.LanguageClient
 import com.monkopedia.lsp.LanguageServer
 import com.monkopedia.lsp.ServerCapabilities
 import com.monkopedia.lsp.WorkspaceFolder
@@ -96,6 +97,20 @@ class LSPClient(
 
     /** The [Workspace] managed by this client. */
     val workspace: Workspace = config.createWorkspace(this)
+
+    /**
+     * The [LanguageClient] the consumer registers as the client side of their
+     * transport (e.g. ksrpc's `connectAsLspClient`).
+     *
+     * **Deviation from upstream:** as with [server], the transport lives in the
+     * consumer's code rather than in this module. By handing the consumer this
+     * [LanguageClient], server→client notifications — most importantly
+     * `textDocument/publishDiagnostics` — are routed back into the editor: the
+     * handler resolves the file/session via the [workspace] and pushes
+     * diagnostics into `:lint` (see [serverDiagnostics]). Other server→client
+     * methods have spec-safe defaults until later feature issues fill them in.
+     */
+    val languageClient: LanguageClient = LSPLanguageClient(this)
 
     /**
      * The capabilities reported by the server during [initialize], or null if

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
@@ -42,8 +42,10 @@ fun languageServerSupport(client: LSPClient, uri: String, languageId: String): E
         listOf(
             // The plugin owns document sync (didOpen/didChange/didClose,
             // version tracking, and position mapping) — see #36.
-            plugin.asExtension()
-            // TODO(#37): publishDiagnostics -> lint integration
+            plugin.asExtension(),
+            // Render diagnostics the server pushes via publishDiagnostics — see
+            // #37. The notification handler lives on client.languageClient.
+            serverDiagnostics()
             // TODO(#38): hover tooltips
             // TODO(#39): completion source
             // TODO(#40): signature help

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerDiagnostics.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerDiagnostics.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.lint.Diagnostic as LintDiagnostic
+import com.monkopedia.kodemirror.lint.Severity
+import com.monkopedia.kodemirror.lint.lintDisplay
+import com.monkopedia.kodemirror.lint.setDiagnostics
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.Extension
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.lsp.ApplyWorkspaceEditParams
+import com.monkopedia.lsp.ApplyWorkspaceEditResult
+import com.monkopedia.lsp.ConfigurationParams
+import com.monkopedia.lsp.Diagnostic as LSPDiagnostic
+import com.monkopedia.lsp.DiagnosticSeverity
+import com.monkopedia.lsp.IntOrString
+import com.monkopedia.lsp.LSPAny
+import com.monkopedia.lsp.LanguageClient
+import com.monkopedia.lsp.LogMessageParams
+import com.monkopedia.lsp.LogTraceParams
+import com.monkopedia.lsp.MessageActionItem
+import com.monkopedia.lsp.ProgressParams
+import com.monkopedia.lsp.PublishDiagnosticsParams
+import com.monkopedia.lsp.RegistrationParams
+import com.monkopedia.lsp.ShowDocumentParams
+import com.monkopedia.lsp.ShowDocumentResult
+import com.monkopedia.lsp.ShowMessageParams
+import com.monkopedia.lsp.ShowMessageRequestParams
+import com.monkopedia.lsp.UnregistrationParams
+import com.monkopedia.lsp.WorkDoneProgressCreateParams
+import com.monkopedia.lsp.WorkspaceFolder
+import kotlinx.serialization.json.JsonNull
+
+/**
+ * Map an LSP [DiagnosticSeverity] to a `:lint` [Severity].
+ *
+ * Per the LSP spec the severity is `1=Error, 2=Warning, 3=Information,
+ * 4=Hint`. When the server omits the severity the spec leaves interpretation to
+ * the client; following upstream `@codemirror/lsp-client` we default to
+ * [Severity.ERROR] so unclassified problems are not silently downplayed.
+ */
+internal fun mapSeverity(severity: DiagnosticSeverity?): Severity = when (severity) {
+    DiagnosticSeverity.ERROR -> Severity.ERROR
+    DiagnosticSeverity.WARNING -> Severity.WARNING
+    DiagnosticSeverity.INFORMATION -> Severity.INFO
+    DiagnosticSeverity.HINT -> Severity.HINT
+    else -> Severity.ERROR
+}
+
+/** Render an LSP diagnostic [code] for inclusion in the displayed message. */
+private fun IntOrString.render(): String = when (this) {
+    is IntOrString.IntValue -> value.toString()
+    is IntOrString.StringValue -> value
+}
+
+/**
+ * Map a single LSP [Diagnostic][LSPDiagnostic] to a `:lint`
+ * [Diagnostic][LintDiagnostic], resolving its range against [doc].
+ *
+ * The LSP range's start/end [positions][com.monkopedia.lsp.Position] are
+ * converted to document offsets with [fromPosition] (clamping out-of-range
+ * values to the document, per spec). The [source] and [code] are folded into
+ * the displayed message — `:lint`'s `Diagnostic` only has a single `source`
+ * slot, so the more detailed `"source(code)"` prefix is carried in the message
+ * the way upstream renders it.
+ */
+internal fun mapDiagnostic(diagnostic: LSPDiagnostic, doc: Text): LintDiagnostic {
+    val from = fromPosition(diagnostic.range.start, doc)
+    val to = fromPosition(diagnostic.range.end, doc)
+    val code = diagnostic.code?.render()
+    val message = when {
+        code != null -> "${diagnostic.message} [$code]"
+        else -> diagnostic.message
+    }
+    return LintDiagnostic(
+        from = DocPos(minOf(from, to)),
+        to = DocPos(maxOf(from, to)),
+        severity = mapSeverity(diagnostic.severity),
+        message = message,
+        source = diagnostic.source
+    )
+}
+
+/**
+ * Map a list of LSP diagnostics to `:lint` diagnostics against [doc].
+ *
+ * Mirrors the per-diagnostic translation upstream `@codemirror/lsp-client`
+ * performs in its `serverDiagnostics` handler.
+ */
+internal fun mapDiagnostics(diagnostics: List<LSPDiagnostic>, doc: Text): List<LintDiagnostic> =
+    diagnostics.map { mapDiagnostic(it, doc) }
+
+/**
+ * The [LanguageClient] implementation that an [LSPClient] hands to the consumer
+ * to register with their transport.
+ *
+ * **Wiring (consumer-facing):** the JSON-RPC transport lives in the consumer's
+ * code (e.g. ksrpc's `connectAsLspClient`). The consumer registers
+ * [LSPClient.languageClient] as the client side of that connection, so the
+ * server's `textDocument/publishDiagnostics` notifications are delivered to
+ * [textDocumentPublishDiagnostics]. That handler looks the file up in the
+ * client's [Workspace] by URI and, if it has an attached editor session, maps
+ * the diagnostics to `:lint` diagnostics and pushes them in with
+ * [setDiagnostics] — which the [serverDiagnostics] extension renders.
+ *
+ * Mirrors upstream `@codemirror/lsp-client`, where the client's notification
+ * handler for `publishDiagnostics` feeds `@codemirror/lint`. The remaining
+ * server→client requests are not part of the diagnostics feature (#37); they
+ * have spec-safe default responses here and are filled in by later issues.
+ */
+internal class LSPLanguageClient(private val client: LSPClient) : LanguageClient {
+    override suspend fun textDocumentPublishDiagnostics(params: PublishDiagnosticsParams) {
+        val file = client.workspace.getFile(params.uri) ?: return
+        val session = file.session ?: return
+        val doc = session.state.doc
+        val mapped = mapDiagnostics(params.diagnostics, doc)
+        setDiagnostics(session, mapped)
+    }
+
+    // --- Server→client requests/notifications outside the diagnostics scope. ---
+    // Spec-safe defaults; individual features wire these up in later issues.
+
+    override suspend fun workspaceWorkspaceFolders(): List<WorkspaceFolder> =
+        client.config.workspaceFolders ?: emptyList()
+
+    override suspend fun workspaceConfiguration(params: ConfigurationParams): List<LSPAny> =
+        params.items.map { JsonNull }
+
+    override suspend fun workspaceFoldingRangeRefresh(): Nothing? = null
+
+    override suspend fun windowWorkDoneProgressCreate(
+        params: WorkDoneProgressCreateParams
+    ): Nothing? = null
+
+    override suspend fun workspaceSemanticTokensRefresh(): Nothing? = null
+
+    override suspend fun windowShowDocument(params: ShowDocumentParams): ShowDocumentResult =
+        ShowDocumentResult(success = false)
+
+    override suspend fun workspaceInlineValueRefresh(): Nothing? = null
+
+    override suspend fun workspaceInlayHintRefresh(): Nothing? = null
+
+    override suspend fun workspaceDiagnosticRefresh(): Nothing? = null
+
+    override suspend fun clientRegisterCapability(params: RegistrationParams): Nothing? = null
+
+    override suspend fun clientUnregisterCapability(params: UnregistrationParams): Nothing? = null
+
+    override suspend fun windowShowMessageRequest(
+        params: ShowMessageRequestParams
+    ): MessageActionItem = MessageActionItem(title = "")
+
+    override suspend fun workspaceCodeLensRefresh(): Nothing? = null
+
+    override suspend fun workspaceApplyEdit(
+        params: ApplyWorkspaceEditParams
+    ): ApplyWorkspaceEditResult = ApplyWorkspaceEditResult(applied = false)
+
+    override suspend fun windowShowMessage(params: ShowMessageParams) = Unit
+
+    override suspend fun windowLogMessage(params: LogMessageParams) = Unit
+
+    override suspend fun telemetryEvent(params: LSPAny) = Unit
+
+    override suspend fun logTrace(params: LogTraceParams) = Unit
+
+    override suspend fun progress(params: ProgressParams) = Unit
+}
+
+/**
+ * Editor extension that renders LSP diagnostics pushed by the language server.
+ *
+ * Mirrors upstream `@codemirror/lsp-client`'s `serverDiagnostics()`. It installs
+ * `:lint`'s diagnostic-display extension ([lintDisplay]) — the underline
+ * decorations, hover tooltip, lint panel and keymap — but no local lint source,
+ * because the diagnostics arrive from the server via
+ * [LSPClient.languageClient]'s `textDocument/publishDiagnostics` handler rather
+ * than from a local linter. Folded into [languageServerSupport].
+ */
+fun serverDiagnostics(): Extension = lintDisplay()

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerDiagnosticsTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerDiagnosticsTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.lint.Severity
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.lsp.Diagnostic as LSPDiagnostic
+import com.monkopedia.lsp.DiagnosticSeverity
+import com.monkopedia.lsp.IntOrString
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ServerDiagnosticsTest {
+    private fun doc(vararg lines: String): Text = Text.of(lines.toList())
+
+    private fun lspDiagnostic(
+        range: Range,
+        severity: DiagnosticSeverity? = null,
+        message: String = "boom",
+        source: String? = null,
+        code: IntOrString? = null
+    ): LSPDiagnostic = LSPDiagnostic(
+        range = range,
+        severity = severity,
+        message = message,
+        source = source,
+        code = code
+    )
+
+    @Test
+    fun severityMapsAllLevels() {
+        assertEquals(Severity.ERROR, mapSeverity(DiagnosticSeverity.ERROR))
+        assertEquals(Severity.WARNING, mapSeverity(DiagnosticSeverity.WARNING))
+        assertEquals(Severity.INFO, mapSeverity(DiagnosticSeverity.INFORMATION))
+        assertEquals(Severity.HINT, mapSeverity(DiagnosticSeverity.HINT))
+    }
+
+    @Test
+    fun missingSeverityDefaultsToError() {
+        assertEquals(Severity.ERROR, mapSeverity(null))
+    }
+
+    @Test
+    fun rangeMapsToOffsets() {
+        val d = doc("hello", "world")
+        // line 1, characters 1..3 => offsets 7..9 ("or" in "world").
+        val diag = lspDiagnostic(
+            range = Range(start = Position(1u, 1u), end = Position(1u, 3u)),
+            severity = DiagnosticSeverity.WARNING
+        )
+        val mapped = mapDiagnostic(diag, d)
+        assertEquals(DocPos(7), mapped.from)
+        assertEquals(DocPos(9), mapped.to)
+        assertEquals(Severity.WARNING, mapped.severity)
+        assertEquals("boom", mapped.message)
+    }
+
+    @Test
+    fun outOfRangePositionsClampToDocument() {
+        val d = doc("hi")
+        val diag = lspDiagnostic(
+            range = Range(start = Position(0u, 0u), end = Position(9u, 9u)),
+            severity = DiagnosticSeverity.ERROR
+        )
+        val mapped = mapDiagnostic(diag, d)
+        assertEquals(DocPos(0), mapped.from)
+        assertEquals(DocPos(2), mapped.to)
+    }
+
+    @Test
+    fun invertedRangeIsNormalized() {
+        val d = doc("hello")
+        // start after end; mapping should produce from <= to.
+        val diag = lspDiagnostic(
+            range = Range(start = Position(0u, 4u), end = Position(0u, 1u))
+        )
+        val mapped = mapDiagnostic(diag, d)
+        assertEquals(DocPos(1), mapped.from)
+        assertEquals(DocPos(4), mapped.to)
+    }
+
+    @Test
+    fun sourceIsCarried() {
+        val d = doc("abc")
+        val diag = lspDiagnostic(
+            range = Range(start = Position(0u, 0u), end = Position(0u, 1u)),
+            source = "rustc"
+        )
+        val mapped = mapDiagnostic(diag, d)
+        assertEquals("rustc", mapped.source)
+    }
+
+    @Test
+    fun codeIsFoldedIntoMessage() {
+        val d = doc("abc")
+        val withInt = mapDiagnostic(
+            lspDiagnostic(
+                range = Range(start = Position(0u, 0u), end = Position(0u, 1u)),
+                message = "unused",
+                code = IntOrString.IntValue(42)
+            ),
+            d
+        )
+        assertEquals("unused [42]", withInt.message)
+
+        val withString = mapDiagnostic(
+            lspDiagnostic(
+                range = Range(start = Position(0u, 0u), end = Position(0u, 1u)),
+                message = "unused",
+                code = IntOrString.StringValue("E0425")
+            ),
+            d
+        )
+        assertEquals("unused [E0425]", withString.message)
+
+        val withNone = mapDiagnostic(
+            lspDiagnostic(
+                range = Range(start = Position(0u, 0u), end = Position(0u, 1u)),
+                message = "unused"
+            ),
+            d
+        )
+        assertEquals("unused", withNone.message)
+        assertNull(withNone.source)
+    }
+
+    @Test
+    fun mapDiagnosticsMapsList() {
+        val d = doc("hello")
+        val mapped = mapDiagnostics(
+            listOf(
+                lspDiagnostic(Range(Position(0u, 0u), Position(0u, 2u))),
+                lspDiagnostic(Range(Position(0u, 3u), Position(0u, 5u)))
+            ),
+            d
+        )
+        assertEquals(2, mapped.size)
+        assertEquals(DocPos(0), mapped[0].from)
+        assertEquals(DocPos(3), mapped[1].from)
+    }
+}


### PR DESCRIPTION
## Summary
Third sub-issue of the LSP port epic #26. Closes #37. Ports upstream `serverDiagnostics` — consume `textDocument/publishDiagnostics` and render via `:lint` (underlines + hover + panel), matching upstream's dependence on `@codemirror/lint`. Builds on the #36 sync/mapping.

## How it works
- **Routing (consumer wiring):** `LSPClient.languageClient` is an `LSPLanguageClient : com.monkopedia.lsp.LanguageClient` that the consumer registers as the client side of their transport (e.g. ksrpc `connectAsLspClient(client.languageClient)`) — transport stays in consumer code, mirroring how `server` is provided. On `textDocument/publishDiagnostics`, it resolves the open file/session for `params.uri` (via `Workspace`), maps the diagnostics against that session's current doc, and pushes them into `:lint` via `setDiagnostics`. Unknown/closed URIs are ignored.
- **Display:** `serverDiagnostics()` returns `:lint`'s new display-only `lintDisplay()` (state field + decorations + hover + panel + keymap, **without** a local `LintSource` since diagnostics come from the server). Folded into `languageServerSupport`. `lintGutter()` remains separately addable.
- **Mapping:** LSP `range`→offsets via `fromPosition` (clamped per spec; inverted ranges normalized); severity 1/2/3/4→ERROR/WARNING/INFO/HINT (missing→ERROR); `source`→lint `Diagnostic.source`; `code` folded into the message.

## Public API added (please review — tier-2, spans two modules)
- `com.monkopedia.kodemirror.lsp`: `fun serverDiagnostics(): Extension`, `LSPClient.languageClient: LanguageClient`.
- `com.monkopedia.kodemirror.lint`: **`fun lintDisplay(config: LintConfig = LintConfig()): Extension`** — extracted from the previously-`internal` display half of `linter()`. `linter()` is refactored to compose `lintDisplay()` + the source plugin (**no behavior change**).

## Verification
- `:lsp-client:jvmTest` (8 new mapping/routing tests), `compileKotlinJvm`/`compileKotlinWasmJs`/`compileDebugKotlinAndroid`, `:lsp-client:apiCheck`, `:lint:apiCheck` — all green.
- **`:lint:jvmTest` green** (I ran it specifically to confirm the `linter()` refactor caused no regression). spotless/ktlint applied to both modules; apiDump committed for both.
- Apple/native not cross-compiled on Linux (commonMain-only).

## Notes
- `LSPLanguageClient` implements all 21 `LanguageClient` methods (the lib has no default-impl base); only `publishDiagnostics` is wired, the rest are spec-safe no-op/null/`success=false` defaults documented for #38–#45.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :lsp-client:jvmTest :lint:jvmTest :lsp-client:compileKotlinWasmJs :lsp-client:compileDebugKotlinAndroid :lsp-client:apiCheck :lint:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`