### PR TITLE
LSP go-to-definition family (#41)

### DIFF
--- a/lsp-client/api/android/lsp-client.api
+++ b/lsp-client/api/android/lsp-client.api
@@ -113,6 +113,16 @@ public final class com/monkopedia/kodemirror/lsp/ServerCompletionKt {
 	public static synthetic fun serverCompletionSource$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;ILjava/lang/Object;)Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerDefinitionKt {
+	public static final fun definitionJumps (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Z)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun definitionJumps$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static final fun getJumpToDefinitionKeymap ()Ljava/util/List;
+	public static final fun jumpToDeclaration (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun jumpToDefinition (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun jumpToImplementation (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun jumpToTypeDefinition (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+}
+
 public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }
@@ -151,6 +161,7 @@ public class com/monkopedia/kodemirror/lsp/Workspace {
 	public fun closeFile (Ljava/lang/String;)V
 	public fun didCloseFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun didOpenFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun displayFile (Ljava/lang/String;)Lcom/monkopedia/kodemirror/view/EditorSession;
 	public final fun getClient ()Lcom/monkopedia/kodemirror/lsp/LSPClient;
 	public final fun getFile (Ljava/lang/String;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
 	public final fun getMapping (Ljava/lang/String;)Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;

--- a/lsp-client/api/jvm/lsp-client.api
+++ b/lsp-client/api/jvm/lsp-client.api
@@ -113,6 +113,16 @@ public final class com/monkopedia/kodemirror/lsp/ServerCompletionKt {
 	public static synthetic fun serverCompletionSource$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Lcom/monkopedia/kodemirror/lsp/ServerCompletionConfig;ILjava/lang/Object;)Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerDefinitionKt {
+	public static final fun definitionJumps (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Z)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun definitionJumps$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static final fun getJumpToDefinitionKeymap ()Ljava/util/List;
+	public static final fun jumpToDeclaration (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun jumpToDefinition (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun jumpToImplementation (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun jumpToTypeDefinition (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+}
+
 public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }
@@ -151,6 +161,7 @@ public class com/monkopedia/kodemirror/lsp/Workspace {
 	public fun closeFile (Ljava/lang/String;)V
 	public fun didCloseFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun didOpenFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun displayFile (Ljava/lang/String;)Lcom/monkopedia/kodemirror/view/EditorSession;
 	public final fun getClient ()Lcom/monkopedia/kodemirror/lsp/LSPClient;
 	public final fun getFile (Ljava/lang/String;)Lcom/monkopedia/kodemirror/lsp/WorkspaceFile;
 	public final fun getMapping (Ljava/lang/String;)Lcom/monkopedia/kodemirror/lsp/WorkspaceMapping;

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
@@ -53,8 +53,10 @@ fun languageServerSupport(client: LSPClient, uri: String, languageId: String): E
             serverHover(client, uri),
             // Show signature help (parameter hints) as a tooltip on trigger
             // characters or explicit invocation — see #40.
-            signatureHelp(client, uri)
-            // TODO(#41): go-to-definition
+            signatureHelp(client, uri),
+            // Go-to-definition family (definition/declaration/typeDefinition/
+            // implementation) with the F12 jump-to-definition keymap — see #41.
+            definitionJumps(client, uri)
             // TODO(#42): find references
             // TODO(#43): rename
             // TODO(#44): formatting

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinition.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinition.kt
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.Extension
+import com.monkopedia.kodemirror.state.ExtensionList
+import com.monkopedia.kodemirror.state.Facet
+import com.monkopedia.kodemirror.state.Prec
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.TransactionSpec
+import com.monkopedia.kodemirror.state.define
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.kodemirror.view.KeyBinding
+import com.monkopedia.kodemirror.view.keymap as keymapFacet
+import com.monkopedia.lsp.BooleanOr
+import com.monkopedia.lsp.DeclarationParams
+import com.monkopedia.lsp.DefinitionParams
+import com.monkopedia.lsp.ImplementationParams
+import com.monkopedia.lsp.Location
+import com.monkopedia.lsp.LocationLink
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.TextDocumentIdentifier
+import com.monkopedia.lsp.TypeDefinitionParams
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * The per-editor go-to-definition binding: the [client] wrapping the language
+ * server and the document [uri] for this editor's file.
+ *
+ * Carried through state by [definitionServer] so the [jumpToDefinition] family
+ * of commands can read their configuration from the editor session they run in
+ * rather than capturing it at install time. This is what keeps the jump commands
+ * per-editor when multiple editors are open — there is no module-level mutable
+ * per-editor state (mirroring the per-editor design used by signature help).
+ */
+internal data class DefinitionServer(val client: LSPClient, val uri: String)
+
+/**
+ * The [Facet] carrying the per-editor [DefinitionServer] binding.
+ *
+ * Combines to the last non-null value, so an editor that installs
+ * [definitionJumps] gets its own [client][DefinitionServer.client] /
+ * [uri][DefinitionServer.uri] while editors without it see null (and the jump
+ * commands no-op, returning false).
+ */
+internal val definitionServer: Facet<DefinitionServer?, DefinitionServer?> =
+    Facet.define(combine = { values -> values.lastOrNull { it != null } })
+
+/**
+ * A normalized navigation target parsed out of an LSP definition-family result.
+ *
+ * The LSP `textDocument/{definition,declaration,typeDefinition,implementation}`
+ * result is the union `Location | Location[] | LocationLink[] | null`. This
+ * collapses whichever shape was returned (and, for arrays, the first element,
+ * matching upstream) into a single URI + the LSP [range] whose
+ * [start][Range.start] the cursor should jump to.
+ *
+ * @param uri The target document URI.
+ * @param range The target range; navigation moves to its start.
+ */
+internal data class JumpTarget(val uri: String, val range: Range)
+
+private val definitionJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+/**
+ * Parse the raw definition-family result (which the typed
+ * [LanguageServer][com.monkopedia.lsp.LanguageServer] returns as a [JsonElement])
+ * into the first navigable [JumpTarget], or null when there is nothing to jump
+ * to.
+ *
+ * Handles every shape the result union allows:
+ * - `null` / JSON `null` → null,
+ * - a single `Location` object (`{uri, range}`),
+ * - a single `LocationLink` object (`{targetUri, targetSelectionRange, ...}`),
+ * - an array of `Location` or `LocationLink` (the **first** element is used,
+ *   matching upstream's `Array.isArray(response) ? response[0] : response`).
+ *
+ * For a [LocationLink] the [targetSelectionRange][LocationLink.targetSelectionRange]
+ * is used (the range that should be revealed/selected when the link is followed,
+ * per the LSP spec), with its [targetUri][LocationLink.targetUri].
+ */
+internal fun parseDefinitionResult(element: JsonElement?): JumpTarget? = when (element) {
+    null, JsonNull -> null
+    is JsonObject -> parseLocationElement(element)
+    is JsonArray -> element.firstOrNull()?.let { parseLocationElement(it) }
+    else -> null
+}
+
+/**
+ * Parse a single element of a definition-family result — either a [Location]
+ * (`{uri, range}`) or a [LocationLink] (`{targetUri, targetSelectionRange, …}`),
+ * disambiguated by which key is present (`uri` vs `targetUri`).
+ */
+private fun parseLocationElement(element: JsonElement): JumpTarget? {
+    val obj = element as? JsonObject ?: return null
+    if (obj.containsKey("targetUri")) {
+        val link = runCatching {
+            definitionJson.decodeFromJsonElement(LocationLink.serializer(), obj)
+        }.getOrNull() ?: return null
+        return JumpTarget(link.targetUri, link.targetSelectionRange)
+    }
+    val loc = runCatching {
+        definitionJson.decodeFromJsonElement(Location.serializer(), obj)
+    }.getOrNull() ?: return null
+    return JumpTarget(loc.uri, loc.range)
+}
+
+/**
+ * Whether a [ServerCapabilities] field carrying one of the definition-family
+ * provider capabilities is present (the server supports the feature).
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `hasCapability`: a capability is
+ * supported when its value is truthy, i.e. present and not the boolean `false`.
+ * A `BooleanOr` options object (`Value`) always counts as supported; a bare
+ * boolean counts only when true; null/absent counts as unsupported.
+ */
+internal fun hasProvider(capability: BooleanOr<*>?): Boolean = when (capability) {
+    null -> false
+    is BooleanOr.BooleanValue -> capability.value
+    is BooleanOr.Value<*> -> true
+}
+
+/** Resolve the definition-family provider capability selected by [select]. */
+private inline fun DefinitionServer.serverSupports(
+    select: (ServerCapabilities) -> BooleanOr<*>?
+): Boolean {
+    val caps = client.serverCapabilities ?: return true // not initialized: match upstream (proceed)
+    return hasProvider(select(caps))
+}
+
+/**
+ * The shared implementation behind the four jump commands.
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `jumpToOrigin`:
+ * - resolves this editor's [DefinitionServer] binding from the [definitionServer]
+ *   facet; returns false (command not handled) when none is installed,
+ * - returns false when the server explicitly lacks the [capability],
+ * - otherwise flushes pending edits ([LSPClient.sync]), issues [request] at the
+ *   cursor, parses the result union ([parseDefinitionResult]) and navigates
+ *   ([navigateToTarget]).
+ *
+ * The suspending work runs on the [client scope][LSPClient.scope] (not the
+ * session's) because a cross-file jump targets a different editor session, and
+ * the navigation must outlive the requesting session if it is torn down. A new
+ * jump does not cancel an in-flight one (each is an explicit user gesture);
+ * cancellation of the in-flight LSP call is cooperative through structured
+ * concurrency, consistent with the other LSP features.
+ *
+ * @return true when the command is handled (a binding exists and the server
+ *   advertises the capability), so the keymap stops here; false to fall through.
+ */
+private inline fun jumpToOrigin(
+    session: EditorSession,
+    crossinline capability: (ServerCapabilities) -> BooleanOr<*>?,
+    crossinline request: suspend (DefinitionServer, Position) -> JsonElement
+): Boolean {
+    val binding = session.state.facet(definitionServer) ?: return false
+    if (!binding.serverSupports(capability)) return false
+    val pos = session.state.selection.main.head.value
+    binding.client.scope.launch {
+        binding.client.sync()
+        val position = toPosition(pos, session.state.doc)
+        val result = try {
+            request(binding, position)
+        } catch (e: CancellationException) {
+            throw e
+        }
+        val target = parseDefinitionResult(result) ?: return@launch
+        navigateToTarget(binding, target)
+    }
+    return true
+}
+
+/**
+ * Move the user to [target].
+ *
+ * Ports upstream `jumpToOrigin`'s navigation tail:
+ * - **Same file** (target URI equals the binding's [uri][DefinitionServer.uri]):
+ *   resolve the target range start against the file's current document
+ *   ([fromPosition]) and dispatch a selection move with scroll-into-view on the
+ *   binding's own file session.
+ * - **Cross file:** ask the [Workspace] to surface the target file
+ *   ([Workspace.displayFile]); if it returns a session, move that session's
+ *   selection to the target start (resolved against *that* session's document).
+ *
+ * **Workspace limitation:** the default [Workspace] is single-file — its
+ * [displayFile][Workspace.displayFile] only returns a session for a file that is
+ * already open (it cannot open arbitrary files). For such a workspace a cross-file
+ * jump degrades gracefully to a no-op. To support real cross-file navigation, a
+ * consumer must subclass [Workspace] and override [displayFile][Workspace.displayFile]
+ * to create/find and reveal an editor for the URI (mirroring upstream's
+ * `Workspace.displayFile`).
+ */
+private fun navigateToTarget(binding: DefinitionServer, target: JumpTarget) {
+    val workspace = binding.client.workspace
+    val targetSession: EditorSession? = if (target.uri == binding.uri) {
+        workspace.getFile(binding.uri)?.session
+    } else {
+        workspace.displayFile(target.uri)
+    }
+    if (targetSession == null) return
+    val offset = fromPosition(target.range.start, targetSession.state.doc)
+    targetSession.dispatch(
+        TransactionSpec(
+            selection = SelectionSpec.CursorSpec(DocPos(offset)),
+            scrollIntoView = true,
+            userEvent = "select.definition"
+        )
+    )
+}
+
+/**
+ * Jump to the definition of the symbol at the cursor.
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `jumpToDefinition` command (requires
+ * the server's `definitionProvider` capability). Returns false when no
+ * [definitionJumps] extension is installed in [session] or the server lacks the
+ * capability. To support cross-file jumps, override
+ * [Workspace.displayFile] (see [navigateToTarget]).
+ */
+fun jumpToDefinition(session: EditorSession): Boolean = jumpToOrigin(
+    session,
+    capability = { it.definitionProvider },
+    request = { binding, position ->
+        binding.client.server.textDocumentDefinition(
+            DefinitionParams(
+                textDocument = TextDocumentIdentifier(uri = binding.uri),
+                position = position
+            )
+        )
+    }
+)
+
+/**
+ * Jump to the declaration of the symbol at the cursor.
+ *
+ * Ports upstream's `jumpToDeclaration` command (requires the server's
+ * `declarationProvider` capability). See [jumpToDefinition].
+ */
+fun jumpToDeclaration(session: EditorSession): Boolean = jumpToOrigin(
+    session,
+    capability = { it.declarationProvider },
+    request = { binding, position ->
+        binding.client.server.textDocumentDeclaration(
+            DeclarationParams(
+                textDocument = TextDocumentIdentifier(uri = binding.uri),
+                position = position
+            )
+        )
+    }
+)
+
+/**
+ * Jump to the type definition of the symbol at the cursor.
+ *
+ * Ports upstream's `jumpToTypeDefinition` command (requires the server's
+ * `typeDefinitionProvider` capability). See [jumpToDefinition].
+ */
+fun jumpToTypeDefinition(session: EditorSession): Boolean = jumpToOrigin(
+    session,
+    capability = { it.typeDefinitionProvider },
+    request = { binding, position ->
+        binding.client.server.textDocumentTypeDefinition(
+            TypeDefinitionParams(
+                textDocument = TextDocumentIdentifier(uri = binding.uri),
+                position = position
+            )
+        )
+    }
+)
+
+/**
+ * Jump to the implementation of the symbol at the cursor.
+ *
+ * Ports upstream's `jumpToImplementation` command (requires the server's
+ * `implementationProvider` capability). See [jumpToDefinition].
+ */
+fun jumpToImplementation(session: EditorSession): Boolean = jumpToOrigin(
+    session,
+    capability = { it.implementationProvider },
+    request = { binding, position ->
+        binding.client.server.textDocumentImplementation(
+            ImplementationParams(
+                textDocument = TextDocumentIdentifier(uri = binding.uri),
+                position = position
+            )
+        )
+    }
+)
+
+/**
+ * The default go-to-definition key bindings, matching upstream's
+ * `jumpToDefinitionKeymap`: `F12` runs [jumpToDefinition] (preventing the default
+ * action).
+ */
+val jumpToDefinitionKeymap: List<KeyBinding> = listOf(
+    KeyBinding(key = "F12", run = ::jumpToDefinition, preventDefault = true)
+)
+
+/**
+ * Build the editor [Extension] that enables the LSP go-to-definition family
+ * ([jumpToDefinition] / [jumpToDeclaration] / [jumpToTypeDefinition] /
+ * [jumpToImplementation]) for the file at [uri] served by [client].
+ *
+ * Mirrors how upstream `@codemirror/lsp-client` wires the jump commands: it
+ * carries this editor's per-editor binding through the [definitionServer] facet
+ * so the commands resolve their client/uri from the session they run in (no
+ * module-level mutable state), and — unless [keymap] is false — installs the
+ * [jumpToDefinitionKeymap] (`F12`) at high precedence.
+ *
+ * @param client The LSP client wrapping the language server.
+ * @param uri The document URI for this editor's file.
+ * @param keymap When true (the default), the [jumpToDefinitionKeymap] binding is
+ *   installed at high precedence. Pass false to bind the jump commands yourself.
+ */
+fun definitionJumps(client: LSPClient, uri: String, keymap: Boolean = true): Extension {
+    val extensions = buildList {
+        add(definitionServer.of(DefinitionServer(client, uri)))
+        if (keymap) add(Prec.high(keymapFacet.of(jumpToDefinitionKeymap)))
+    }
+    return ExtensionList(extensions)
+}

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/Workspace.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/Workspace.kt
@@ -148,6 +148,24 @@ open class Workspace(
     fun getFile(uri: String): WorkspaceFile? = files[uri]
 
     /**
+     * Surface the file at [uri] to the user and return the editor session showing
+     * it, or null when this is not possible.
+     *
+     * Mirrors upstream `@codemirror/lsp-client`'s `Workspace.displayFile`, called
+     * by features that need to put a file other than the one in the current
+     * editor in front of the user (most notably the [jumpToDefinition] family for
+     * cross-file jumps).
+     *
+     * **Default (single-file) behavior:** this base [Workspace] only tracks files
+     * that have been [opened][openFile] with an attached session; it returns the
+     * [session][WorkspaceFile.session] of an already-open file and cannot open
+     * arbitrary files from disk. A consumer that wants real cross-file navigation
+     * should subclass [Workspace] and override this to create/find and reveal an
+     * editor for [uri].
+     */
+    open fun displayFile(uri: String): EditorSession? = files[uri]?.session
+
+    /**
      * Obtain a live [WorkspaceMapping] for [uri] that tracks edits applied after
      * this call, or null if no such file is open. A feature that issues an LSP
      * request should capture a mapping when it sends the request and use it to

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinitionTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinitionTest.kt
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.lsp.BooleanOr
+import com.monkopedia.lsp.DefinitionOptions
+import com.monkopedia.lsp.LanguageServer
+import java.lang.reflect.Proxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class ServerDefinitionTest {
+
+    private fun rangeJson(startLine: Int, startChar: Int, endLine: Int, endChar: Int): JsonObject =
+        buildJsonObject {
+            put(
+                "start",
+                buildJsonObject {
+                    put("line", startLine)
+                    put("character", startChar)
+                }
+            )
+            put(
+                "end",
+                buildJsonObject {
+                    put("line", endLine)
+                    put("character", endChar)
+                }
+            )
+        }
+
+    private fun locationJson(uri: String, line: Int, char: Int): JsonObject = buildJsonObject {
+        put("uri", uri)
+        put("range", rangeJson(line, char, line, char + 1))
+    }
+
+    private fun locationLinkJson(uri: String, line: Int, char: Int): JsonObject = buildJsonObject {
+        put("targetUri", uri)
+        put("targetRange", rangeJson(line, 0, line, 20))
+        put("targetSelectionRange", rangeJson(line, char, line, char + 4))
+    }
+
+    // --- result-union parsing: Location vs Location[] vs LocationLink[] vs null ---
+
+    @Test
+    fun parsesSingleLocation() {
+        val target = parseDefinitionResult(locationJson("file:///a.kt", 3, 7))
+        assertEquals("file:///a.kt", target?.uri)
+        assertEquals(3u, target?.range?.start?.line)
+        assertEquals(7u, target?.range?.start?.character)
+    }
+
+    @Test
+    fun parsesLocationArrayPicksFirst() {
+        val arr = buildJsonArray {
+            add(locationJson("file:///first.kt", 1, 2))
+            add(locationJson("file:///second.kt", 9, 9))
+        }
+        val target = parseDefinitionResult(arr)
+        // Upstream uses response[0] for arrays.
+        assertEquals("file:///first.kt", target?.uri)
+        assertEquals(1u, target?.range?.start?.line)
+    }
+
+    @Test
+    fun parsesSingleLocationLinkUsesTargetSelectionRange() {
+        val target = parseDefinitionResult(locationLinkJson("file:///b.kt", 5, 4))
+        assertEquals("file:///b.kt", target?.uri)
+        // targetSelectionRange start (not targetRange).
+        assertEquals(5u, target?.range?.start?.line)
+        assertEquals(4u, target?.range?.start?.character)
+    }
+
+    @Test
+    fun parsesLocationLinkArrayPicksFirst() {
+        val arr = buildJsonArray {
+            add(locationLinkJson("file:///x.kt", 2, 1))
+            add(locationLinkJson("file:///y.kt", 8, 8))
+        }
+        val target = parseDefinitionResult(arr)
+        assertEquals("file:///x.kt", target?.uri)
+        assertEquals(2u, target?.range?.start?.line)
+    }
+
+    @Test
+    fun parsesNullResults() {
+        assertNull(parseDefinitionResult(null))
+        assertNull(parseDefinitionResult(JsonNull))
+        assertNull(parseDefinitionResult(JsonArray(emptyList())))
+        assertNull(parseDefinitionResult(JsonPrimitive("nonsense")))
+    }
+
+    // --- target-range -> document offset resolution ---
+
+    @Test
+    fun targetRangeStartResolvesToOffset() {
+        val doc = Text.of(listOf("line0", "line1", "XXXXXX"))
+        // Target on line 2 (0-based), character 3 -> offset of "X" + 3.
+        val target = parseDefinitionResult(locationJson("file:///a.kt", 2, 3))!!
+        val offset = fromPosition(target.range.start, doc)
+        // "line0\n" = 6, "line1\n" = 12, +3 = 15.
+        assertEquals(15, offset)
+    }
+
+    @Test
+    fun targetRangeStartFromLocationLinkResolvesToOffset() {
+        val doc = Text.of(listOf("abc", "defgh"))
+        val target = parseDefinitionResult(locationLinkJson("file:///a.kt", 1, 2))!!
+        val offset = fromPosition(target.range.start, doc)
+        // "abc\n" = 4, +2 = 6.
+        assertEquals(6, offset)
+    }
+
+    // --- hasProvider: capability presence semantics (matches upstream hasCapability) ---
+
+    @Test
+    fun providerPresenceSemantics() {
+        assertFalse(hasProvider(null))
+        assertFalse(hasProvider(BooleanOr.BooleanValue(false)))
+        assertTrue(hasProvider(BooleanOr.BooleanValue(true)))
+        assertTrue(hasProvider(BooleanOr.Value(DefinitionOptions())))
+    }
+
+    // --- multi-instance: per-editor go-to-definition binding ---
+
+    /**
+     * A do-nothing [LanguageServer] used only to construct distinct [LSPClient]s;
+     * [definitionJumps] merely stores the client in the [definitionServer] facet,
+     * it does not contact the server at install time.
+     */
+    private fun stubServer(): LanguageServer = Proxy.newProxyInstance(
+        LanguageServer::class.java.classLoader,
+        arrayOf(LanguageServer::class.java)
+    ) { _, method, _ ->
+        error("stub LanguageServer.${method.name} should not be called in this test")
+    } as LanguageServer
+
+    @Test
+    fun twoEditorsKeepIndependentDefinitionBindings() {
+        val clientA = LSPClient(stubServer())
+        val clientB = LSPClient(stubServer())
+
+        val stateA = EditorState.create(
+            doc = "a",
+            extensions = definitionJumps(clientA, "file:///a.kt")
+        )
+        // Installing a second editor must NOT clobber the first one's binding —
+        // the per-editor Facet design (no module-level mutable state) guards
+        // against the multi-instance bug we fixed in signature help.
+        val stateB = EditorState.create(
+            doc = "b",
+            extensions = definitionJumps(clientB, "file:///b.kt")
+        )
+
+        val bindingA = stateA.facet(definitionServer)
+        val bindingB = stateB.facet(definitionServer)
+
+        assertEquals("file:///a.kt", bindingA?.uri)
+        assertSame(clientA, bindingA?.client)
+        assertEquals("file:///b.kt", bindingB?.uri)
+        assertSame(clientB, bindingB?.client)
+
+        assertNotSame(bindingA, bindingB)
+        // The second install did not overwrite the first.
+        assertSame(clientA, stateA.facet(definitionServer)?.client)
+    }
+
+    @Test
+    fun editorWithoutDefinitionJumpsHasNullBinding() {
+        val state = EditorState.create(doc = "x")
+        assertNull(state.facet(definitionServer))
+    }
+
+    @Test
+    fun jumpCommandReturnsFalseWithoutBinding() {
+        // No definitionJumps installed -> command is not handled (returns false),
+        // so a keymap can fall through to other handlers (and nothing touches the
+        // server).
+        val state = EditorState.create(doc = "x")
+        val session = EditorSession(state)
+        assertFalse(jumpToDefinition(session))
+        assertFalse(jumpToDeclaration(session))
+        assertFalse(jumpToTypeDefinition(session))
+        assertFalse(jumpToImplementation(session))
+    }
+
+    @Test
+    fun defaultKeymapBindsF12ToJumpToDefinition() {
+        assertEquals(1, jumpToDefinitionKeymap.size)
+        val binding = jumpToDefinitionKeymap.single()
+        assertEquals("F12", binding.key)
+        assertTrue(binding.preventDefault)
+    }
+}


### PR DESCRIPTION
## Summary
Seventh sub-issue of the LSP port epic #26. Closes #41. Ports upstream's `jumpToDefinition`/`jumpToDeclaration`/`jumpToTypeDefinition`/`jumpToImplementation` commands + keymap. Builds on #36 mapping.

## What it does
- Four commands `(EditorSession) -> Boolean`; each skips when the server lacks the matching capability (faithful to upstream `hasCapability`: returns false on explicit `false`/`null` provider, proceeds when caps not yet initialized), flushes via `client.sync()`, requests at the cursor (`toPosition`), and parses the `Location | Location[] | LocationLink[] | null` union into a normalized `JumpTarget` (arrays → first element per upstream; `LocationLink` → `targetSelectionRange`).
- **Navigation:** same-file (target URI == binding URI) → `fromPosition` to the range start + `CursorSpec` selection with `scrollIntoView=true`, `userEvent="select.definition"`. Cross-file → `Workspace.displayFile(uri)`.
- `jumpToDefinitionKeymap` (F12) and `definitionJumps(client, uri, keymap=true)` folded into `languageServerSupport`.

## Per-editor design (no multi-instance bug)
Client/uri flow via an internal `definitionServer` Facet; commands resolve through `session.state.facet(...)` — **no module-level mutable per-editor state** (applies the lesson from #40). Suspend work runs on `LSPClient.scope` (SupervisorJob) so a cross-file jump survives the requesting session's teardown. Test `twoEditorsKeepIndependentDefinitionBindings` guards it.

## Public API added (tier-2)
- `fun jumpToDefinition/jumpToDeclaration/jumpToTypeDefinition/jumpToImplementation(session): Boolean`
- `val jumpToDefinitionKeymap: List<KeyBinding>`
- `fun definitionJumps(client, uri, keymap = true): Extension`
- `open fun Workspace.displayFile(uri): EditorSession?`
(No other modules touched.)

## Documented limitation / deviation
- The default single-file `Workspace.displayFile` only returns an already-open file's session — it can't open arbitrary files, so cross-file jumps degrade to a no-op. Consumers override `Workspace.displayFile` for real cross-file navigation (mirrors upstream `Workspace`).
- Upstream calls `plugin.reportError` on failure; kodemirror has no such hook, so errors propagate to the SupervisorJob scope (consistent with hover/signature-help).

## Verification
`:lsp-client:jvmTest` (11 tests incl. union parsing + multi-instance guard), `compileKotlinJvm`/`compileKotlinWasmJs`/`compileDebugKotlinAndroid`, `:lsp-client:apiCheck` — all green. spotless/ktlint applied; apiDump committed. Apple/native not cross-compiled on Linux.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :lsp-client:jvmTest :lsp-client:compileKotlinWasmJs :lsp-client:compileDebugKotlinAndroid :lsp-client:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`