### PR TITLE
LSP hover (#39)

### DIFF
--- a/lsp-client/api/android/lsp-client.api
+++ b/lsp-client/api/android/lsp-client.api
@@ -117,6 +117,11 @@ public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerHoverKt {
+	public static final fun serverHover (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;J)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun serverHover$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;JILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+}
+
 public class com/monkopedia/kodemirror/lsp/Workspace {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/kodemirror/lsp/LSPClient;)V

--- a/lsp-client/api/jvm/lsp-client.api
+++ b/lsp-client/api/jvm/lsp-client.api
@@ -117,6 +117,11 @@ public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerHoverKt {
+	public static final fun serverHover (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;J)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun serverHover$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;JILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+}
+
 public class com/monkopedia/kodemirror/lsp/Workspace {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/kodemirror/lsp/LSPClient;)V

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
@@ -48,8 +48,9 @@ fun languageServerSupport(client: LSPClient, uri: String, languageId: String): E
             serverDiagnostics(),
             // Request completions from the server as the editor's autocomplete
             // source — see #38.
-            serverCompletion(client, uri)
-            // TODO(#39): hover tooltips
+            serverCompletion(client, uri),
+            // Show hover information from the server as a tooltip — see #39.
+            serverHover(client, uri)
             // TODO(#40): signature help
             // TODO(#41): go-to-definition
             // TODO(#42): find references

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerHover.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerHover.kt
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import com.monkopedia.kodemirror.state.Extension
+import com.monkopedia.kodemirror.view.LocalEditorTheme
+import com.monkopedia.kodemirror.view.Tooltip
+import com.monkopedia.kodemirror.view.hoverTooltip
+import com.monkopedia.lsp.Hover
+import com.monkopedia.lsp.HoverParams
+import com.monkopedia.lsp.MarkupContent
+import com.monkopedia.lsp.MarkupKind
+import com.monkopedia.lsp.TextDocumentIdentifier
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * A single rendered block of LSP hover content.
+ *
+ * The LSP `Hover.contents` field is a union (`MarkupContent | MarkedString |
+ * MarkedString[] | string`); [parseHoverContents] flattens it into an ordered
+ * list of these blocks for rendering.
+ *
+ * @param text The textual body of the block.
+ * @param language When non-null, the block is a fenced code block tagged with
+ *   this language (a `MarkedString` with a `language`, or a fenced block parsed
+ *   out of markdown). When null, the block is markdown (or plain) prose.
+ * @param markdown Whether [text] should be interpreted as markdown. Plain
+ *   `string`/`PlainText` content sets this false so markdown punctuation is
+ *   shown literally; `MarkupContent` of kind `markdown` sets it true.
+ */
+internal data class HoverBlock(
+    val text: String,
+    val language: String? = null,
+    val markdown: Boolean = false
+)
+
+private val hoverJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+/**
+ * Parse the raw `textDocument/hover` result (which the typed
+ * [LanguageServer][com.monkopedia.lsp.LanguageServer] returns as a [Hover] whose
+ * [contents][Hover.contents] is an untyped [JsonElement]) into an ordered list
+ * of [HoverBlock]s.
+ *
+ * Handles every shape the LSP `Hover.contents` union allows:
+ * - a plain `string` (non-markdown prose),
+ * - a `MarkupContent` object `{kind, value}` (markdown when
+ *   [kind][MarkupContent.kind] is [MARKDOWN][MarkupKind.MARKDOWN]),
+ * - a `MarkedString`, i.e. either a `string` (rendered as a markdown block, per
+ *   the LSP spec) or `{language, value}` (a fenced code block in that language),
+ * - an array of `MarkedString` (each element handled as above).
+ *
+ * Empty/blank blocks are dropped. Returns an empty list when there is nothing to
+ * show (which the caller treats as "no tooltip").
+ */
+internal fun parseHoverContents(contents: JsonElement): List<HoverBlock> = when (contents) {
+    is JsonNull -> emptyList()
+    is JsonPrimitive -> {
+        // Plain `string` form of the union.
+        contents.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+            ?.let { listOf(HoverBlock(text = it, markdown = false)) }
+            ?: emptyList()
+    }
+    is JsonObject -> parseHoverObject(contents)?.let { listOf(it) } ?: emptyList()
+    is JsonArray -> contents.flatMap { element ->
+        when (element) {
+            is JsonPrimitive ->
+                element.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+                    // Per the spec, a bare string inside a MarkedString[] is markdown.
+                    ?.let { listOf(HoverBlock(text = it, markdown = true)) }
+                    ?: emptyList()
+            is JsonObject -> parseHoverObject(element)?.let { listOf(it) } ?: emptyList()
+            else -> emptyList()
+        }
+    }
+}
+
+/**
+ * Parse a single object element of `Hover.contents` — either a
+ * [MarkupContent] (`{kind, value}`) or a `MarkedString` (`{language, value}`).
+ * The two are disambiguated by which key is present (`kind` vs `language`).
+ */
+private fun parseHoverObject(obj: JsonObject): HoverBlock? {
+    val value = (obj["value"] as? JsonPrimitive)?.contentOrNull ?: return null
+    if (value.isBlank()) return null
+    val language = (obj["language"] as? JsonPrimitive)?.contentOrNull
+    if (language != null) {
+        // MarkedString {language, value}: a fenced code block.
+        return HoverBlock(text = value, language = language, markdown = false)
+    }
+    // MarkupContent {kind, value}.
+    val markup = runCatching {
+        hoverJson.decodeFromJsonElement(MarkupContent.serializer(), obj)
+    }.getOrNull()
+    val markdown = markup?.kind == MarkupKind.MARKDOWN
+    return HoverBlock(text = value, markdown = markdown)
+}
+
+/**
+ * Styling knobs for rendering a [HoverBlock] to an [AnnotatedString], so the
+ * pure markdown→annotated-string conversion can be unit-tested without a Compose
+ * runtime (the per-style attributes are resolved by the caller).
+ */
+internal class HoverMarkdownStyles(
+    val bold: SpanStyle = SpanStyle(fontWeight = FontWeight.Bold),
+    val italic: SpanStyle = SpanStyle(fontStyle = FontStyle.Italic),
+    val code: SpanStyle = SpanStyle(fontFamily = FontFamily.Monospace),
+    val heading: SpanStyle = SpanStyle(fontWeight = FontWeight.Bold)
+)
+
+/**
+ * Convert one [block]'s text to an [AnnotatedString].
+ *
+ * **Deviation from upstream (HTML → Compose):** upstream `@codemirror/lsp-client`
+ * renders hover `MarkupContent` to HTML via `docToHTML` and injects it into the
+ * tooltip DOM. kodemirror's editor renders on a Compose canvas with no DOM, so
+ * there is nothing to inject HTML into. Instead this performs a small, dependency
+ * -free markdown→[AnnotatedString] conversion covering the inline/structure
+ * constructs that appear in practice in hover popups:
+ *
+ * - `**bold**` / `__bold__`
+ * - `*italic*` / `_italic_`
+ * - `` `inline code` ``
+ * - `# heading` … `###### heading` (the marker is stripped, the line bolded)
+ * - fenced code blocks delimited by ``` are rendered monospace (the info string
+ *   is dropped)
+ *
+ * A `MarkedString` with a `language` (a [HoverBlock] with non-null
+ * [language][HoverBlock.language]) is always rendered as monospace code with no
+ * markdown interpretation. Non-markdown ([markdown][HoverBlock.markdown] = false)
+ * prose is emitted verbatim. Anything not in the list above (links, lists,
+ * tables, images, raw HTML) is rendered as its literal source text rather than
+ * being interpreted — this is the documented limit of the conversion.
+ */
+internal fun hoverBlockToAnnotatedString(
+    block: HoverBlock,
+    styles: HoverMarkdownStyles = HoverMarkdownStyles()
+): AnnotatedString {
+    if (block.language != null) {
+        // Fenced/typed code block: monospace, no markdown.
+        return buildAnnotatedString {
+            withStyle(styles.code) { append(block.text) }
+        }
+    }
+    if (!block.markdown) {
+        return AnnotatedString(block.text)
+    }
+    return buildAnnotatedString {
+        val lines = block.text.split("\n")
+        var inFence = false
+        var first = true
+        for (line in lines) {
+            val trimmed = line.trimStart()
+            if (trimmed.startsWith("```")) {
+                inFence = !inFence
+                continue
+            }
+            if (!first) append('\n')
+            first = false
+            when {
+                inFence -> withStyle(styles.code) { append(line) }
+                trimmed.startsWith("#") -> {
+                    val heading = trimmed.trimStart('#').trimStart()
+                    withStyle(styles.heading) { appendInlineMarkdown(heading, styles) }
+                }
+                else -> appendInlineMarkdown(line, styles)
+            }
+        }
+    }
+}
+
+/**
+ * Append [text] to the builder, interpreting inline markdown emphasis
+ * (`**`/`__` bold, `*`/`_` italic) and `` ` `` inline code. Unmatched markers
+ * are emitted literally.
+ */
+private fun androidx.compose.ui.text.AnnotatedString.Builder.appendInlineMarkdown(
+    text: String,
+    styles: HoverMarkdownStyles
+) {
+    var i = 0
+    while (i < text.length) {
+        val c = text[i]
+        when {
+            c == '`' -> {
+                val end = text.indexOf('`', i + 1)
+                if (end > i) {
+                    withStyle(styles.code) { append(text.substring(i + 1, end)) }
+                    i = end + 1
+                } else {
+                    append(c)
+                    i++
+                }
+            }
+            (c == '*' || c == '_') && i + 1 < text.length && text[i + 1] == c -> {
+                val marker = "$c$c"
+                val end = text.indexOf(marker, i + 2)
+                if (end > i + 1) {
+                    withStyle(styles.bold) {
+                        appendInlineMarkdown(text.substring(i + 2, end), styles)
+                    }
+                    i = end + 2
+                } else {
+                    append(c)
+                    i++
+                }
+            }
+            c == '*' || c == '_' -> {
+                val end = text.indexOf(c, i + 1)
+                if (end > i) {
+                    withStyle(styles.italic) {
+                        appendInlineMarkdown(text.substring(i + 1, end), styles)
+                    }
+                    i = end + 1
+                } else {
+                    append(c)
+                    i++
+                }
+            }
+            else -> {
+                append(c)
+                i++
+            }
+        }
+    }
+}
+
+/**
+ * The Compose body of an LSP hover tooltip: each parsed [HoverBlock] rendered as
+ * a line of styled text. See [hoverBlockToAnnotatedString] for the conversion and
+ * its documented HTML→Compose deviation.
+ */
+@Composable
+internal fun HoverContent(blocks: List<HoverBlock>) {
+    val theme = LocalEditorTheme.current
+    val baseStyle = TextStyle(color = theme.foreground)
+    Column(modifier = Modifier.padding(2.dp)) {
+        for (block in blocks) {
+            BasicText(
+                text = hoverBlockToAnnotatedString(block),
+                style = baseStyle
+            )
+        }
+    }
+}
+
+/**
+ * Compute the document position the hover tooltip should anchor to, honoring an
+ * LSP [Hover.range] when the server supplies one (and remapping it through any
+ * edits that happened while the request was in flight via [mapping]). When no
+ * range is given the tooltip anchors at the pointer [pos], matching upstream.
+ *
+ * @param hover The server's hover result.
+ * @param pos The document offset the pointer was over when the request fired.
+ * @param prevDoc The document the request was issued against.
+ * @param mapping Live mapping from the request-time document to the current one.
+ */
+internal fun hoverTooltipPos(
+    hover: Hover,
+    pos: Int,
+    prevDoc: com.monkopedia.kodemirror.state.Text,
+    mapping: WorkspaceMapping?
+): Int {
+    val range = hover.range ?: return pos
+    val start = fromPosition(range.start, prevDoc)
+    return mapping?.mapPos(start) ?: start
+}
+
+/**
+ * Build the editor [Extension] that shows LSP hover information from the language
+ * server wrapped by [client] for the file at [uri].
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `hoverTooltips`. On a hover that
+ * rests for [hoverTime] ms it:
+ * 1. checks the server advertises the `hoverProvider` capability (else no-op),
+ * 2. flushes pending edits ([LSPClient.sync]) so the server resolves against the
+ *    current text,
+ * 3. captures a [WorkspaceMapping] so the response range can be remapped if the
+ *    document changes while the request is in flight,
+ * 4. issues `textDocument/hover` at the pointer position,
+ * 5. parses the [contents][Hover.contents] union ([parseHoverContents]) and
+ *    renders it to Compose ([HoverContent]; see its HTML→Compose deviation
+ *    note), anchored at the [Hover.range] start when present.
+ *
+ * The async hover bridge uses `:view`'s suspending
+ * [hoverTooltip][com.monkopedia.kodemirror.view.hoverTooltip] overload, which
+ * debounces by [hoverTime] and cancels an in-flight request when the pointer
+ * moves — matching upstream's hover-delay + cancel-on-move semantics. There is
+ * no explicit `$/cancelRequest`; the in-flight call is cancelled cooperatively
+ * through structured concurrency (consistent with [serverCompletionSource]).
+ *
+ * @param client The LSP client wrapping the language server.
+ * @param uri The document URI for this editor's file.
+ * @param hoverTime Delay, in milliseconds, before a resting pointer triggers the
+ *   request. Defaults to `:view`'s
+ *   [DEFAULT_HOVER_TIME][com.monkopedia.kodemirror.view.DEFAULT_HOVER_TIME].
+ */
+fun serverHover(
+    client: LSPClient,
+    uri: String,
+    hoverTime: Long = com.monkopedia.kodemirror.view.DEFAULT_HOVER_TIME
+): Extension = hoverTooltip(hoverTime) hover@{ session, pos ->
+    if (client.serverCapabilities?.hoverProvider == null) return@hover null
+
+    // Flush pending edits so the server resolves against current text.
+    client.sync()
+
+    val prevDoc = session.state.doc
+    val mapping = client.workspace.getMapping(uri)
+    try {
+        val params = HoverParams(
+            textDocument = TextDocumentIdentifier(uri = uri),
+            position = toPosition(pos, prevDoc)
+        )
+        val hover = try {
+            client.server.textDocumentHover(params)
+        } catch (e: CancellationException) {
+            throw e
+        }
+        val blocks = parseHoverContents(hover.contents)
+        if (blocks.isEmpty()) return@hover null
+        val anchor = hoverTooltipPos(hover, pos, prevDoc, mapping)
+        Tooltip(pos = anchor, content = { HoverContent(blocks) })
+    } finally {
+        mapping?.let { client.workspace.releaseMapping(it) }
+    }
+}

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerHoverTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerHoverTest.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.lsp.Hover
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+class ServerHoverTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun element(raw: String): JsonElement = json.parseToJsonElement(raw)
+
+    // --- parseHoverContents: union shapes ---
+
+    @Test
+    fun parsesPlainString() {
+        val blocks = parseHoverContents(element("\"hello world\""))
+        assertEquals(1, blocks.size)
+        assertEquals("hello world", blocks[0].text)
+        assertFalse(blocks[0].markdown)
+        assertNull(blocks[0].language)
+    }
+
+    @Test
+    fun parsesMarkupContentMarkdown() {
+        val blocks = parseHoverContents(
+            element("""{"kind":"markdown","value":"**bold** text"}""")
+        )
+        assertEquals(1, blocks.size)
+        assertEquals("**bold** text", blocks[0].text)
+        assertTrue(blocks[0].markdown)
+        assertNull(blocks[0].language)
+    }
+
+    @Test
+    fun parsesMarkupContentPlainText() {
+        val blocks = parseHoverContents(
+            element("""{"kind":"plaintext","value":"*not* bold"}""")
+        )
+        assertEquals(1, blocks.size)
+        assertFalse(blocks[0].markdown)
+    }
+
+    @Test
+    fun parsesMarkedStringObject() {
+        val blocks = parseHoverContents(
+            element("""{"language":"kotlin","value":"fun foo()"}""")
+        )
+        assertEquals(1, blocks.size)
+        assertEquals("fun foo()", blocks[0].text)
+        assertEquals("kotlin", blocks[0].language)
+        assertFalse(blocks[0].markdown)
+    }
+
+    @Test
+    fun parsesMarkedStringArray() {
+        val blocks = parseHoverContents(
+            element(
+                """[{"language":"kotlin","value":"fun foo()"},"some *markdown*"]"""
+            )
+        )
+        assertEquals(2, blocks.size)
+        assertEquals("kotlin", blocks[0].language)
+        assertEquals("some *markdown*", blocks[1].text)
+        // Bare string inside a MarkedString[] is markdown per the spec.
+        assertTrue(blocks[1].markdown)
+    }
+
+    @Test
+    fun dropsBlankAndNullBlocks() {
+        assertTrue(parseHoverContents(element("\"   \"")).isEmpty())
+        assertTrue(parseHoverContents(element("null")).isEmpty())
+        assertTrue(parseHoverContents(element("[]")).isEmpty())
+        val blocks = parseHoverContents(
+            element("""[{"language":"kotlin","value":"x"},"  "]""")
+        )
+        assertEquals(1, blocks.size)
+    }
+
+    // --- hoverBlockToAnnotatedString: markdown -> AnnotatedString ---
+
+    private val styles = HoverMarkdownStyles()
+
+    @Test
+    fun plainTextIsVerbatim() {
+        val out = hoverBlockToAnnotatedString(HoverBlock("**not** bold", markdown = false))
+        assertEquals("**not** bold", out.text)
+        assertTrue(out.spanStyles.isEmpty())
+    }
+
+    @Test
+    fun languageBlockIsMonospace() {
+        val out = hoverBlockToAnnotatedString(
+            HoverBlock("fun foo()", language = "kotlin")
+        )
+        assertEquals("fun foo()", out.text)
+        assertEquals(1, out.spanStyles.size)
+        assertEquals(FontFamily.Monospace, out.spanStyles[0].item.fontFamily)
+    }
+
+    @Test
+    fun boldIsStripped() {
+        val out = hoverBlockToAnnotatedString(HoverBlock("a **b** c", markdown = true))
+        assertEquals("a b c", out.text)
+        val bold = out.spanStyles.first { it.item.fontWeight == FontWeight.Bold }
+        assertEquals(2, bold.start)
+        assertEquals(3, bold.end)
+    }
+
+    @Test
+    fun italicIsStripped() {
+        val out = hoverBlockToAnnotatedString(HoverBlock("a *b* c", markdown = true))
+        assertEquals("a b c", out.text)
+        assertTrue(out.spanStyles.any { it.item.fontStyle == FontStyle.Italic })
+    }
+
+    @Test
+    fun inlineCodeIsStripped() {
+        val out = hoverBlockToAnnotatedString(HoverBlock("call `foo()` now", markdown = true))
+        assertEquals("call foo() now", out.text)
+        assertTrue(out.spanStyles.any { it.item.fontFamily == FontFamily.Monospace })
+    }
+
+    @Test
+    fun headingMarkerIsStripped() {
+        val out = hoverBlockToAnnotatedString(HoverBlock("## Title", markdown = true))
+        assertEquals("Title", out.text)
+        assertTrue(out.spanStyles.any { it.item.fontWeight == FontWeight.Bold })
+    }
+
+    @Test
+    fun fencedCodeBlockIsMonospaceWithoutFences() {
+        val src = "before\n```kotlin\nval x = 1\n```\nafter"
+        val out = hoverBlockToAnnotatedString(HoverBlock(src, markdown = true))
+        assertEquals("before\nval x = 1\nafter", out.text)
+        assertTrue(out.spanStyles.any { it.item.fontFamily == FontFamily.Monospace })
+    }
+
+    @Test
+    fun unmatchedMarkerIsLiteral() {
+        val out = hoverBlockToAnnotatedString(HoverBlock("a * b", markdown = true))
+        assertEquals("a * b", out.text)
+        assertTrue(out.spanStyles.isEmpty())
+    }
+
+    @Test
+    fun customStylesAreApplied() {
+        val custom = HoverMarkdownStyles(bold = SpanStyle(fontWeight = FontWeight.Black))
+        val out = hoverBlockToAnnotatedString(HoverBlock("**x**", markdown = true), custom)
+        assertEquals("x", out.text)
+        assertEquals(FontWeight.Black, out.spanStyles[0].item.fontWeight)
+    }
+
+    // --- hoverTooltipPos: range honoring + remapping ---
+
+    private fun doc(text: String): Text = Text.of(text.split("\n"))
+
+    @Test
+    fun usesPointerPosWhenNoRange() {
+        val d = doc("line one\nline two")
+        val hover = Hover(contents = json.parseToJsonElement("\"x\""), range = null)
+        assertEquals(5, hoverTooltipPos(hover, 5, d, null))
+    }
+
+    @Test
+    fun usesRangeStartWhenPresent() {
+        val d = doc("line one\nline two")
+        // Range starts at line 1 (0-based), char 0 -> offset 9.
+        val hover = Hover(
+            contents = json.parseToJsonElement("\"x\""),
+            range = Range(
+                start = Position(line = 1u, character = 0u),
+                end = Position(line = 1u, character = 4u)
+            )
+        )
+        assertEquals(9, hoverTooltipPos(hover, 12, d, null))
+    }
+}

--- a/view/api/android/view.api
+++ b/view/api/android/view.api
@@ -765,12 +765,14 @@ public final class com/monkopedia/kodemirror/view/Tooltip {
 }
 
 public final class com/monkopedia/kodemirror/view/TooltipKt {
+	public static final field DEFAULT_HOVER_TIME J
 	public static final fun TooltipLayer (Lcom/monkopedia/kodemirror/view/EditorSession;Landroidx/compose/runtime/Composer;I)V
 	public static final fun closeHoverTooltips (Lcom/monkopedia/kodemirror/view/EditorSession;)V
 	public static final fun getShowTooltip ()Lcom/monkopedia/kodemirror/state/Facet;
 	public static final fun getShowTooltips ()Lcom/monkopedia/kodemirror/state/Facet;
 	public static final fun getTooltips (Lcom/monkopedia/kodemirror/view/EditorSession;)Ljava/util/List;
 	public static final fun hasHoverTooltips (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun hoverTooltip (JLkotlin/jvm/functions/Function3;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static final fun hoverTooltip (Lkotlin/jvm/functions/Function2;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static final fun repositionTooltips (Lcom/monkopedia/kodemirror/view/EditorSession;)V
 }

--- a/view/api/jvm/view.api
+++ b/view/api/jvm/view.api
@@ -765,12 +765,14 @@ public final class com/monkopedia/kodemirror/view/Tooltip {
 }
 
 public final class com/monkopedia/kodemirror/view/TooltipKt {
+	public static final field DEFAULT_HOVER_TIME J
 	public static final fun TooltipLayer (Lcom/monkopedia/kodemirror/view/EditorSession;Landroidx/compose/runtime/Composer;I)V
 	public static final fun closeHoverTooltips (Lcom/monkopedia/kodemirror/view/EditorSession;)V
 	public static final fun getShowTooltip ()Lcom/monkopedia/kodemirror/state/Facet;
 	public static final fun getShowTooltips ()Lcom/monkopedia/kodemirror/state/Facet;
 	public static final fun getTooltips (Lcom/monkopedia/kodemirror/view/EditorSession;)Ljava/util/List;
 	public static final fun hasHoverTooltips (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun hoverTooltip (JLkotlin/jvm/functions/Function3;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static final fun hoverTooltip (Lkotlin/jvm/functions/Function2;)Lcom/monkopedia/kodemirror/state/Extension;
 	public static final fun repositionTooltips (Lcom/monkopedia/kodemirror/view/EditorSession;)V
 }

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/Tooltip.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/Tooltip.kt
@@ -31,6 +31,11 @@ import androidx.compose.ui.window.Popup
 import com.monkopedia.kodemirror.state.Extension
 import com.monkopedia.kodemirror.state.Facet
 import com.monkopedia.kodemirror.state.RangeSet
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Describes a tooltip to show near a document position.
@@ -114,7 +119,53 @@ fun TooltipLayer(session: EditorSession) {
  */
 fun hoverTooltip(source: (EditorSession, Int) -> Tooltip?): Extension {
     return ViewPlugin.define(
-        create = { session -> HoverTooltipPlugin(session, source) },
+        create = { session -> HoverTooltipPlugin(session, syncSource = source) },
+        configure = {
+            copy(
+                decorations = { _ -> RangeSet.empty() }
+            )
+        }
+    ).asExtension()
+}
+
+/**
+ * Default hover delay, in milliseconds, used by the async [hoverTooltip]
+ * overload. Mirrors upstream CodeMirror's `hoverTime` default.
+ */
+const val DEFAULT_HOVER_TIME: Long = 300
+
+/**
+ * Show a hover tooltip computed by a **suspending** [source].
+ *
+ * This is the asynchronous counterpart to the synchronous [hoverTooltip]: where
+ * the synchronous overload demands a tooltip be produced immediately, this one
+ * lets [source] suspend — for example to issue a network/IPC request such as an
+ * LSP `textDocument/hover` — before returning a [Tooltip] (or null for "no
+ * tooltip here").
+ *
+ * Upstream CodeMirror's hover source is promise-based (`(view, pos, side) =>
+ * Tooltip | Promise<Tooltip | null> | null`); kodemirror's
+ * [synchronous overload][hoverTooltip] cannot express that, so this overload is
+ * the Kotlin/coroutine adaptation of upstream's async hover path.
+ *
+ * Behavior matches upstream's hover machinery:
+ * - The request is debounced by [hoverTime] (the pointer must rest for that long
+ *   before [source] is invoked).
+ * - Moving to a different position cancels any in-flight request, so a slow
+ *   server response for an abandoned position never pops a stale tooltip.
+ *
+ * @param hoverTime Delay before [source] is invoked, in milliseconds. Pass
+ *   [DEFAULT_HOVER_TIME] for upstream's default; an explicit value is required
+ *   so a bare trailing lambda is not ambiguous with the synchronous
+ *   [hoverTooltip] overload.
+ * @param source Suspending function returning a tooltip for the position, or
+ *               null.
+ */
+fun hoverTooltip(hoverTime: Long, source: suspend (EditorSession, Int) -> Tooltip?): Extension {
+    return ViewPlugin.define(
+        create = { session ->
+            HoverTooltipPlugin(session, asyncSource = source, hoverTime = hoverTime)
+        },
         configure = {
             copy(
                 decorations = { _ -> RangeSet.empty() }
@@ -168,9 +219,22 @@ fun repositionTooltips(session: EditorSession) {
 
 internal class HoverTooltipPlugin(
     private val session: EditorSession,
-    private val source: (EditorSession, Int) -> Tooltip?
+    private val syncSource: ((EditorSession, Int) -> Tooltip?)? = null,
+    private val asyncSource: (suspend (EditorSession, Int) -> Tooltip?)? = null,
+    private val hoverTime: Long = DEFAULT_HOVER_TIME
 ) : PluginValue {
     private val _currentTooltip = mutableStateOf<Tooltip?>(null)
+
+    /** Lifecycle scope for in-flight async hover requests. */
+    private val job = SupervisorJob(session.coroutineScope.coroutineContext[Job])
+    private val scope: CoroutineScope =
+        CoroutineScope(session.coroutineScope.coroutineContext + job)
+
+    /** The most recent in-flight async hover request, cancelled on move. */
+    private var pending: Job? = null
+
+    /** The position the current/pending tooltip is anchored at. */
+    private var lastPos: Int? = null
 
     val currentTooltip: Tooltip? get() = _currentTooltip.value
 
@@ -180,10 +244,39 @@ internal class HoverTooltipPlugin(
     }
 
     fun updateHoverAtPos(docPos: Int?) {
-        _currentTooltip.value = if (docPos != null) source(session, docPos) else null
+        if (docPos == lastPos) return
+        lastPos = docPos
+        // Any move cancels an outstanding async request so a late response for
+        // an abandoned position can't pop a stale tooltip (matches upstream).
+        pending?.cancel()
+        pending = null
+
+        val async = asyncSource
+        if (async != null) {
+            // Clear immediately, then debounce by [hoverTime] before requesting.
+            _currentTooltip.value = null
+            if (docPos == null) return
+            pending = scope.launch {
+                delay(hoverTime)
+                val result = async(session, docPos)
+                // Only show if the pointer is still resting on this position.
+                if (lastPos == docPos) _currentTooltip.value = result
+            }
+        } else {
+            val sync = syncSource
+            _currentTooltip.value =
+                if (docPos != null && sync != null) sync(session, docPos) else null
+        }
     }
 
     fun clearHover() {
+        pending?.cancel()
+        pending = null
+        lastPos = null
         _currentTooltip.value = null
+    }
+
+    override fun destroy() {
+        job.cancel()
     }
 }


### PR DESCRIPTION
## Summary
Fifth sub-issue of the LSP port epic #26. Closes #39. Ports upstream `hoverTooltips` — `textDocument/hover` rendered as a Compose tooltip. Builds on #36 mapping.

## Touches two modules (public API → tier-2)
**`:view`** (additive, regression-checked):
- `const val DEFAULT_HOVER_TIME: Long = 300`
- `fun hoverTooltip(hoverTime: Long, source: suspend (EditorSession, Int) -> Tooltip?): Extension` — async counterpart to the existing synchronous `hoverTooltip(source)`. The sync overload (used by `:lint`) is unchanged; `HoverTooltipPlugin` now branches sync-vs-async. The async overload requires an explicit `hoverTime` to avoid trailing-lambda overload ambiguity with the sync one. Debounced by `hoverTime`; in-flight request cancelled on move, with a position re-check so a slow response can't pop a stale tooltip. This is the Kotlin/coroutine adaptation of CM6's promise-based hover.

**`:lsp-client`**:
- `fun serverHover(client: LSPClient, uri: String, hoverTime: Long = DEFAULT_HOVER_TIME): Extension` — folded into `languageServerSupport`. Sends `textDocument/hover` (via `toPosition`, after `client.sync()`); honors `Hover.range` for placement and remaps the response range through a `WorkspaceMapping` (released in `finally`); falls back to pointer pos when no range.

## Rendering deviation (documented)
Upstream renders `MarkupContent` to **HTML** via `docToHTML`; the Compose canvas has no DOM. `parseHoverContents` handles the full `contents` union (plain string, `MarkupContent{kind,value}`, `MarkedString` string/`{language,value}`, arrays) → ordered `HoverBlock`s; `hoverBlockToAnnotatedString` does a small dependency-free **markdown→AnnotatedString** conversion (bold/italic/inline code/headings/fenced code; MarkedString language blocks → monospace; unsupported constructs like links/lists/tables fall through as literal text). Documented as the necessary HTML→Compose deviation.

## Verification
- `:lsp-client:jvmTest` (16 union-parse + markdown-convert tests), `compileKotlinJvm`/`compileKotlinWasmJs`/`compileDebugKotlinAndroid`, `:lsp-client:apiCheck` — green.
- **`:view:jvmTest` + `:view:apiCheck` green** (re-verified — the sync hover path that `:lint` uses is unchanged). spotless/ktlint applied to both modules; apiDump committed for both.
- Apple/native not cross-compiled on Linux (commonMain-only).

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :lsp-client:jvmTest :view:jvmTest :lsp-client:compileKotlinWasmJs :lsp-client:compileDebugKotlinAndroid :lsp-client:apiCheck :view:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`