### PR TITLE
LSP completion (#38)

### DIFF
--- a/lsp-client/api/android/lsp-client.api
+++ b/lsp-client/api/android/lsp-client.api
@@ -90,6 +90,29 @@ public final class com/monkopedia/kodemirror/lsp/LanguageServerSupportKt {
 	public static final fun languageServerSupport (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Ljava/lang/String;)Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerCompletionConfig {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (ZLkotlin/text/Regex;)V
+	public synthetic fun <init> (ZLkotlin/text/Regex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Lkotlin/text/Regex;
+	public final fun copy (ZLkotlin/text/Regex;)Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;ZLkotlin/text/Regex;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOverride ()Z
+	public final fun getValidFor ()Lkotlin/text/Regex;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/monkopedia/kodemirror/lsp/ServerCompletionKt {
+	public static final fun serverCompletion (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun serverCompletion$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static final fun serverCompletionSource (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;)Lkotlin/jvm/functions/Function2;
+	public static synthetic fun serverCompletionSource$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;ILjava/lang/Object;)Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }

--- a/lsp-client/api/jvm/lsp-client.api
+++ b/lsp-client/api/jvm/lsp-client.api
@@ -90,6 +90,29 @@ public final class com/monkopedia/kodemirror/lsp/LanguageServerSupportKt {
 	public static final fun languageServerSupport (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Ljava/lang/String;)Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerCompletionConfig {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (ZLkotlin/text/Regex;)V
+	public synthetic fun <init> (ZLkotlin/text/Regex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Lkotlin/text/Regex;
+	public final fun copy (ZLkotlin/text/Regex;)Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;ZLkotlin/text/Regex;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOverride ()Z
+	public final fun getValidFor ()Lkotlin/text/Regex;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/monkopedia/kodemirror/lsp/ServerCompletionKt {
+	public static final fun serverCompletion (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun serverCompletion$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static final fun serverCompletionSource (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;)Lkotlin/jvm/functions/Function2;
+	public static synthetic fun serverCompletionSource$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;ILjava/lang/Object;)Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }

--- a/lsp-client/build.gradle.kts
+++ b/lsp-client/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
             implementation(project(":state"))
             implementation(project(":view"))
             implementation(project(":lint"))
+            implementation(project(":autocomplete"))
             implementation(libs.lsp)
             implementation(libs.kotlinx.coroutines.core)
             implementation(compose.ui)
@@ -19,6 +20,7 @@ kotlin {
         commonTest.dependencies {
             implementation(project(":state"))
             implementation(project(":view"))
+            implementation(project(":autocomplete"))
         }
     }
 }

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
@@ -25,10 +25,10 @@ import com.monkopedia.kodemirror.state.ExtensionList
  * Public entry point: build the editor [Extension] that connects an editor for
  * a single file to a language server through [client].
  *
- * Mirrors upstream `@codemirror/lsp-client`'s `languageServerSupport`. For the
- * scaffold this only registers the [LSPPlugin]; feature extensions (completion,
- * hover, diagnostics, signature help, rename, etc.) are appended to the returned
- * [ExtensionList] by later issues.
+ * Mirrors upstream `@codemirror/lsp-client`'s `languageServerSupport`. It
+ * registers the [LSPPlugin], server-pushed diagnostics, and server completion;
+ * the remaining feature extensions (hover, signature help, rename, etc.) are
+ * appended to the returned [ExtensionList] by later issues.
  *
  * @param client The [LSPClient] wrapping the provided language server.
  * @param uri The document URI for this editor's file.
@@ -45,9 +45,11 @@ fun languageServerSupport(client: LSPClient, uri: String, languageId: String): E
             plugin.asExtension(),
             // Render diagnostics the server pushes via publishDiagnostics — see
             // #37. The notification handler lives on client.languageClient.
-            serverDiagnostics()
-            // TODO(#38): hover tooltips
-            // TODO(#39): completion source
+            serverDiagnostics(),
+            // Request completions from the server as the editor's autocomplete
+            // source — see #38.
+            serverCompletion(client, uri)
+            // TODO(#39): hover tooltips
             // TODO(#40): signature help
             // TODO(#41): go-to-definition
             // TODO(#42): find references

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletion.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletion.kt
@@ -1,0 +1,510 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.autocomplete.Completion
+import com.monkopedia.kodemirror.autocomplete.CompletionApplyContext
+import com.monkopedia.kodemirror.autocomplete.CompletionConfig
+import com.monkopedia.kodemirror.autocomplete.CompletionContext
+import com.monkopedia.kodemirror.autocomplete.CompletionResult
+import com.monkopedia.kodemirror.autocomplete.CompletionSource
+import com.monkopedia.kodemirror.autocomplete.SuspendCompletionSource
+import com.monkopedia.kodemirror.autocomplete.asyncCompletionSource
+import com.monkopedia.kodemirror.autocomplete.autocompletion
+import com.monkopedia.kodemirror.autocomplete.snippet
+import com.monkopedia.kodemirror.autocomplete.snippets
+import com.monkopedia.kodemirror.state.ChangeSpec
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.Extension
+import com.monkopedia.kodemirror.state.ExtensionList
+import com.monkopedia.kodemirror.state.InsertContent
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.kodemirror.state.TransactionSpec
+import com.monkopedia.lsp.CompletionItem
+import com.monkopedia.lsp.CompletionItemKind
+import com.monkopedia.lsp.CompletionItemTextEdit
+import com.monkopedia.lsp.CompletionList
+import com.monkopedia.lsp.CompletionParams
+import com.monkopedia.lsp.InsertReplaceEdit
+import com.monkopedia.lsp.InsertTextFormat
+import com.monkopedia.lsp.MarkupContent
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.StringOr
+import com.monkopedia.lsp.TextDocumentIdentifier
+import com.monkopedia.lsp.TextEdit
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Configuration for [serverCompletion].
+ *
+ * Mirrors the shape of the options object upstream `@codemirror/lsp-client`'s
+ * `serverCompletion` accepts.
+ *
+ * @param override When true, the language-server completion source *replaces*
+ *   all other completion sources (upstream's `autocompletion({override: [...]})`
+ *   path). When false (the default) it is installed as the editor's completion
+ *   source — see the deviation note on [serverCompletion].
+ * @param validFor A custom [Regex] used as the
+ *   [CompletionResult.validFor][com.monkopedia.kodemirror.autocomplete.CompletionResult.validFor]
+ *   for results, allowing the cached list to be reused as the user keeps typing.
+ *   When null, a regex derived from the result items' prefixes is used (matching
+ *   upstream's `prefixRegexp`).
+ */
+data class ServerCompletionConfig(
+    val override: Boolean = false,
+    val validFor: Regex? = null
+)
+
+/**
+ * The kind→type mapping upstream `@codemirror/lsp-client` uses to translate an
+ * LSP [CompletionItemKind] into the `:autocomplete`
+ * [type][Completion.type] string (which selects the completion icon).
+ *
+ * Kinds without an entry (e.g. `Unit` only maps to `keyword`, but `File`,
+ * `Folder`, `Reference`, `Event`, `Operator`, `Snippet`) leave [Completion.type]
+ * null — exactly as upstream's `kindToType` table, which is intentionally
+ * partial.
+ */
+internal fun kindToType(kind: CompletionItemKind?): String? = when (kind) {
+    CompletionItemKind.TEXT -> "text"
+    CompletionItemKind.METHOD -> "method"
+    CompletionItemKind.FUNCTION -> "function"
+    CompletionItemKind.CONSTRUCTOR -> "class"
+    CompletionItemKind.FIELD -> "property"
+    CompletionItemKind.VARIABLE -> "variable"
+    CompletionItemKind.CLASS -> "class"
+    CompletionItemKind.INTERFACE -> "interface"
+    CompletionItemKind.MODULE -> "namespace"
+    CompletionItemKind.PROPERTY -> "property"
+    CompletionItemKind.UNIT -> "keyword"
+    CompletionItemKind.VALUE -> "constant"
+    CompletionItemKind.ENUM -> "constant"
+    CompletionItemKind.KEYWORD -> "keyword"
+    CompletionItemKind.COLOR -> "constant"
+    CompletionItemKind.ENUM_MEMBER -> "constant"
+    CompletionItemKind.CONSTANT -> "constant"
+    CompletionItemKind.STRUCT -> "class"
+    CompletionItemKind.TYPE_PARAMETER -> "type"
+    else -> null
+}
+
+/**
+ * Translate an LSP snippet template (the `newText`/`insertText` of an item whose
+ * [insertTextFormat][CompletionItem.insertTextFormat] is
+ * [InsertTextFormat.SNIPPET]) into the `${name}` template the `:autocomplete`
+ * [snippet] applicator understands.
+ *
+ * LSP snippet syntax (a subset of TextMate snippets) uses numbered tab stops:
+ * `$1`, `$2`, …, the final cursor stop `$0`, and placeholder stops
+ * `${1:label}`. `:autocomplete`'s [snippet] supports only `${name}` named stops
+ * (no nested placeholders, no choices, no variables), navigated in document
+ * order via Tab/Shift-Tab.
+ *
+ * **Deviation:** `:autocomplete` snippets cannot represent placeholder *text*
+ * inside a tab stop, so `${1:foo}` is mapped to an empty `${1}` stop (the `foo`
+ * default text is dropped) and the numeric ordering is preserved only insofar as
+ * the stops appear in document order. `$0` becomes the named stop `${0}`. This
+ * matches upstream's own lossy translation (`text.replace(/\$(\d+)/g, "${$1}")`)
+ * for the bare-`$N` case; the placeholder-text and escape handling here is a
+ * faithful superset. Backslash escapes (`\$`, `\}`, `\\`) are unescaped to their
+ * literal characters.
+ */
+internal fun lspSnippetToTemplate(snippet: String): String {
+    val out = StringBuilder()
+    var i = 0
+    while (i < snippet.length) {
+        val c = snippet[i]
+        when {
+            c == '\\' && i + 1 < snippet.length -> {
+                // Escaped character: emit the next char literally.
+                out.append(snippet[i + 1])
+                i += 2
+            }
+            c == '$' && i + 1 < snippet.length && snippet[i + 1] == '{' -> {
+                // ${ ... } placeholder. Find the matching closing brace.
+                val end = snippet.indexOf('}', i + 2)
+                if (end == -1) {
+                    out.append(c)
+                    i++
+                } else {
+                    val body = snippet.substring(i + 2, end)
+                    // Body is "name", "name:default", or "name|a,b,c|" (choice).
+                    val name = body.substringBefore(':').substringBefore('|')
+                    out.append("\${").append(name).append('}')
+                    i = end + 1
+                }
+            }
+            c == '$' && i + 1 < snippet.length && snippet[i + 1].isDigit() -> {
+                // $N tab stop.
+                var j = i + 1
+                while (j < snippet.length && snippet[j].isDigit()) j++
+                val name = snippet.substring(i + 1, j)
+                out.append("\${").append(name).append('}')
+                i = j
+            }
+            else -> {
+                out.append(c)
+                i++
+            }
+        }
+    }
+    return out.toString()
+}
+
+/** Extract the documentation string from an LSP `string | MarkupContent`. */
+internal fun documentationText(documentation: StringOr<MarkupContent>?): String? =
+    when (documentation) {
+        null -> null
+        is StringOr.StringValue -> documentation.value.takeIf { it.isNotEmpty() }
+        is StringOr.Value -> documentation.value.value.takeIf { it.isNotEmpty() }
+    }
+
+/** The LSP [Range] of a [CompletionItemTextEdit], whichever variant it is. */
+internal fun CompletionItemTextEdit.range(): Range = when (this) {
+    is TextEdit -> range
+    is InsertReplaceEdit -> replace
+}
+
+/** The `newText` of a [CompletionItemTextEdit], whichever variant it is. */
+internal fun CompletionItemTextEdit.newText(): String = when (this) {
+    is TextEdit -> newText
+    is InsertReplaceEdit -> newText
+}
+
+/**
+ * Decide the text a [CompletionItem] should insert, following upstream's
+ * precedence: `textEdit.newText` then `textEditText` then `insertText` then
+ * `label`.
+ */
+internal fun CompletionItem.insertionText(): String =
+    textEdit?.newText() ?: textEditText ?: insertText ?: label
+
+/**
+ * Map a single LSP [CompletionItem] to an `:autocomplete` [Completion].
+ *
+ * Mirrors upstream `@codemirror/lsp-client`'s per-item mapping in
+ * `serverCompletionSource`:
+ * - `label` is the insertion text (`textEdit.newText`/`textEditText`/
+ *   `insertText`/`label`), except for snippets where the display label is the
+ *   item's own [label][CompletionItem.label].
+ * - `type` is derived from [kind][CompletionItem.kind] via [kindToType].
+ * - `detail`/`sortText` are carried through.
+ * - `documentation` (string or markdown) becomes the [info][Completion.info].
+ * - When [insertTextFormat][CompletionItem.insertTextFormat] is
+ *   [Snippet][InsertTextFormat.SNIPPET], an [applyFn][Completion.applyFn] is
+ *   installed that expands the LSP snippet template (see [lspSnippetToTemplate]).
+ * - [additionalTextEdits][CompletionItem.additionalTextEdits] are applied
+ *   alongside the primary insertion via a custom [applyFn] (see the note on
+ *   [serverCompletionSource] — upstream does not currently apply these).
+ *
+ * **Deviations:** `:autocomplete`'s [Completion] has no slot for
+ * `commitCharacters`, so [commitCharacters][CompletionItem.commitCharacters] /
+ * [command][CompletionItem.command] are dropped (and noted) here. The
+ * `documentation` markup kind is also flattened to its raw `value` string
+ * because [Completion.info] is a plain string.
+ *
+ * @param item The LSP completion item to map.
+ * @param doc The document the completion applies to, used to resolve any
+ *   [additionalTextEdits][CompletionItem.additionalTextEdits] ranges.
+ */
+internal fun mapCompletionItem(item: CompletionItem, doc: Text): Completion {
+    val text = item.insertionText()
+    val isSnippet = item.insertTextFormat == InsertTextFormat.SNIPPET
+    val extraEdits = item.additionalTextEdits.orEmpty()
+
+    val type = kindToType(item.kind)
+    val info = documentationText(item.documentation)
+
+    if (isSnippet) {
+        // Snippet: display the item's own label, expand the template on apply.
+        val template = lspSnippetToTemplate(text)
+        val baseApply = snippet(template)
+        val applyFn: (CompletionApplyContext) -> Unit = if (extraEdits.isEmpty()) {
+            baseApply
+        } else {
+            { ctx ->
+                applyAdditionalTextEdits(ctx, doc, extraEdits)
+                baseApply(ctx)
+            }
+        }
+        return Completion(
+            label = item.label,
+            detail = item.detail,
+            info = info,
+            type = type,
+            applyFn = applyFn
+        )
+    }
+
+    // Plain-text completion. The label *is* the inserted text (upstream sets
+    // both label and the implicit apply text to `text`).
+    val applyFn: ((CompletionApplyContext) -> Unit)? = if (extraEdits.isEmpty()) {
+        null
+    } else {
+        { ctx ->
+            applyAdditionalTextEdits(ctx, doc, extraEdits)
+            insertPlainText(ctx, text)
+        }
+    }
+    return Completion(
+        label = text,
+        detail = item.detail,
+        info = info,
+        type = type,
+        applyFn = applyFn
+    )
+}
+
+/** Insert [text] over the completion's replace range (plain, non-snippet path). */
+private fun insertPlainText(ctx: CompletionApplyContext, text: String) {
+    ctx.session.dispatch(
+        TransactionSpec(
+            changes = ChangeSpec.Single(ctx.from, ctx.to, InsertContent.StringContent(text)),
+            selection = SelectionSpec.CursorSpec(ctx.from + text.length),
+            userEvent = "input.complete"
+        )
+    )
+}
+
+/**
+ * Apply an LSP item's [additionalTextEdits] (e.g. an auto-import added at the
+ * top of the file) as a single transaction against the editor session in
+ * [ctx]. Edits are resolved against [doc] with [fromPosition].
+ */
+private fun applyAdditionalTextEdits(
+    ctx: CompletionApplyContext,
+    doc: Text,
+    edits: List<TextEdit>
+) {
+    if (edits.isEmpty()) return
+    val specs = edits.map { edit ->
+        val from = fromPosition(edit.range.start, doc)
+        val to = fromPosition(edit.range.end, doc)
+        ChangeSpec.Single(
+            DocPos(minOf(from, to)),
+            DocPos(maxOf(from, to)),
+            InsertContent.StringContent(edit.newText)
+        )
+    }
+    ctx.session.dispatch(
+        TransactionSpec(
+            changes = ChangeSpec.Multi(specs),
+            userEvent = "input.complete"
+        )
+    )
+}
+
+/**
+ * Build a [Regex] that matches word characters optionally prefixed by any
+ * non-word prefixes found in [items], for use as a result's
+ * [validFor][CompletionResult.validFor].
+ *
+ * Ports upstream `prefixRegexp`: it samples up to ~50 items, collects the
+ * leading non-word run of each sampled insertion text, and produces
+ * `^(?:prefixA|prefixB)?\w*$`. When no non-word prefixes are found it returns
+ * `^\w*$`.
+ */
+internal fun prefixRegexp(items: List<CompletionItem>): Regex {
+    if (items.isEmpty()) return Regex("^\\w*$")
+    val step = ((items.size + 49) / 50).coerceAtLeast(1)
+    val prefixes = mutableListOf<String>()
+    var i = 0
+    while (i < items.size) {
+        val text = items[i].insertionText()
+        val first = text.firstOrNull()
+        if (first != null && !isWordChar(first)) {
+            val prefix = text.takeWhile { !isWordChar(it) }
+            if (prefix !in prefixes) prefixes.add(prefix)
+        }
+        i += step
+    }
+    if (prefixes.isEmpty()) return Regex("^\\w*$")
+    val alts = prefixes.joinToString("|") { escapeRegexLiteral(it) }
+    return Regex("^(?:$alts)?\\w*$")
+}
+
+private fun isWordChar(c: Char): Boolean = c == '_' || c.isLetterOrDigit()
+
+private fun escapeRegexLiteral(s: String): String = buildString {
+    for (c in s) {
+        if (!c.isWhitespace() && !isWordChar(c)) append('\\')
+        append(c)
+    }
+}
+
+/**
+ * Resolve the `[from, to)` range a completion result applies to, following
+ * upstream's `completionResultRange`.
+ *
+ * Preference order: the first item's [textEdit][CompletionItem.textEdit] range,
+ * else the word at the cursor, else an empty range at the cursor. LSP edit
+ * ranges are single-line and contain the cursor, so the range is resolved on the
+ * cursor's line via the start/end `character` offsets (mirroring upstream's
+ * `line.from + range.start.character`).
+ */
+internal fun completionResultRange(
+    context: CompletionContext,
+    items: List<CompletionItem>
+): Pair<DocPos, DocPos> {
+    val pos = context.pos
+    if (items.isEmpty()) return pos to pos
+    val range: Range? = items.firstOrNull()?.textEdit?.range()
+    if (range == null) {
+        val word = context.state.wordAt(pos)
+        return if (word != null) word.from to word.to else pos to pos
+    }
+    val line = context.state.doc.lineAt(pos)
+    val from = line.from + range.start.character.toInt()
+    val to = line.from + range.end.character.toInt()
+    return from to to
+}
+
+private val completionJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+/**
+ * Parse the raw `textDocument/completion` result (which the typed
+ * [LanguageServer][com.monkopedia.lsp.LanguageServer] returns as a
+ * [JsonElement]) into a [CompletionList]. The LSP result is
+ * `CompletionItem[] | CompletionList | null`; arrays are wrapped into a list
+ * with `isIncomplete = false`, and `null`/JSON-null become null.
+ */
+internal fun parseCompletionResult(element: JsonElement?): CompletionList? = when (element) {
+    null, JsonNull -> null
+    is JsonArray -> CompletionList(
+        isIncomplete = false,
+        items = completionJson.decodeFromJsonElement(
+            ListSerializer(CompletionItem.serializer()),
+            element
+        )
+    )
+    is JsonObject -> completionJson.decodeFromJsonElement(CompletionList.serializer(), element)
+    else -> null
+}
+
+/**
+ * The suspend completion source that requests completions from the language
+ * server wrapped by [client] for the file at [uri].
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `serverCompletionSource`:
+ * - If the server has no `completionProvider` capability, returns null.
+ * - For implicit (non-explicit) triggers, only fires when the character before
+ *   the cursor is an identifier char (`[A-Za-z_]`) or one of the server's
+ *   advertised `triggerCharacters`.
+ * - Flushes pending document changes ([LSPClient.sync]) before requesting.
+ * - Requests `textDocument/completion` at the cursor, maps the result via
+ *   [mapCompletionItem], and resolves the apply range via
+ *   [completionResultRange].
+ * - Uses [config]'s `validFor` or, failing that, [prefixRegexp].
+ *
+ * **Cancellation:** there is no explicit `$/cancelRequest`. The autocomplete
+ * machinery cancels the coroutine running this source when the user types
+ * again (the agreed design); the in-flight `textDocumentCompletion` call is
+ * cancelled cooperatively through structured concurrency. (Upstream instead
+ * sends an explicit cancel notification.)
+ *
+ * **`isIncomplete`:** when the server marks the list incomplete, the result is
+ * returned with `validFor = null` so `:autocomplete` re-queries on the next
+ * keystroke instead of filtering the stale list; complete lists get the
+ * `validFor` regex so they can be filtered locally.
+ */
+fun serverCompletionSource(
+    client: LSPClient,
+    uri: String,
+    config: ServerCompletionConfig = ServerCompletionConfig()
+): SuspendCompletionSource = source@{ context ->
+    if (client.serverCapabilities?.completionProvider == null) return@source null
+
+    val doc = context.state.doc
+    if (!context.explicit) {
+        val pos = context.pos.value
+        val triggerChar = if (pos > 0) doc.sliceString(DocPos(pos - 1), DocPos(pos)) else ""
+        val triggers = client.serverCapabilities?.completionProvider?.triggerCharacters
+        val isIdentChar = triggerChar.length == 1 && isWordChar(triggerChar[0])
+        if (!isIdentChar && (triggers == null || triggerChar !in triggers)) return@source null
+    }
+
+    // Flush pending edits so the server completes against current text.
+    client.sync()
+
+    val params = CompletionParams(
+        textDocument = TextDocumentIdentifier(uri = uri),
+        position = toPosition(context.pos.value, doc)
+    )
+    val raw = client.server.textDocumentCompletion(params)
+    val result = parseCompletionResult(raw) ?: return@source null
+
+    val items = result.items
+    val (from, to) = completionResultRange(context, items)
+    val options = items.map { mapCompletionItem(it, doc) }
+    val validFor = if (result.isIncomplete) null else (config.validFor ?: prefixRegexp(items))
+
+    CompletionResult(
+        from = from,
+        to = to,
+        options = options,
+        validFor = validFor
+    )
+}
+
+/**
+ * Register the language-server [completion source][serverCompletionSource] as
+ * the editor's autocompletion source.
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `serverCompletion`. The returned
+ * [Extension] installs `:autocomplete`'s [autocompletion] (configured with the
+ * server source as the [override][CompletionConfig.override] source) plus
+ * [snippets] support so snippet completions can be tab-navigated.
+ *
+ * **Deviation from upstream:** kodemirror's `CompletionContext` does not expose
+ * the editor view/session, so the source cannot look the [LSPPlugin] up from the
+ * context the way upstream does. Instead [client]/[uri] are captured here. As a
+ * consequence the non-`override` upstream path (registering the source as
+ * editor *language data* alongside other sources) is not available — kodemirror
+ * `:autocomplete` only consults [CompletionConfig.override], so this always
+ * installs the source there. [ServerCompletionConfig.override] is accepted for
+ * API parity but does not change behavior; see the follow-up note below.
+ *
+ * @param client The LSP client wrapping the language server.
+ * @param uri The document URI for this editor's file.
+ * @param config Completion configuration. See [ServerCompletionConfig].
+ */
+fun serverCompletion(
+    client: LSPClient,
+    uri: String,
+    config: ServerCompletionConfig = ServerCompletionConfig()
+): Extension {
+    val source: CompletionSource = asyncCompletionSource(
+        serverCompletionSource(client, uri, config)
+    )
+    return ExtensionList(
+        listOf(
+            autocompletion(CompletionConfig(override = listOf(source))),
+            snippets()
+        )
+    )
+}

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletionTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletionTest.kt
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.autocomplete.CompletionContext
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.lsp.CompletionItem
+import com.monkopedia.lsp.CompletionItemKind
+import com.monkopedia.lsp.CompletionItemLabelDetails
+import com.monkopedia.lsp.InsertReplaceEdit
+import com.monkopedia.lsp.InsertTextFormat
+import com.monkopedia.lsp.MarkupContent
+import com.monkopedia.lsp.MarkupKind
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.StringOr
+import com.monkopedia.lsp.TextEdit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServerCompletionTest {
+    private fun doc(vararg lines: String): Text = Text.of(lines.toList())
+
+    private fun completionContext(text: String, pos: Int): CompletionContext =
+        CompletionContext(EditorState.create(text), DocPos(pos), explicit = false)
+
+    // ── kind → type mapping ──
+
+    @Test
+    fun kindMapsToType() {
+        assertEquals("function", kindToType(CompletionItemKind.FUNCTION))
+        assertEquals("method", kindToType(CompletionItemKind.METHOD))
+        assertEquals("class", kindToType(CompletionItemKind.CLASS))
+        assertEquals("class", kindToType(CompletionItemKind.CONSTRUCTOR))
+        assertEquals("class", kindToType(CompletionItemKind.STRUCT))
+        assertEquals("property", kindToType(CompletionItemKind.FIELD))
+        assertEquals("property", kindToType(CompletionItemKind.PROPERTY))
+        assertEquals("variable", kindToType(CompletionItemKind.VARIABLE))
+        assertEquals("interface", kindToType(CompletionItemKind.INTERFACE))
+        assertEquals("namespace", kindToType(CompletionItemKind.MODULE))
+        assertEquals("keyword", kindToType(CompletionItemKind.KEYWORD))
+        assertEquals("keyword", kindToType(CompletionItemKind.UNIT))
+        assertEquals("constant", kindToType(CompletionItemKind.CONSTANT))
+        assertEquals("constant", kindToType(CompletionItemKind.ENUM))
+        assertEquals("constant", kindToType(CompletionItemKind.ENUM_MEMBER))
+        assertEquals("constant", kindToType(CompletionItemKind.VALUE))
+        assertEquals("constant", kindToType(CompletionItemKind.COLOR))
+        assertEquals("type", kindToType(CompletionItemKind.TYPE_PARAMETER))
+        assertEquals("text", kindToType(CompletionItemKind.TEXT))
+    }
+
+    @Test
+    fun unmappedKindsAreNull() {
+        assertNull(kindToType(null))
+        assertNull(kindToType(CompletionItemKind.SNIPPET))
+        assertNull(kindToType(CompletionItemKind.FILE))
+        assertNull(kindToType(CompletionItemKind.FOLDER))
+        assertNull(kindToType(CompletionItemKind.OPERATOR))
+        assertNull(kindToType(CompletionItemKind.EVENT))
+        assertNull(kindToType(CompletionItemKind.REFERENCE))
+    }
+
+    // ── insertion text precedence ──
+
+    @Test
+    fun insertionTextPrefersTextEdit() {
+        val item = CompletionItem(
+            label = "label",
+            insertText = "insert",
+            textEditText = "editText",
+            textEdit = TextEdit(
+                range = Range(Position(0u, 0u), Position(0u, 1u)),
+                newText = "fromEdit"
+            )
+        )
+        assertEquals("fromEdit", item.insertionText())
+    }
+
+    @Test
+    fun insertionTextFallsBackThroughChain() {
+        assertEquals(
+            "editText",
+            CompletionItem(label = "l", insertText = "i", textEditText = "editText").insertionText()
+        )
+        assertEquals(
+            "i",
+            CompletionItem(label = "l", insertText = "i").insertionText()
+        )
+        assertEquals(
+            "l",
+            CompletionItem(label = "l").insertionText()
+        )
+    }
+
+    // ── plain-text completion mapping ──
+
+    @Test
+    fun plainTextMappingUsesInsertionTextAsLabel() {
+        val item = CompletionItem(
+            label = "println",
+            insertText = "println",
+            kind = CompletionItemKind.FUNCTION,
+            detail = "fun println(): Unit",
+            sortText = "0001"
+        )
+        val c = mapCompletionItem(item, doc("x"))
+        assertEquals("println", c.label)
+        assertEquals("function", c.type)
+        assertEquals("fun println(): Unit", c.detail)
+        // Plain text with no extra edits => default apply (no custom applyFn).
+        assertNull(c.applyFn)
+    }
+
+    @Test
+    fun documentationStringBecomesInfo() {
+        val plain = mapCompletionItem(
+            CompletionItem(label = "a", documentation = StringOr.StringValue("hello docs")),
+            doc("x")
+        )
+        assertEquals("hello docs", plain.info)
+
+        val markup = mapCompletionItem(
+            CompletionItem(
+                label = "b",
+                documentation = StringOr.Value(
+                    MarkupContent(kind = MarkupKind.MARKDOWN, value = "# heading")
+                )
+            ),
+            doc("x")
+        )
+        assertEquals("# heading", markup.info)
+
+        val none = mapCompletionItem(CompletionItem(label = "c"), doc("x"))
+        assertNull(none.info)
+    }
+
+    @Test
+    fun emptyDocumentationIsNull() {
+        val c = mapCompletionItem(
+            CompletionItem(label = "a", documentation = StringOr.StringValue("")),
+            doc("x")
+        )
+        assertNull(c.info)
+    }
+
+    // ── snippet completion mapping ──
+
+    @Test
+    fun snippetMappingUsesLabelAndInstallsApplyFn() {
+        val item = CompletionItem(
+            label = "for",
+            insertText = "for (\${1:item} in \${2:items}) {\n\t\$0\n}",
+            insertTextFormat = InsertTextFormat.SNIPPET,
+            kind = CompletionItemKind.SNIPPET
+        )
+        val c = mapCompletionItem(item, doc("x"))
+        // Display label is the item label, not the (expanded) snippet text.
+        assertEquals("for", c.label)
+        assertNotNull(c.applyFn)
+    }
+
+    // ── snippet template translation ──
+
+    @Test
+    fun lspSnippetTranslatesNumberedStops() {
+        assertEquals("\${1}", lspSnippetToTemplate("\$1"))
+        assertEquals("\${0}", lspSnippetToTemplate("\$0"))
+        assertEquals(
+            "foo(\${1}, \${2})",
+            lspSnippetToTemplate("foo(\$1, \$2)")
+        )
+    }
+
+    @Test
+    fun lspSnippetTranslatesPlaceholderStops() {
+        // Placeholder default text is dropped (deviation), only the name kept.
+        assertEquals(
+            "for (\${1} in \${2}) {}",
+            lspSnippetToTemplate("for (\${1:item} in \${2:items}) {}")
+        )
+    }
+
+    @Test
+    fun lspSnippetTranslatesChoiceStops() {
+        assertEquals("\${1}", lspSnippetToTemplate("\${1|a,b,c|}"))
+    }
+
+    @Test
+    fun lspSnippetUnescapesBackslashes() {
+        // \$ should become a literal $, not a tab stop.
+        assertEquals("price: \$5", lspSnippetToTemplate("price: \\\$5"))
+        assertEquals("a}b", lspSnippetToTemplate("a\\}b"))
+    }
+
+    @Test
+    fun lspSnippetLeavesPlainTextUntouched() {
+        assertEquals("println()", lspSnippetToTemplate("println()"))
+    }
+
+    // ── result range resolution ──
+
+    @Test
+    fun resultRangeFromTextEditRange() {
+        // doc "foo bar", cursor after "ba" (offset 6); textEdit covers "bar".
+        val item = CompletionItem(
+            label = "bar",
+            textEdit = TextEdit(
+                range = Range(Position(0u, 4u), Position(0u, 7u)),
+                newText = "bar"
+            )
+        )
+        val ctx = completionContext("foo bar", 6)
+        val (from, to) = completionResultRange(ctx, listOf(item))
+        assertEquals(4, from.value)
+        assertEquals(7, to.value)
+    }
+
+    @Test
+    fun resultRangeFromInsertReplaceEditUsesReplace() {
+        val item = CompletionItem(
+            label = "bar",
+            textEdit = InsertReplaceEdit(
+                newText = "bar",
+                insert = Range(Position(0u, 4u), Position(0u, 6u)),
+                replace = Range(Position(0u, 4u), Position(0u, 7u))
+            )
+        )
+        val ctx = completionContext("foo bar", 6)
+        val (from, to) = completionResultRange(ctx, listOf(item))
+        assertEquals(4, from.value)
+        assertEquals(7, to.value)
+    }
+
+    @Test
+    fun resultRangeFallsBackToWordAtCursor() {
+        val item = CompletionItem(label = "barbecue")
+        // doc "foo bar", cursor inside "bar" at offset 6 -> word [4,7).
+        val ctx = completionContext("foo bar", 6)
+        val (from, to) = completionResultRange(ctx, listOf(item))
+        assertEquals(4, from.value)
+        assertEquals(7, to.value)
+    }
+
+    @Test
+    fun resultRangeEmptyItemsIsCursor() {
+        val ctx = completionContext("foo bar", 6)
+        val (from, to) = completionResultRange(ctx, emptyList())
+        assertEquals(6, from.value)
+        assertEquals(6, to.value)
+    }
+
+    // ── prefix regexp / validFor ──
+
+    @Test
+    fun prefixRegexpWordOnly() {
+        val re = prefixRegexp(listOf(CompletionItem(label = "foo"), CompletionItem(label = "bar")))
+        assertTrue(re.matches("foo"))
+        assertTrue(re.matches(""))
+        assertTrue(!re.matches(".foo"))
+    }
+
+    @Test
+    fun prefixRegexpIncludesNonWordPrefixes() {
+        val re = prefixRegexp(
+            listOf(
+                CompletionItem(label = "@foo"),
+                CompletionItem(label = "bar")
+            )
+        )
+        assertTrue(re.matches("@foo"))
+        assertTrue(re.matches("@"))
+        assertTrue(re.matches("plain"))
+    }
+
+    @Test
+    fun prefixRegexpEmptyItems() {
+        val re = prefixRegexp(emptyList())
+        assertTrue(re.matches("anything123"))
+        assertTrue(!re.matches("has space"))
+    }
+
+    // ── completion list result parsing ──
+
+    @Test
+    fun parseNullResult() {
+        assertNull(parseCompletionResult(null))
+    }
+
+    @Test
+    fun parseArrayResult() {
+        val json = kotlinx.serialization.json.Json.parseToJsonElement(
+            """[{"label":"a"},{"label":"b"}]"""
+        )
+        val list = parseCompletionResult(json)
+        assertNotNull(list)
+        assertEquals(false, list.isIncomplete)
+        assertEquals(2, list.items.size)
+        assertEquals("a", list.items[0].label)
+    }
+
+    @Test
+    fun parseCompletionListResult() {
+        val json = kotlinx.serialization.json.Json.parseToJsonElement(
+            """{"isIncomplete":true,"items":[{"label":"x"}]}"""
+        )
+        val list = parseCompletionResult(json)
+        assertNotNull(list)
+        assertTrue(list.isIncomplete)
+        assertEquals(1, list.items.size)
+    }
+
+    // ── labelDetails carried as detail when item.detail absent ──
+
+    @Test
+    fun detailFromItemDetail() {
+        val c = mapCompletionItem(
+            CompletionItem(
+                label = "foo",
+                detail = "Int",
+                labelDetails = CompletionItemLabelDetails(detail = ": String")
+            ),
+            doc("x")
+        )
+        assertEquals("Int", c.detail)
+    }
+}


### PR DESCRIPTION
## Summary
Fourth sub-issue of the LSP port epic #26. Closes #38. Ports upstream `serverCompletion`/`serverCompletionSource` — server-backed completion via `:autocomplete`. Builds on #36 mapping + #37.

## How it works
- `serverCompletionSource(client, uri, config)` is a `SuspendCompletionSource`; `serverCompletion(...)` wraps it with `asyncCompletionSource` + registers via `autocompletion(CompletionConfig(override=[source]))`, and adds `snippets()`. Folded into `languageServerSupport`.
- Source: skips if no `completionProvider` capability; for implicit triggers requires prior char `[A-Za-z_]` or a server `triggerCharacter`; `client.sync()` then `server.textDocumentCompletion(params at cursor)`; parses `CompletionItem[] | CompletionList | null`; resolves `from/to` from the first item's `textEdit` range else `wordAt` else cursor; `validFor` = config regex or computed `prefixRegexp` (null when `isIncomplete` → re-query). Cancellation is cooperative (next keystroke cancels the suspend call).
- **Mapping fidelity:** insertion precedence `textEdit.newText → textEditText → insertText → label`; `kind→type` (upstream's `kindToType` table); `detail`/`sortText`/`documentation(string|MarkupContent)→info`; `textEdit`(TextEdit range | InsertReplaceEdit.replace)→apply range; `additionalTextEdits` applied via a custom `applyFn`.
- **Snippets:** `:autocomplete` supports `${name}` stops; `insertTextFormat==Snippet` is translated (`lspSnippetToTemplate`): `$1`/`$0`→`${1}`/`${0}`, `${1:def}`/`${1|a,b|}`→`${1}`, backslash-unescape.

## Public API added (tier-2)
- `fun serverCompletion(client, uri, config = ServerCompletionConfig()): Extension`
- `fun serverCompletionSource(client, uri, config = ServerCompletionConfig()): SuspendCompletionSource`
- `data class ServerCompletionConfig(override: Boolean = false, validFor: Regex? = null)`

## Deviations (documented in KDoc — flagging for transparency)
- Snippet **placeholder default text and choice options are dropped** (kodemirror snippets carry no per-field default) — a faithful superset of upstream's own lossy `$N`→`${N}`.
- `commitCharacters` and `command` dropped (no kodemirror `Completion` slots).
- `documentation` markup flattened to its raw `value` (`Completion.info` is `String?`, not a renderer).
- `ServerCompletionConfig.override` accepted for parity but a no-op (kodemirror only consults `CompletionConfig.override`; the source is always installed there).
- `additionalTextEdits` **are** applied here — a deliberate fidelity improvement over upstream's current `serverCompletion`.
- (Minor) `lspSnippetToTemplate` uses first-`}` matching, so deeply-nested placeholders aren't handled — rare in practice; upstream is also lossy here.

## Verification
`:lsp-client:jvmTest` (new mapping tests), `compileKotlinJvm`/`compileKotlinWasmJs`/`compileDebugKotlinAndroid`, `:lsp-client:apiCheck` — all green. `:autocomplete` only added as a dependency (no source changes). spotless/ktlint applied; apiDump committed. Apple/native not cross-compiled on Linux.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :lsp-client:jvmTest :lsp-client:compileKotlinWasmJs :lsp-client:compileDebugKotlinAndroid :lsp-client:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`