### PR TITLE
LSP signature help (#40)

### DIFF
--- a/lsp-client/api/android/lsp-client.api
+++ b/lsp-client/api/android/lsp-client.api
@@ -122,6 +122,29 @@ public final class com/monkopedia/kodemirror/lsp/ServerHoverKt {
 	public static synthetic fun serverHover$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;JILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerSignatureHelpKt {
+	public static final fun getSignatureKeymap ()Ljava/util/List;
+	public static final fun nextSignature (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun prevSignature (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun showSignatureHelp (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun signatureHelp (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun signatureHelp$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+}
+
+public final class com/monkopedia/kodemirror/lsp/SignatureHelpConfig {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeymap ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public class com/monkopedia/kodemirror/lsp/Workspace {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/kodemirror/lsp/LSPClient;)V

--- a/lsp-client/api/jvm/lsp-client.api
+++ b/lsp-client/api/jvm/lsp-client.api
@@ -122,6 +122,29 @@ public final class com/monkopedia/kodemirror/lsp/ServerHoverKt {
 	public static synthetic fun serverHover$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;JILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerSignatureHelpKt {
+	public static final fun getSignatureKeymap ()Ljava/util/List;
+	public static final fun nextSignature (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun prevSignature (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun showSignatureHelp (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun signatureHelp (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun signatureHelp$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+}
+
+public final class com/monkopedia/kodemirror/lsp/SignatureHelpConfig {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/SignatureHelpConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeymap ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public class com/monkopedia/kodemirror/lsp/Workspace {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/kodemirror/lsp/LSPClient;)V

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
@@ -50,8 +50,10 @@ fun languageServerSupport(client: LSPClient, uri: String, languageId: String): E
             // source — see #38.
             serverCompletion(client, uri),
             // Show hover information from the server as a tooltip — see #39.
-            serverHover(client, uri)
-            // TODO(#40): signature help
+            serverHover(client, uri),
+            // Show signature help (parameter hints) as a tooltip on trigger
+            // characters or explicit invocation — see #40.
+            signatureHelp(client, uri)
             // TODO(#41): go-to-definition
             // TODO(#42): find references
             // TODO(#43): rename

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerHover.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerHover.kt
@@ -40,6 +40,7 @@ import com.monkopedia.lsp.Hover
 import com.monkopedia.lsp.HoverParams
 import com.monkopedia.lsp.MarkupContent
 import com.monkopedia.lsp.MarkupKind
+import com.monkopedia.lsp.StringOr
 import com.monkopedia.lsp.TextDocumentIdentifier
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
@@ -137,6 +138,37 @@ private fun parseHoverObject(obj: JsonObject): HoverBlock? {
     val markdown = markup?.kind == MarkupKind.MARKDOWN
     return HoverBlock(text = value, markdown = markdown)
 }
+
+/**
+ * Convert a typed LSP `string | MarkupContent` documentation value (as carried
+ * by [SignatureInformation][com.monkopedia.lsp.SignatureInformation] and
+ * [ParameterInformation][com.monkopedia.lsp.ParameterInformation]) into the same
+ * ordered list of [HoverBlock]s used to render hover popups, so the shared
+ * markdown→Compose conversion ([hoverBlockToAnnotatedString]/[HoverContent]) can
+ * be reused for signature-help documentation.
+ *
+ * A plain `string` is rendered as non-markdown prose; a `MarkupContent` is
+ * rendered as markdown only when its [kind][MarkupContent.kind] is
+ * [MARKDOWN][MarkupKind.MARKDOWN]. Blank values yield an empty list.
+ */
+internal fun documentationBlocks(documentation: StringOr<MarkupContent>?): List<HoverBlock> =
+    when (documentation) {
+        null -> emptyList()
+        is StringOr.StringValue ->
+            documentation.value
+                .takeIf { it.isNotBlank() }
+                ?.let { listOf(HoverBlock(text = it, markdown = false)) }
+                ?: emptyList()
+        is StringOr.Value -> {
+            val markup = documentation.value
+            markup.value
+                .takeIf { it.isNotBlank() }
+                ?.let {
+                    listOf(HoverBlock(text = it, markdown = markup.kind == MarkupKind.MARKDOWN))
+                }
+                ?: emptyList()
+        }
+    }
 
 /**
  * Styling knobs for rendering a [HoverBlock] to an [AnnotatedString], so the

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelp.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelp.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import com.monkopedia.kodemirror.state.DocPos
 import com.monkopedia.kodemirror.state.Extension
 import com.monkopedia.kodemirror.state.ExtensionList
+import com.monkopedia.kodemirror.state.Facet
 import com.monkopedia.kodemirror.state.Prec
 import com.monkopedia.kodemirror.state.StateEffect
 import com.monkopedia.kodemirror.state.StateEffectType
@@ -77,6 +78,28 @@ import kotlinx.serialization.json.intOrNull
 data class SignatureHelpConfig(
     val keymap: Boolean = true
 )
+
+/**
+ * The per-editor signature-help server binding: the [client] wrapping the
+ * language server and the document [uri] for this editor's file.
+ *
+ * Carried through state by [signatureHelpServer] so the single, shared
+ * [signatureHelpPlugin] can read its configuration from the editor it is
+ * running in rather than capturing it at install time. This is what keeps
+ * signature help per-editor when multiple editors are open.
+ */
+internal data class SignatureHelpServer(val client: LSPClient, val uri: String)
+
+/**
+ * The [Facet] carrying the per-editor [SignatureHelpServer] binding.
+ *
+ * Combines to the last non-null value, so an editor that installs
+ * [signatureHelp] gets its own [client][SignatureHelpServer.client] /
+ * [uri][SignatureHelpServer.uri] while editors without it see null (and the
+ * shared [signatureHelpPlugin] no-ops).
+ */
+internal val signatureHelpServer: Facet<SignatureHelpServer?, SignatureHelpServer?> =
+    Facet.define(combine = { values -> values.lastOrNull { it != null } })
 
 /**
  * The inclusive-start / exclusive-end offsets into a signature label that
@@ -261,8 +284,14 @@ internal fun signatureLabel(label: String, range: ActiveParamRange?) = buildAnno
 
 /**
  * The [ViewPlugin] that drives signature help for a single editor, requesting
- * `textDocument/signatureHelp` from the language server wrapped by [client] for
- * the file at [uri] and dispatching [signatureEffect]s into [signatureState].
+ * `textDocument/signatureHelp` from the language server and dispatching
+ * [signatureEffect]s into [signatureState].
+ *
+ * The plugin reads its per-editor [SignatureHelpServer] binding (client + uri)
+ * from the [signatureHelpServer] facet of the session it is running in, so a
+ * single shared [signatureHelpPlugin] handle works correctly for every open
+ * editor. When no binding is present (the facet is null) every operation is a
+ * no-op.
  *
  * Ports upstream `@codemirror/lsp-client`'s `signaturePlugin`:
  * - On an `input.type` transaction that inserts a server
@@ -280,9 +309,7 @@ internal fun signatureLabel(label: String, range: ActiveParamRange?) = buildAnno
  * [serverHover]/[serverCompletionSource].
  */
 internal class SignatureHelpPlugin(
-    private val session: EditorSession,
-    private val client: LSPClient,
-    private val uri: String
+    private val session: EditorSession
 ) : PluginValue {
     private val job = SupervisorJob(session.coroutineScope.coroutineContext[Job])
     private val scope: CoroutineScope =
@@ -294,7 +321,12 @@ internal class SignatureHelpPlugin(
     /** The most recent debounced re-trigger job, cancelled when superseded. */
     private var delayed: Job? = null
 
+    /** This editor's signature-help binding, or null when none is installed. */
+    private val server: SignatureHelpServer?
+        get() = session.state.facet(signatureHelpServer)
+
     override fun update(update: ViewUpdate) {
+        val client = update.state.facet(signatureHelpServer)?.client ?: return
         val sigState = update.state.field(signatureState)
 
         var triggerCharacter: String? = null
@@ -378,14 +410,17 @@ internal class SignatureHelpPlugin(
 
     /**
      * Request `textDocument/signatureHelp` at [pos] with [context], or null when
-     * the server has no `signatureHelpProvider` capability. Rethrows
-     * [CancellationException] so cancellation propagates cooperatively.
+     * this editor has no [signatureHelpServer] binding or the server has no
+     * `signatureHelpProvider` capability. Rethrows [CancellationException] so
+     * cancellation propagates cooperatively.
      */
     private suspend fun getSignatureHelp(pos: Int, context: SignatureHelpContext): SignatureHelp? {
+        val binding = server ?: return null
+        val client = binding.client
         if (client.serverCapabilities?.signatureHelpProvider == null) return null
         client.sync()
         val params = SignatureHelpParams(
-            textDocument = TextDocumentIdentifier(uri = uri),
+            textDocument = TextDocumentIdentifier(uri = binding.uri),
             position = toPosition(pos, session.state.doc),
             context = context
         )
@@ -415,31 +450,27 @@ internal class SignatureHelpPlugin(
 }
 
 /**
- * Build the [ViewPlugin] descriptor for the [SignatureHelpPlugin], capturing
- * [client]/[uri]. Held in a single field so [showSignatureHelp] and the cycling
- * commands can locate the active plugin via [EditorSession.plugin].
+ * The single, shared [ViewPlugin] handle for signature help.
+ *
+ * Defined once at module scope and installed by every [signatureHelp] call. The
+ * plugin captures no client/uri — each instance reads its per-editor binding
+ * from the [signatureHelpServer] facet of the session it is created for. Because
+ * the handle is shared and stateless across editors, [showSignatureHelp]
+ * resolves the correct per-editor plugin via [EditorSession.plugin] for every
+ * open editor (no module-level mutable state to clobber).
  */
-private fun signaturePlugin(client: LSPClient, uri: String): ViewPlugin<SignatureHelpPlugin> =
-    ViewPlugin.define(create = { session -> SignatureHelpPlugin(session, client, uri) })
-
-/**
- * The [ViewPlugin] handle for the most recently installed [signatureHelp]
- * extension, so the module-level [showSignatureHelp] command can find the
- * plugin. Mirrors upstream's module-level `signaturePlugin`; a single
- * signature-help configuration per editor is supported (as upstream).
- */
-private var activeSignaturePlugin: ViewPlugin<SignatureHelpPlugin>? = null
+private val signatureHelpPlugin: ViewPlugin<SignatureHelpPlugin> =
+    ViewPlugin.define(create = { session -> SignatureHelpPlugin(session) })
 
 /**
  * Explicitly prompt the server to provide signature help at the cursor.
  *
  * Ports upstream `@codemirror/lsp-client`'s `showSignatureHelp` command: fires an
- * `Invoked` request through the active [SignatureHelpPlugin]. Returns false when
- * no signature-help extension is installed.
+ * `Invoked` request through this editor's [SignatureHelpPlugin]. Returns false
+ * when no signature-help extension is installed in [session].
  */
 fun showSignatureHelp(session: EditorSession): Boolean {
-    val handle = activeSignaturePlugin ?: return false
-    val plugin = session.plugin(handle) ?: return false
+    val plugin = session.plugin(signatureHelpPlugin) ?: return false
     val field = session.state.field(signatureState)
     plugin.startRequest(
         SignatureHelpContext(
@@ -517,11 +548,10 @@ fun signatureHelp(
     uri: String,
     config: SignatureHelpConfig = SignatureHelpConfig()
 ): Extension {
-    val plugin = signaturePlugin(client, uri)
-    activeSignaturePlugin = plugin
     val extensions = buildList {
+        add(signatureHelpServer.of(SignatureHelpServer(client, uri)))
+        add(signatureHelpPlugin.asExtension())
         add(signatureState)
-        add(plugin.asExtension())
         if (config.keymap) add(Prec.high(keymap.of(signatureKeymap)))
     }
     return ExtensionList(extensions)

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelp.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelp.kt
@@ -1,0 +1,528 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.Extension
+import com.monkopedia.kodemirror.state.ExtensionList
+import com.monkopedia.kodemirror.state.Prec
+import com.monkopedia.kodemirror.state.StateEffect
+import com.monkopedia.kodemirror.state.StateEffectType
+import com.monkopedia.kodemirror.state.StateField
+import com.monkopedia.kodemirror.state.TransactionSpec
+import com.monkopedia.kodemirror.state.define
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.kodemirror.view.KeyBinding
+import com.monkopedia.kodemirror.view.LocalEditorTheme
+import com.monkopedia.kodemirror.view.PluginValue
+import com.monkopedia.kodemirror.view.Tooltip
+import com.monkopedia.kodemirror.view.ViewPlugin
+import com.monkopedia.kodemirror.view.ViewUpdate
+import com.monkopedia.kodemirror.view.keymap
+import com.monkopedia.kodemirror.view.showTooltip
+import com.monkopedia.lsp.SignatureHelp
+import com.monkopedia.lsp.SignatureHelpContext
+import com.monkopedia.lsp.SignatureHelpParams
+import com.monkopedia.lsp.SignatureHelpTriggerKind
+import com.monkopedia.lsp.SignatureInformation
+import com.monkopedia.lsp.TextDocumentIdentifier
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+
+/**
+ * Configuration for [signatureHelp].
+ *
+ * Mirrors the shape of the options object upstream `@codemirror/lsp-client`'s
+ * `signatureHelp` accepts.
+ *
+ * @param keymap When true (the default), the [signatureKeymap] default bindings
+ *   are installed at high precedence. Pass false to bind the
+ *   [showSignatureHelp]/[nextSignature]/[prevSignature] commands yourself.
+ */
+data class SignatureHelpConfig(
+    val keymap: Boolean = true
+)
+
+/**
+ * The inclusive-start / exclusive-end offsets into a signature label that
+ * delimit the active parameter, or null when there is no active parameter to
+ * highlight.
+ */
+internal data class ActiveParamRange(val from: Int, val to: Int)
+
+/**
+ * Resolve the `[from, to)` slice of [signature]'s [label][SignatureInformation.label]
+ * that the active parameter occupies, given the help-level
+ * [activeParameter][SignatureHelp.activeParameter].
+ *
+ * Ports upstream `@codemirror/lsp-client`'s active-parameter computation in
+ * `drawSignatureTooltip`:
+ * - the active parameter index is the signature's own
+ *   [activeParameter][SignatureInformation.activeParameter] when present, else
+ *   the help-level [activeParameter][SignatureHelp.activeParameter];
+ * - the parameter's [label][com.monkopedia.lsp.ParameterInformation.label] is
+ *   either an `[start, end]` offset pair into the signature label (returned
+ *   as-is) or a string that is located as a substring of the signature label;
+ * - returns null when there is no parameter list, the index is out of range, or
+ *   the string label can't be found in the signature label.
+ */
+internal fun activeParamRange(
+    signature: SignatureInformation,
+    helpActiveParameter: UInt?
+): ActiveParamRange? {
+    val params = signature.parameters ?: return null
+    val index = (signature.activeParameter ?: helpActiveParameter)?.toInt() ?: return null
+    val param = params.getOrNull(index) ?: return null
+    val label = param.label
+    if (label is JsonArray && label.size == 2) {
+        val from = (label[0] as? JsonPrimitive)?.intOrNull
+        val to = (label[1] as? JsonPrimitive)?.intOrNull
+        if (from != null && to != null) return ActiveParamRange(from, to)
+        return null
+    }
+    val str = (label as? JsonPrimitive)?.contentOrNull ?: return null
+    val found = signature.label.indexOf(str)
+    if (found < 0) return null
+    return ActiveParamRange(found, found + str.length)
+}
+
+/**
+ * Whether two [SignatureHelp] results describe the same set of signatures.
+ *
+ * Ports upstream's `sameSignatures`: the lists must be the same length and have
+ * pairwise-equal [labels][SignatureInformation.label]. Used to decide whether a
+ * fresh response should keep the existing tooltip position and active index.
+ */
+internal fun sameSignatures(a: SignatureHelp, b: SignatureHelp): Boolean {
+    if (a.signatures.size != b.signatures.size) return false
+    return a.signatures.indices.all { a.signatures[it].label == b.signatures[it].label }
+}
+
+/**
+ * Whether the active parameter of the signature at [active] is unchanged between
+ * [a] and [b]. Ports upstream's `sameActiveParam`, falling back from the
+ * signature's own active parameter to the help-level one. Returns true when
+ * [active] is out of range for either result (nothing to differ).
+ */
+internal fun sameActiveParam(a: SignatureHelp, b: SignatureHelp, active: Int): Boolean {
+    val sa = a.signatures.getOrNull(active) ?: return true
+    val sb = b.signatures.getOrNull(active) ?: return true
+    return (sa.activeParameter ?: a.activeParameter) == (sb.activeParameter ?: b.activeParameter)
+}
+
+/**
+ * The active signature index after advancing to the next signature, clamped at
+ * the last index. Pure cycling logic shared by [nextSignature].
+ */
+internal fun nextActive(active: Int, count: Int): Int =
+    if (active < count - 1) active + 1 else active
+
+/**
+ * The active signature index after moving to the previous signature, clamped at
+ * the first index. Pure cycling logic shared by [prevSignature].
+ */
+internal fun prevActive(active: Int): Int = if (active > 0) active - 1 else active
+
+/**
+ * The state backing an active signature-help tooltip.
+ *
+ * Mirrors upstream's `SignatureState`: the raw [data] returned by the server,
+ * the currently displayed [active] signature index (cycled by
+ * [nextSignature]/[prevSignature]), and the document [pos] the tooltip anchors
+ * to.
+ */
+internal data class SignatureState(
+    val data: SignatureHelp,
+    val active: Int,
+    val pos: Int
+)
+
+/**
+ * The new state produced by a [signatureEffect]: either a full [SignatureState]
+ * to show, or null to clear the tooltip.
+ */
+internal val signatureEffect: StateEffectType<SignatureState?> =
+    StateEffect.define { value, mapping ->
+        // Remap the tooltip anchor through document changes so the tooltip stays put.
+        value?.copy(pos = mapping.mapPos(DocPos(value.pos)).value)
+    }
+
+/**
+ * The [StateField] holding the active [SignatureState], or null when no
+ * signature help is showing. Provides the anchored [Tooltip] to the
+ * [showTooltip] facet, matching upstream's `signatureState` field.
+ */
+internal val signatureState: StateField<SignatureState?> = StateField.define {
+    create { _ -> null }
+    update { sig: SignatureState?, tr ->
+        val effect = tr.effects.firstNotNullOfOrNull { it.asType(signatureEffect) }
+        if (effect != null) {
+            effect.value
+        } else if (sig != null && tr.docChanged) {
+            // Keep the tooltip pinned to its (mapped) position across edits.
+            sig.copy(pos = tr.changes.mapPos(DocPos(sig.pos)).value)
+        } else {
+            sig
+        }
+    }
+    provide { field ->
+        showTooltip.from(field) { sig -> sig?.let { signatureTooltip(it) } }
+    }
+}
+
+/** Build the anchored [Tooltip] for a [SignatureState]. */
+private fun signatureTooltip(state: SignatureState): Tooltip = Tooltip(
+    pos = state.pos,
+    above = true,
+    content = { SignatureContent(state.data, state.active) }
+)
+
+/**
+ * The Compose body of a signature-help tooltip: an optional `n/total` counter
+ * when multiple signatures are available, the active signature's label with its
+ * active parameter bolded, and any signature documentation.
+ *
+ * **Deviation from upstream (HTML → Compose):** upstream renders the label into
+ * DOM nodes (wrapping the active parameter in a `<span>`) and injects the
+ * documentation as HTML via `docToHTML`. kodemirror renders on a Compose canvas,
+ * so the active parameter is highlighted with a bold [SpanStyle] and the
+ * documentation reuses the shared markdown→Compose conversion ([HoverContent];
+ * see its deviation note).
+ */
+@Composable
+internal fun SignatureContent(data: SignatureHelp, active: Int) {
+    val theme = LocalEditorTheme.current
+    val baseStyle = TextStyle(color = theme.foreground)
+    val signature = data.signatures.getOrNull(active) ?: return
+    val range = activeParamRange(signature, data.activeParameter)
+    Column(modifier = Modifier.padding(2.dp)) {
+        if (data.signatures.size > 1) {
+            BasicText(text = "${active + 1}/${data.signatures.size}", style = baseStyle)
+        }
+        BasicText(text = signatureLabel(signature.label, range), style = baseStyle)
+        for (block in documentationBlocks(signature.documentation)) {
+            BasicText(text = hoverBlockToAnnotatedString(block), style = baseStyle)
+        }
+    }
+}
+
+/**
+ * Render a signature [label] with the slice given by [range] (the active
+ * parameter) bolded. When [range] is null the label is returned verbatim.
+ */
+internal fun signatureLabel(label: String, range: ActiveParamRange?) = buildAnnotatedString {
+    if (range == null || range.to <= range.from ||
+        range.from !in 0..label.length || range.to !in 0..label.length
+    ) {
+        append(label)
+        return@buildAnnotatedString
+    }
+    append(label.substring(0, range.from))
+    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+        append(label.substring(range.from, range.to))
+    }
+    append(label.substring(range.to))
+}
+
+/**
+ * The [ViewPlugin] that drives signature help for a single editor, requesting
+ * `textDocument/signatureHelp` from the language server wrapped by [client] for
+ * the file at [uri] and dispatching [signatureEffect]s into [signatureState].
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `signaturePlugin`:
+ * - On an `input.type` transaction that inserts a server
+ *   [triggerCharacter][com.monkopedia.lsp.SignatureHelpOptions.triggerCharacters]
+ *   (or a [retriggerCharacter][com.monkopedia.lsp.SignatureHelpOptions.retriggerCharacters]
+ *   while help is already showing), it fires a `TriggerCharacter` request.
+ * - While help is showing and the selection moves, it debounces a
+ *   `ContentChange` re-trigger by [RETRIGGER_DELAY] ms.
+ * - [showSignatureHelp] fires an `Invoked` request.
+ *
+ * **Cancellation:** there is no explicit `$/cancelRequest`. A new request (or a
+ * selection/edit that invalidates the in-flight one) cancels the previous
+ * coroutine; the in-flight `textDocumentSignatureHelp` call is cancelled
+ * cooperatively through structured concurrency, consistent with
+ * [serverHover]/[serverCompletionSource].
+ */
+internal class SignatureHelpPlugin(
+    private val session: EditorSession,
+    private val client: LSPClient,
+    private val uri: String
+) : PluginValue {
+    private val job = SupervisorJob(session.coroutineScope.coroutineContext[Job])
+    private val scope: CoroutineScope =
+        CoroutineScope(session.coroutineScope.coroutineContext + job)
+
+    /** The most recent in-flight request, cancelled when superseded. */
+    private var pending: Job? = null
+
+    /** The most recent debounced re-trigger job, cancelled when superseded. */
+    private var delayed: Job? = null
+
+    override fun update(update: ViewUpdate) {
+        val sigState = update.state.field(signatureState)
+
+        var triggerCharacter: String? = null
+        if (update.docChanged && update.transactions.any { it.isUserEvent("input.type") }) {
+            val serverConf = client.serverCapabilities?.signatureHelpProvider
+            val triggers = serverConf?.triggerCharacters.orEmpty() +
+                (if (sigState != null) serverConf?.retriggerCharacters.orEmpty() else emptyList())
+            if (triggers.isNotEmpty()) {
+                update.changes.iterChanges({ _, _, _, _, inserted ->
+                    val ins = inserted.toString()
+                    if (ins.isNotEmpty()) {
+                        for (ch in triggers) if (ch.isNotEmpty() && ins.contains(ch)) {
+                            triggerCharacter = ch
+                        }
+                    }
+                })
+            }
+        }
+
+        when {
+            triggerCharacter != null -> startRequest(
+                SignatureHelpContext(
+                    triggerKind = SignatureHelpTriggerKind.TRIGGER_CHARACTER,
+                    isRetrigger = sigState != null,
+                    triggerCharacter = triggerCharacter,
+                    activeSignatureHelp = sigState?.data
+                )
+            )
+            sigState != null && update.selectionSet -> {
+                delayed?.cancel()
+                delayed = scope.launch {
+                    delay(RETRIGGER_DELAY)
+                    startRequest(
+                        SignatureHelpContext(
+                            triggerKind = SignatureHelpTriggerKind.CONTENT_CHANGE,
+                            isRetrigger = true,
+                            activeSignatureHelp = sigState.data
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    /** Issue a signature-help request with the given [context] and update state. */
+    fun startRequest(context: SignatureHelpContext) {
+        delayed?.cancel()
+        delayed = null
+        pending?.cancel()
+        val pos = session.state.selection.main.head.value
+        pending = scope.launch {
+            val result = getSignatureHelp(pos, context) ?: run {
+                if (session.state.field(signatureState) != null) {
+                    dispatchEffect(null)
+                }
+                return@launch
+            }
+            if (result.signatures.isEmpty()) {
+                if (session.state.field(signatureState) != null) dispatchEffect(null)
+                return@launch
+            }
+            val cur = session.state.field(signatureState)
+            val same = cur != null && sameSignatures(cur.data, result)
+            val contentChange = context.triggerKind == SignatureHelpTriggerKind.CONTENT_CHANGE
+            val active = if (same && contentChange) {
+                cur.active
+            } else {
+                result.activeSignature?.toInt() ?: 0
+            }
+            // Nothing changed: leave the existing tooltip untouched.
+            if (same && sameActiveParam(cur.data, result, active)) return@launch
+            dispatchEffect(
+                SignatureState(
+                    data = result,
+                    active = active,
+                    pos = if (same) cur.pos else pos
+                )
+            )
+        }
+    }
+
+    /**
+     * Request `textDocument/signatureHelp` at [pos] with [context], or null when
+     * the server has no `signatureHelpProvider` capability. Rethrows
+     * [CancellationException] so cancellation propagates cooperatively.
+     */
+    private suspend fun getSignatureHelp(pos: Int, context: SignatureHelpContext): SignatureHelp? {
+        if (client.serverCapabilities?.signatureHelpProvider == null) return null
+        client.sync()
+        val params = SignatureHelpParams(
+            textDocument = TextDocumentIdentifier(uri = uri),
+            position = toPosition(pos, session.state.doc),
+            context = context
+        )
+        return try {
+            client.server.textDocumentSignatureHelp(params)
+        } catch (e: CancellationException) {
+            throw e
+        }
+    }
+
+    private fun dispatchEffect(state: SignatureState?) {
+        session.dispatch(TransactionSpec(effects = listOf(signatureEffect.of(state))))
+    }
+
+    override fun destroy() {
+        job.cancel()
+    }
+
+    companion object {
+        /**
+         * Debounce, in milliseconds, before a selection move while signature
+         * help is showing re-triggers a `ContentChange` request. Mirrors
+         * upstream's 250ms `setTimeout`.
+         */
+        const val RETRIGGER_DELAY: Long = 250
+    }
+}
+
+/**
+ * Build the [ViewPlugin] descriptor for the [SignatureHelpPlugin], capturing
+ * [client]/[uri]. Held in a single field so [showSignatureHelp] and the cycling
+ * commands can locate the active plugin via [EditorSession.plugin].
+ */
+private fun signaturePlugin(client: LSPClient, uri: String): ViewPlugin<SignatureHelpPlugin> =
+    ViewPlugin.define(create = { session -> SignatureHelpPlugin(session, client, uri) })
+
+/**
+ * The [ViewPlugin] handle for the most recently installed [signatureHelp]
+ * extension, so the module-level [showSignatureHelp] command can find the
+ * plugin. Mirrors upstream's module-level `signaturePlugin`; a single
+ * signature-help configuration per editor is supported (as upstream).
+ */
+private var activeSignaturePlugin: ViewPlugin<SignatureHelpPlugin>? = null
+
+/**
+ * Explicitly prompt the server to provide signature help at the cursor.
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `showSignatureHelp` command: fires an
+ * `Invoked` request through the active [SignatureHelpPlugin]. Returns false when
+ * no signature-help extension is installed.
+ */
+fun showSignatureHelp(session: EditorSession): Boolean {
+    val handle = activeSignaturePlugin ?: return false
+    val plugin = session.plugin(handle) ?: return false
+    val field = session.state.field(signatureState)
+    plugin.startRequest(
+        SignatureHelpContext(
+            triggerKind = SignatureHelpTriggerKind.INVOKED,
+            isRetrigger = field != null,
+            activeSignatureHelp = field?.data
+        )
+    )
+    return true
+}
+
+/**
+ * If a signature tooltip with multiple signatures is showing, move to the next
+ * one. Ports upstream's `nextSignature`. Returns false when no tooltip is active.
+ */
+fun nextSignature(session: EditorSession): Boolean {
+    val field = session.state.field(signatureState) ?: return false
+    val next = nextActive(field.active, field.data.signatures.size)
+    if (next != field.active) {
+        session.dispatch(
+            TransactionSpec(effects = listOf(signatureEffect.of(field.copy(active = next))))
+        )
+    }
+    return true
+}
+
+/**
+ * If a signature tooltip with multiple signatures is showing, move to the
+ * previous one. Ports upstream's `prevSignature`. Returns false when no tooltip
+ * is active.
+ */
+fun prevSignature(session: EditorSession): Boolean {
+    val field = session.state.field(signatureState) ?: return false
+    val prev = prevActive(field.active)
+    if (prev != field.active) {
+        session.dispatch(
+            TransactionSpec(effects = listOf(signatureEffect.of(field.copy(active = prev))))
+        )
+    }
+    return true
+}
+
+/**
+ * The default signature-help key bindings, matching upstream's
+ * `signatureKeymap`:
+ * - `Mod-Shift-Space` ([showSignatureHelp]),
+ * - `Mod-Shift-ArrowUp` ([prevSignature]),
+ * - `Mod-Shift-ArrowDown` ([nextSignature]).
+ *
+ * (`Mod` is `Ctrl` on non-Mac platforms and `Meta`/Cmd on macOS.)
+ */
+val signatureKeymap: List<KeyBinding> = listOf(
+    KeyBinding(key = "Mod-Shift-Space", run = ::showSignatureHelp),
+    KeyBinding(key = "Mod-Shift-ArrowUp", run = ::prevSignature),
+    KeyBinding(key = "Mod-Shift-ArrowDown", run = ::nextSignature)
+)
+
+/**
+ * Build the editor [Extension] that enables LSP signature help from the language
+ * server wrapped by [client] for the file at [uri].
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `signatureHelp`. It installs the
+ * [signatureState] field (which provides the tooltip to the [showTooltip] facet)
+ * and the [SignatureHelpPlugin] (which requests help on trigger characters /
+ * explicit invocation and cycles signatures), and — unless
+ * [keymap][SignatureHelpConfig.keymap] is false — the [signatureKeymap] bindings
+ * at high precedence.
+ *
+ * @param client The LSP client wrapping the language server.
+ * @param uri The document URI for this editor's file.
+ * @param config Signature-help configuration. See [SignatureHelpConfig].
+ */
+fun signatureHelp(
+    client: LSPClient,
+    uri: String,
+    config: SignatureHelpConfig = SignatureHelpConfig()
+): Extension {
+    val plugin = signaturePlugin(client, uri)
+    activeSignaturePlugin = plugin
+    val extensions = buildList {
+        add(signatureState)
+        add(plugin.asExtension())
+        if (config.keymap) add(Prec.high(keymap.of(signatureKeymap)))
+    }
+    return ExtensionList(extensions)
+}

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelpTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelpTest.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import androidx.compose.ui.text.font.FontWeight
+import com.monkopedia.lsp.ParameterInformation
+import com.monkopedia.lsp.SignatureHelp
+import com.monkopedia.lsp.SignatureInformation
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+
+class ServerSignatureHelpTest {
+
+    private fun param(label: kotlinx.serialization.json.JsonElement) =
+        ParameterInformation(label = label)
+
+    private fun strParam(label: String) = param(JsonPrimitive(label))
+
+    private fun offsetParam(from: Int, to: Int) =
+        param(JsonArray(listOf(JsonPrimitive(from), JsonPrimitive(to))))
+
+    private fun signature(
+        label: String,
+        parameters: List<ParameterInformation>? = null,
+        activeParameter: UInt? = null
+    ) = SignatureInformation(
+        label = label,
+        parameters = parameters,
+        activeParameter = activeParameter
+    )
+
+    // --- activeParamRange: string label vs [start, end] offset label ---
+
+    @Test
+    fun stringLabelResolvedAsSubstring() {
+        val sig = signature("foo(a: Int, b: Int)", listOf(strParam("a: Int"), strParam("b: Int")))
+        // Help-level active parameter = 1 -> "b: Int".
+        val range = activeParamRange(sig, helpActiveParameter = 1u)
+        assertEquals(ActiveParamRange(12, 18), range)
+        assertEquals("b: Int", sig.label.substring(range!!.from, range.to))
+    }
+
+    @Test
+    fun offsetLabelResolvedDirectly() {
+        val sig = signature("foo(a, b)", listOf(offsetParam(4, 5), offsetParam(7, 8)))
+        val range = activeParamRange(sig, helpActiveParameter = 0u)
+        assertEquals(ActiveParamRange(4, 5), range)
+    }
+
+    @Test
+    fun signatureActiveParameterOverridesHelpLevel() {
+        val sig = signature(
+            "f(x, y)",
+            listOf(offsetParam(2, 3), offsetParam(5, 6)),
+            activeParameter = 1u
+        )
+        // Help says 0, but the signature's own activeParameter (1) wins.
+        val range = activeParamRange(sig, helpActiveParameter = 0u)
+        assertEquals(ActiveParamRange(5, 6), range)
+    }
+
+    @Test
+    fun nullWhenNoParameters() {
+        assertNull(activeParamRange(signature("f()"), helpActiveParameter = 0u))
+    }
+
+    @Test
+    fun nullWhenNoActiveParameter() {
+        val sig = signature("f(a)", listOf(strParam("a")))
+        assertNull(activeParamRange(sig, helpActiveParameter = null))
+    }
+
+    @Test
+    fun nullWhenIndexOutOfRange() {
+        val sig = signature("f(a)", listOf(strParam("a")))
+        assertNull(activeParamRange(sig, helpActiveParameter = 5u))
+    }
+
+    @Test
+    fun nullWhenStringLabelNotFound() {
+        val sig = signature("f(a)", listOf(strParam("zzz")))
+        assertNull(activeParamRange(sig, helpActiveParameter = 0u))
+    }
+
+    // --- signatureLabel: active parameter highlighting ---
+
+    @Test
+    fun labelHighlightsActiveParameter() {
+        val out = signatureLabel("foo(a, b)", ActiveParamRange(4, 5))
+        assertEquals("foo(a, b)", out.text)
+        val bold = out.spanStyles.first { it.item.fontWeight == FontWeight.Bold }
+        assertEquals(4, bold.start)
+        assertEquals(5, bold.end)
+    }
+
+    @Test
+    fun labelVerbatimWhenNoRange() {
+        val out = signatureLabel("foo(a, b)", null)
+        assertEquals("foo(a, b)", out.text)
+        assertTrue(out.spanStyles.isEmpty())
+    }
+
+    @Test
+    fun labelVerbatimWhenRangeOutOfBounds() {
+        val out = signatureLabel("foo", ActiveParamRange(2, 10))
+        assertEquals("foo", out.text)
+        assertTrue(out.spanStyles.isEmpty())
+    }
+
+    // --- sameSignatures / sameActiveParam ---
+
+    @Test
+    fun sameSignaturesByLabel() {
+        val a = SignatureHelp(signatures = listOf(signature("f(a)"), signature("g(b)")))
+        val b = SignatureHelp(signatures = listOf(signature("f(a)"), signature("g(b)")))
+        assertTrue(sameSignatures(a, b))
+    }
+
+    @Test
+    fun differentSignaturesByLength() {
+        val a = SignatureHelp(signatures = listOf(signature("f(a)")))
+        val b = SignatureHelp(signatures = listOf(signature("f(a)"), signature("g(b)")))
+        assertFalse(sameSignatures(a, b))
+    }
+
+    @Test
+    fun differentSignaturesByLabel() {
+        val a = SignatureHelp(signatures = listOf(signature("f(a)")))
+        val b = SignatureHelp(signatures = listOf(signature("f(b)")))
+        assertFalse(sameSignatures(a, b))
+    }
+
+    @Test
+    fun sameActiveParamHelpLevel() {
+        val a = SignatureHelp(signatures = listOf(signature("f(a)")), activeParameter = 0u)
+        val b = SignatureHelp(signatures = listOf(signature("f(a)")), activeParameter = 0u)
+        assertTrue(sameActiveParam(a, b, 0))
+    }
+
+    @Test
+    fun differentActiveParam() {
+        val a = SignatureHelp(signatures = listOf(signature("f(a)")), activeParameter = 0u)
+        val b = SignatureHelp(signatures = listOf(signature("f(a)")), activeParameter = 1u)
+        assertFalse(sameActiveParam(a, b, 0))
+    }
+
+    @Test
+    fun signatureActiveParamWinsInSameActiveParam() {
+        val a = SignatureHelp(
+            signatures = listOf(signature("f(a)", activeParameter = 2u)),
+            activeParameter = 0u
+        )
+        val b = SignatureHelp(
+            signatures = listOf(signature("f(a)", activeParameter = 2u)),
+            activeParameter = 9u
+        )
+        // Signature-level activeParameter (2 == 2) is used, ignoring help-level.
+        assertTrue(sameActiveParam(a, b, 0))
+    }
+
+    // --- signature cycling: next/prev clamp at the ends ---
+
+    @Test
+    fun nextAdvancesUntilLast() {
+        assertEquals(1, nextActive(0, 3))
+        assertEquals(2, nextActive(1, 3))
+        // Clamp at last.
+        assertEquals(2, nextActive(2, 3))
+    }
+
+    @Test
+    fun prevDecrementsUntilFirst() {
+        assertEquals(0, prevActive(1))
+        // Clamp at first.
+        assertEquals(0, prevActive(0))
+    }
+}

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelpTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelpTest.kt
@@ -19,13 +19,18 @@
 package com.monkopedia.kodemirror.lsp
 
 import androidx.compose.ui.text.font.FontWeight
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.lsp.LanguageServer
 import com.monkopedia.lsp.ParameterInformation
 import com.monkopedia.lsp.SignatureHelp
 import com.monkopedia.lsp.SignatureInformation
+import java.lang.reflect.Proxy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
@@ -194,5 +199,55 @@ class ServerSignatureHelpTest {
         assertEquals(0, prevActive(1))
         // Clamp at first.
         assertEquals(0, prevActive(0))
+    }
+
+    // --- multi-instance: per-editor signature-help binding ---
+
+    /**
+     * A do-nothing [LanguageServer] used only to construct distinct [LSPClient]s;
+     * none of its methods are invoked because [signatureHelp] merely stores the
+     * client in the [signatureHelpServer] facet (it does not contact the server).
+     */
+    private fun stubServer(): LanguageServer = Proxy.newProxyInstance(
+        LanguageServer::class.java.classLoader,
+        arrayOf(LanguageServer::class.java)
+    ) { _, method, _ ->
+        error("stub LanguageServer.${method.name} should not be called in this test")
+    } as LanguageServer
+
+    @Test
+    fun twoEditorsKeepIndependentSignatureHelpBindings() {
+        val clientA = LSPClient(stubServer())
+        val clientB = LSPClient(stubServer())
+
+        val stateA = EditorState.create(
+            doc = "a",
+            extensions = signatureHelp(clientA, "file:///a.kt")
+        )
+        // Installing a second editor must NOT clobber the first one's binding,
+        // which was the original module-level `activeSignaturePlugin` bug.
+        val stateB = EditorState.create(
+            doc = "b",
+            extensions = signatureHelp(clientB, "file:///b.kt")
+        )
+
+        val bindingA = stateA.facet(signatureHelpServer)
+        val bindingB = stateB.facet(signatureHelpServer)
+
+        // Each editor resolves its OWN client/uri from its own state.
+        assertEquals("file:///a.kt", bindingA?.uri)
+        assertSame(clientA, bindingA?.client)
+        assertEquals("file:///b.kt", bindingB?.uri)
+        assertSame(clientB, bindingB?.client)
+
+        // The second install did not overwrite the first (no shared mutable state).
+        assertNotSame(bindingA, bindingB)
+        assertSame(clientA, stateA.facet(signatureHelpServer)?.client)
+    }
+
+    @Test
+    fun editorWithoutSignatureHelpHasNullBinding() {
+        val state = EditorState.create(doc = "x")
+        assertNull(state.facet(signatureHelpServer))
     }
 }


### PR DESCRIPTION
## Summary
Sixth sub-issue of the LSP port epic #26. Closes #40. Ports upstream `signatureHelp` — an async signature tooltip with active-parameter highlighting, plus commands + keymap. Builds on #36/#39 (reuses the async-tooltip + markdown→Compose machinery). Two commits: the implementation, then a multi-instance correctness fix (squash-merge).

## What it does
- **Trigger:** opens/refreshes on a server `triggerCharacter` (typically `(`/`,`), re-triggers on `retriggerCharacters` while open, debounced 250ms on selection move; `showSignatureHelp` invokes explicitly; skips when no `signatureHelpProvider` capability. Requests `textDocument/signatureHelp` (after `client.sync()`, via `toPosition`), on the session scope, cooperative cancel-on-move (rethrows `CancellationException`).
- **Render:** `signatureState` field → `showTooltip` facet; shows `n/total` when multiple signatures, the active signature label with the active parameter **bolded** (resolves the parameter range from a string label OR a `[start,end]` JSON offset pair), and docs via the shared markdown→Compose renderer.
- **Cycling:** `nextSignature`/`prevSignature` clamp-advance the active index (per-session via `signatureState`).
- **Keymap:** `Mod-Shift-Space` / `Mod-Shift-ArrowUp` / `Mod-Shift-ArrowDown`.

## Multi-instance fix (second commit)
The first commit used a module-level mutable `activeSignaturePlugin` ("most-recently-installed" handle), which would break `showSignatureHelp` when more than one editor is open — the global-singleton pattern kodemirror deliberately removed (`vimGlobalState`). Fixed to **per-editor config via a Facet** (`signatureHelpServer`) + a single shared module-scope `ViewPlugin` handle; `showSignatureHelp(session)` resolves per-session via `session.plugin(handle)`. Added regression test `twoEditorsKeepIndependentSignatureHelpBindings` (two editors, distinct clients/uris, each keeps its own binding). Public API unchanged.

## Public API added (tier-2)
- `fun signatureHelp(client, uri, config = SignatureHelpConfig()): Extension`, `data class SignatureHelpConfig(keymap: Boolean = true)`
- `fun showSignatureHelp(session): Boolean`, `fun nextSignature(session): Boolean`, `fun prevSignature(session): Boolean`, `val signatureKeymap: List<KeyBinding>`
(`:view` NOT modified — reused existing `showTooltip`/`Tooltip`/`keymap`.)

## Deviation (documented)
HTML→Compose: upstream renders the signature label/docs to DOM; here the active parameter is a bold `SpanStyle` and docs reuse the markdown→`AnnotatedString` conversion.

## Verification
`:lsp-client:jvmTest` (signature tests incl. the new multi-instance guard), `compileKotlinJvm`/`compileKotlinWasmJs`/`compileDebugKotlinAndroid`, `:lsp-client:apiCheck` — all green. spotless/ktlint applied; apiDump committed. Apple/native not cross-compiled on Linux.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :lsp-client:jvmTest :lsp-client:compileKotlinWasmJs :lsp-client:compileDebugKotlinAndroid :lsp-client:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`