### PR TITLE
LSP find references + reference panel (#42)

### DIFF
--- a/lsp-client/api/android/lsp-client.api
+++ b/lsp-client/api/android/lsp-client.api
@@ -90,6 +90,20 @@ public final class com/monkopedia/kodemirror/lsp/LanguageServerSupportKt {
 	public static final fun languageServerSupport (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Ljava/lang/String;)Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ReferenceLocation {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lcom/monkopedia/lsp/Range;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/monkopedia/lsp/Range;
+	public final fun copy (Ljava/lang/String;Lcom/monkopedia/lsp/Range;)Lcom/monkopedia/kodemirror/lsp/ReferenceLocation;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/lsp/ReferenceLocation;Ljava/lang/String;Lcom/monkopedia/lsp/Range;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/ReferenceLocation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRange ()Lcom/monkopedia/lsp/Range;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/monkopedia/kodemirror/lsp/ServerCompletionConfig {
 	public static final field $stable I
 	public fun <init> ()V
@@ -130,6 +144,14 @@ public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 public final class com/monkopedia/kodemirror/lsp/ServerHoverKt {
 	public static final fun serverHover (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;J)Lcom/monkopedia/kodemirror/state/Extension;
 	public static synthetic fun serverHover$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;JILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+}
+
+public final class com/monkopedia/kodemirror/lsp/ServerReferencesKt {
+	public static final fun closeReferencePanel (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun findReferences (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun findReferencesExtension (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Z)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun findReferencesExtension$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static final fun getFindReferencesKeymap ()Ljava/util/List;
 }
 
 public final class com/monkopedia/kodemirror/lsp/ServerSignatureHelpKt {

--- a/lsp-client/api/jvm/lsp-client.api
+++ b/lsp-client/api/jvm/lsp-client.api
@@ -90,6 +90,20 @@ public final class com/monkopedia/kodemirror/lsp/LanguageServerSupportKt {
 	public static final fun languageServerSupport (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Ljava/lang/String;)Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ReferenceLocation {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lcom/monkopedia/lsp/Range;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/monkopedia/lsp/Range;
+	public final fun copy (Ljava/lang/String;Lcom/monkopedia/lsp/Range;)Lcom/monkopedia/kodemirror/lsp/ReferenceLocation;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/lsp/ReferenceLocation;Ljava/lang/String;Lcom/monkopedia/lsp/Range;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/lsp/ReferenceLocation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRange ()Lcom/monkopedia/lsp/Range;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/monkopedia/kodemirror/lsp/ServerCompletionConfig {
 	public static final field $stable I
 	public fun <init> ()V
@@ -130,6 +144,14 @@ public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 public final class com/monkopedia/kodemirror/lsp/ServerHoverKt {
 	public static final fun serverHover (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;J)Lcom/monkopedia/kodemirror/state/Extension;
 	public static synthetic fun serverHover$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;JILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+}
+
+public final class com/monkopedia/kodemirror/lsp/ServerReferencesKt {
+	public static final fun closeReferencePanel (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun findReferences (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun findReferencesExtension (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Z)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun findReferencesExtension$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static final fun getFindReferencesKeymap ()Ljava/util/List;
 }
 
 public final class com/monkopedia/kodemirror/lsp/ServerSignatureHelpKt {

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
@@ -56,8 +56,10 @@ fun languageServerSupport(client: LSPClient, uri: String, languageId: String): E
             signatureHelp(client, uri),
             // Go-to-definition family (definition/declaration/typeDefinition/
             // implementation) with the F12 jump-to-definition keymap — see #41.
-            definitionJumps(client, uri)
-            // TODO(#42): find references
+            definitionJumps(client, uri),
+            // Find references (textDocument/references) with a reference panel
+            // and the Shift-F12 / Escape keymap — see #42.
+            findReferencesExtension(client, uri)
             // TODO(#43): rename
             // TODO(#44): formatting
             // TODO(#45): code actions

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/Navigation.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/Navigation.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.TransactionSpec
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.lsp.Position
+
+/**
+ * Move the user to [targetUri] at the document offset corresponding to LSP
+ * [position], reusing the navigation tail shared by go-to-definition and
+ * find-references.
+ *
+ * Ports the navigation step of upstream `@codemirror/lsp-client`'s
+ * `jumpToOrigin` / reference-panel `showReference`:
+ * - **Same file** ([targetUri] equals [sourceUri]): resolve the position against
+ *   the source file's current document and move its selection.
+ * - **Cross file:** ask the [Workspace] to surface the target file
+ *   ([Workspace.displayFile]); if it returns a session, move that session's
+ *   selection (resolved against *that* session's document).
+ *
+ * In both cases the move scrolls the target into view. Resolving the LSP
+ * [position] against the *current* document (rather than the version the server
+ * saw) keeps the jump correct under concurrent edits, matching the position
+ * mapping upstream performs.
+ *
+ * **Workspace limitation:** the default [Workspace] is single-file — its
+ * [displayFile][Workspace.displayFile] only returns a session for a file that is
+ * already open. For such a workspace a cross-file navigation degrades gracefully
+ * to a no-op. To support real cross-file navigation a consumer must subclass
+ * [Workspace] and override [displayFile][Workspace.displayFile].
+ *
+ * @param client The LSP client whose [workspace][LSPClient.workspace] resolves
+ *   the target file.
+ * @param sourceUri The URI of the file the navigation originates from (used to
+ *   detect the same-file case).
+ * @param targetUri The URI of the file to navigate to.
+ * @param position The LSP position within [targetUri] to move the cursor to.
+ * @param userEvent The `userEvent` annotation on the dispatched selection move.
+ */
+internal fun navigateToLocation(
+    client: LSPClient,
+    sourceUri: String,
+    targetUri: String,
+    position: Position,
+    userEvent: String
+) {
+    val workspace = client.workspace
+    val targetSession: EditorSession? = if (targetUri == sourceUri) {
+        workspace.getFile(sourceUri)?.session
+    } else {
+        workspace.displayFile(targetUri)
+    }
+    if (targetSession == null) return
+    val offset = fromPosition(position, targetSession.state.doc)
+    targetSession.dispatch(
+        TransactionSpec(
+            selection = SelectionSpec.CursorSpec(DocPos(offset)),
+            scrollIntoView = true,
+            userEvent = userEvent
+        )
+    )
+}

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ReferencePanel.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ReferencePanel.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import com.monkopedia.kodemirror.state.Slot
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.kodemirror.view.EditorTheme
+import com.monkopedia.kodemirror.view.LocalEditorSession
+import com.monkopedia.kodemirror.view.LocalEditorTheme
+import com.monkopedia.kodemirror.view.Panel
+import com.monkopedia.kodemirror.view.showPanels
+
+/**
+ * The `showPanels` provider for the reference panel: emits a single bottom
+ * [Panel] (mirroring upstream's `showPanel.from`) whenever the
+ * [referencePanel][referencePanel] field holds an open panel.
+ */
+internal fun referencePanelProvider() = showPanels.compute(
+    listOf(Slot.FieldSlot(referencePanel))
+) { state ->
+    val panel = state.field(referencePanel, require = false)
+    if (panel != null) {
+        listOf(
+            Panel(top = false) {
+                val view = LocalEditorSession.current
+                ReferencePanelContent(view, panel)
+            }
+        )
+    } else {
+        emptyList()
+    }
+}
+
+/**
+ * Composable reference-panel content: a header with a close button and a
+ * scrollable list of references grouped by file, each row showing the line
+ * number plus a context preview with the matched span emphasized.
+ *
+ * Ports upstream's `createReferencePanel` DOM as far as Compose allows:
+ * clicking a row selects (highlights) and navigates to it, and a `[Close]`
+ * affordance dismisses the panel. Upstream's in-panel keyboard list navigation
+ * (Arrow/Home/End/Enter) is not reproduced — closing is instead handled by the
+ * editor-level `Escape` binding in [findReferencesKeymap].
+ */
+@Composable
+internal fun ReferencePanelContent(view: EditorSession, panel: ReferencePanelState) {
+    val theme = LocalEditorTheme.current
+    val textStyle = TextStyle(color = theme.foreground)
+
+    // Resolve previews against the workspace's open documents.
+    val server = view.state.facet(referenceServer)
+    val entries = remember(panel) {
+        buildReferenceEntries(panel.locations) { uri ->
+            server?.client?.workspace?.getFile(uri)?.session?.state?.doc
+        }
+    }
+    var selected by remember(panel) { mutableStateOf(0) }
+
+    Column(modifier = Modifier.padding(4.dp)) {
+        Row(modifier = Modifier.padding(bottom = 4.dp)) {
+            BasicText("References (${entries.size})", style = textStyle)
+            BasicText(
+                " [Close]",
+                modifier = Modifier.clickable { closeReferencePanel(view) },
+                style = textStyle
+            )
+        }
+        if (entries.isEmpty()) {
+            BasicText("No references", style = textStyle)
+        } else {
+            LazyColumn {
+                itemsIndexed(entries) { index, entry ->
+                    val showHeader = index == 0 || entries[index - 1].fileName != entry.fileName
+                    if (showHeader) {
+                        BasicText(
+                            text = entry.fileName,
+                            modifier = Modifier.padding(top = if (index == 0) 0.dp else 4.dp),
+                            style = TextStyle(
+                                color = theme.foreground,
+                                fontWeight = FontWeight.Bold
+                            )
+                        )
+                    }
+                    ReferenceRow(
+                        entry = entry,
+                        selected = index == selected,
+                        theme = theme,
+                        onClick = {
+                            selected = index
+                            server?.let { showReference(it, entry) }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReferenceRow(
+    entry: ReferenceEntry,
+    selected: Boolean,
+    theme: EditorTheme,
+    onClick: () -> Unit
+) {
+    val lineLabel = entry.lineNumber?.let { "$it: " }?.padStart(5, ' ') ?: ""
+    val rowModifier = Modifier
+        .fillMaxWidth()
+        .then(if (selected) Modifier.background(theme.selection) else Modifier)
+        .clickable(onClick = onClick)
+        .padding(vertical = 1.dp)
+    Row(modifier = rowModifier) {
+        BasicText(
+            text = buildAnnotatedString {
+                if (lineLabel.isNotEmpty()) {
+                    append(lineLabel)
+                }
+                append(entry.before)
+                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                    append(entry.matched)
+                }
+                append(entry.after)
+            },
+            style = TextStyle(color = theme.foreground)
+        )
+    }
+}

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinition.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinition.kt
@@ -18,13 +18,10 @@
  */
 package com.monkopedia.kodemirror.lsp
 
-import com.monkopedia.kodemirror.state.DocPos
 import com.monkopedia.kodemirror.state.Extension
 import com.monkopedia.kodemirror.state.ExtensionList
 import com.monkopedia.kodemirror.state.Facet
 import com.monkopedia.kodemirror.state.Prec
-import com.monkopedia.kodemirror.state.SelectionSpec
-import com.monkopedia.kodemirror.state.TransactionSpec
 import com.monkopedia.kodemirror.state.define
 import com.monkopedia.kodemirror.view.EditorSession
 import com.monkopedia.kodemirror.view.KeyBinding
@@ -200,40 +197,17 @@ private inline fun jumpToOrigin(
 }
 
 /**
- * Move the user to [target].
- *
- * Ports upstream `jumpToOrigin`'s navigation tail:
- * - **Same file** (target URI equals the binding's [uri][DefinitionServer.uri]):
- *   resolve the target range start against the file's current document
- *   ([fromPosition]) and dispatch a selection move with scroll-into-view on the
- *   binding's own file session.
- * - **Cross file:** ask the [Workspace] to surface the target file
- *   ([Workspace.displayFile]); if it returns a session, move that session's
- *   selection to the target start (resolved against *that* session's document).
- *
- * **Workspace limitation:** the default [Workspace] is single-file — its
- * [displayFile][Workspace.displayFile] only returns a session for a file that is
- * already open (it cannot open arbitrary files). For such a workspace a cross-file
- * jump degrades gracefully to a no-op. To support real cross-file navigation, a
- * consumer must subclass [Workspace] and override [displayFile][Workspace.displayFile]
- * to create/find and reveal an editor for the URI (mirroring upstream's
- * `Workspace.displayFile`).
+ * Move the user to [target], delegating to the shared [navigateToLocation]
+ * helper (same-file vs cross-file resolution, position mapping, scroll into
+ * view) that go-to-definition and find-references both use.
  */
 private fun navigateToTarget(binding: DefinitionServer, target: JumpTarget) {
-    val workspace = binding.client.workspace
-    val targetSession: EditorSession? = if (target.uri == binding.uri) {
-        workspace.getFile(binding.uri)?.session
-    } else {
-        workspace.displayFile(target.uri)
-    }
-    if (targetSession == null) return
-    val offset = fromPosition(target.range.start, targetSession.state.doc)
-    targetSession.dispatch(
-        TransactionSpec(
-            selection = SelectionSpec.CursorSpec(DocPos(offset)),
-            scrollIntoView = true,
-            userEvent = "select.definition"
-        )
+    navigateToLocation(
+        client = binding.client,
+        sourceUri = binding.uri,
+        targetUri = target.uri,
+        position = target.range.start,
+        userEvent = "select.definition"
     )
 }
 

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerReferences.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerReferences.kt
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.Extension
+import com.monkopedia.kodemirror.state.ExtensionList
+import com.monkopedia.kodemirror.state.Facet
+import com.monkopedia.kodemirror.state.Prec
+import com.monkopedia.kodemirror.state.StateEffect
+import com.monkopedia.kodemirror.state.StateEffectType
+import com.monkopedia.kodemirror.state.StateField
+import com.monkopedia.kodemirror.state.StateFieldSpec
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.kodemirror.state.TransactionSpec
+import com.monkopedia.kodemirror.state.define
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.kodemirror.view.KeyBinding
+import com.monkopedia.kodemirror.view.keymap as keymapFacet
+import com.monkopedia.lsp.Location
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.ReferenceContext
+import com.monkopedia.lsp.ReferenceParams
+import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.TextDocumentIdentifier
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+/**
+ * The per-editor find-references binding: the [client] wrapping the language
+ * server and the document [uri] for this editor's file.
+ *
+ * Carried through state by [referenceServer] so [findReferences] can read its
+ * configuration from the editor session it runs in rather than capturing it at
+ * install time. This is what keeps the command per-editor when multiple editors
+ * are open — there is no module-level mutable per-editor state (mirroring the
+ * per-editor design used by [definitionServer]).
+ */
+internal data class ReferenceServer(val client: LSPClient, val uri: String)
+
+/**
+ * The [Facet] carrying the per-editor [ReferenceServer] binding.
+ *
+ * Combines to the last non-null value, so an editor that installs
+ * [findReferencesExtension] gets its own [client][ReferenceServer.client] /
+ * [uri][ReferenceServer.uri] while editors without it see null (and
+ * [findReferences] no-ops, returning false).
+ */
+internal val referenceServer: Facet<ReferenceServer?, ReferenceServer?> =
+    Facet.define(combine = { values -> values.lastOrNull { it != null } })
+
+/**
+ * A single reference location reported by `textDocument/references`: the target
+ * document [uri] and the [range] of the reference within it.
+ *
+ * Mirrors upstream's `ReferenceLocation`, but keeps the raw URI/range rather than
+ * eagerly binding to a `WorkspaceFile`/view — the panel resolves a preview and
+ * navigates lazily so it works for files that are not currently open.
+ */
+data class ReferenceLocation(val uri: String, val range: Range)
+
+/**
+ * The per-editor reference-panel state: the [locations] to show, or null when no
+ * panel is open.
+ *
+ * Mirrors upstream's `referencePanel` `StateField`. The panel is open exactly
+ * when this is non-null; [findReferences] sets it and [closeReferencePanel]
+ * clears it via [setReferencePanel].
+ */
+internal data class ReferencePanelState(val locations: List<ReferenceLocation>)
+
+/** Effect that replaces the reference-panel state (null closes the panel). */
+internal val setReferencePanel: StateEffectType<ReferencePanelState?> = StateEffect.define()
+
+/** State field holding the open reference panel, or null when closed. */
+internal val referencePanel: StateField<ReferencePanelState?> = StateField.define(
+    StateFieldSpec(
+        create = { null },
+        update = { value, tr ->
+            var result = value
+            for (effect in tr.effects) {
+                val asSet = effect.asType(setReferencePanel)
+                if (asSet != null) result = asSet.value
+            }
+            result
+        }
+    )
+)
+
+/**
+ * Convert the raw `textDocument/references` result into [ReferenceLocation]s.
+ *
+ * The typed [LanguageServer][com.monkopedia.lsp.LanguageServer] already returns a
+ * `List<Location>` (unlike the definition family's JSON union), so this is a
+ * straightforward map preserving server order.
+ */
+internal fun toReferenceLocations(locations: List<Location>): List<ReferenceLocation> =
+    locations.map { ReferenceLocation(it.uri, it.range) }
+
+/**
+ * The length of the longest common directory prefix shared by all [uris],
+ * trimmed back to the last `'/'`.
+ *
+ * Ports upstream's `findCommonPrefix`: reference entries are shown grouped under
+ * file headers with this shared prefix stripped, so only the distinguishing tail
+ * of each URI is displayed. Returns 0 for an empty list.
+ */
+internal fun findCommonPrefix(uris: List<String>): Int {
+    if (uris.isEmpty()) return 0
+    val first = uris[0]
+    var prefix = first.length
+    for (i in 1 until uris.size) {
+        val uri = uris[i]
+        var j = 0
+        val end = minOf(prefix, uri.length)
+        while (j < end && first[j] == uri[j]) j++
+        prefix = j
+    }
+    while (prefix > 0 && first[prefix - 1] != '/') prefix--
+    return prefix
+}
+
+/**
+ * A fully-resolved entry in the reference panel, ready to render.
+ *
+ * @param location The reference's URI and range.
+ * @param fileName The URI with the [common prefix][findCommonPrefix] stripped.
+ * @param lineNumber The 1-based line number of the reference, or null when the
+ *   target file is not open (so its document is unavailable for a preview).
+ * @param before The line text before the matched span (trimmed to a leading
+ *   window, matching upstream's 50-char look-behind).
+ * @param matched The matched span's text.
+ * @param after The line text after the matched span (trimmed to upstream's
+ *   trailing window).
+ */
+internal data class ReferenceEntry(
+    val location: ReferenceLocation,
+    val fileName: String,
+    val lineNumber: Int?,
+    val before: String,
+    val matched: String,
+    val after: String
+)
+
+/**
+ * Build the renderable [ReferenceEntry] list for [locations], resolving line
+ * previews from the document [resolveDoc] returns for each URI (null when the
+ * file is not open).
+ *
+ * Ports upstream's per-entry construction in `createReferencePanel`: file names
+ * have the [common prefix][findCommonPrefix] stripped, and for open files the
+ * matched text plus up to ~50 chars of leading and a trailing window of context
+ * are sliced out of the reference's line.
+ */
+internal fun buildReferenceEntries(
+    locations: List<ReferenceLocation>,
+    resolveDoc: (String) -> Text?
+): List<ReferenceEntry> {
+    val prefixLen = findCommonPrefix(locations.map { it.uri })
+    return locations.map { loc ->
+        val fileName = loc.uri.substring(prefixLen)
+        val doc = resolveDoc(loc.uri)
+        if (doc == null) {
+            ReferenceEntry(loc, fileName, lineNumber = null, before = "", matched = "", after = "")
+        } else {
+            val from = fromPosition(loc.range.start, doc)
+            val to = fromPosition(loc.range.end, doc).coerceAtLeast(from)
+            val line = doc.lineAt(DocPos(from))
+            val lineStart = line.from.value
+            val colFrom = (from - lineStart).coerceIn(0, line.length)
+            val colTo = (to - lineStart).coerceIn(colFrom, line.length)
+            val before = line.text.substring(maxOf(0, colFrom - 50), colFrom)
+            val matched = line.text.substring(colFrom, colTo)
+            val after = line.text.substring(
+                colTo,
+                minOf(line.length, maxOf(colTo, 100 - before.length))
+            )
+            ReferenceEntry(loc, fileName, line.number.value, before, matched, after)
+        }
+    }
+}
+
+/**
+ * Whether the server advertises the `referencesProvider` capability.
+ *
+ * Matches upstream's `hasCapability("referencesProvider") === false` gating:
+ * proceed when the client is not yet initialized (capabilities unknown) or when
+ * the capability is present and truthy; bail only when it is explicitly absent or
+ * `false`.
+ */
+private fun ReferenceServer.supportsReferences(): Boolean {
+    val caps: ServerCapabilities = client.serverCapabilities ?: return true
+    return hasProvider(caps.referencesProvider)
+}
+
+/**
+ * Ask the server to locate all references to the symbol at the cursor and, when
+ * any are returned, show them in a panel.
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `findReferences` command:
+ * - resolves this editor's [ReferenceServer] binding from the [referenceServer]
+ *   facet; returns false (command not handled) when none is installed,
+ * - returns false when the server explicitly lacks `referencesProvider`,
+ * - otherwise flushes pending edits ([LSPClient.sync]), issues
+ *   `textDocument/references` at the cursor (with `includeDeclaration = true`,
+ *   matching upstream), and opens the [reference panel][findReferencesExtension]
+ *   with the resulting locations.
+ *
+ * The suspending work runs on the [client scope][LSPClient.scope] (not the
+ * session's) because navigating to a result may target a different editor session
+ * that must outlive the requesting one. Cancellation of the in-flight LSP call is
+ * cooperative through structured concurrency, consistent with the other LSP
+ * features.
+ *
+ * @return true when the command is handled (a binding exists and the server
+ *   advertises the capability), so the keymap stops here; false to fall through.
+ */
+fun findReferences(session: EditorSession): Boolean {
+    val binding = session.state.facet(referenceServer) ?: return false
+    if (!binding.supportsReferences()) return false
+    val pos = session.state.selection.main.head.value
+    binding.client.scope.launch {
+        binding.client.sync()
+        val position = toPosition(pos, session.state.doc)
+        val response = try {
+            binding.client.server.textDocumentReferences(
+                ReferenceParams(
+                    textDocument = TextDocumentIdentifier(uri = binding.uri),
+                    position = position,
+                    context = ReferenceContext(includeDeclaration = true)
+                )
+            )
+        } catch (e: CancellationException) {
+            throw e
+        }
+        val locations = toReferenceLocations(response)
+        if (locations.isEmpty()) return@launch
+        session.dispatch(
+            TransactionSpec(
+                effects = listOf(setReferencePanel.of(ReferencePanelState(locations)))
+            )
+        )
+    }
+    return true
+}
+
+/**
+ * Close the reference panel, if it is open.
+ *
+ * Ports upstream's `closeReferencePanel` command: returns false (so a keymap can
+ * fall through) when no panel is open, otherwise clears the
+ * [referencePanel][referencePanel] state and returns true.
+ */
+fun closeReferencePanel(session: EditorSession): Boolean {
+    if (session.state.field(referencePanel, require = false) == null) return false
+    session.dispatch(
+        TransactionSpec(
+            effects = listOf(setReferencePanel.of(null))
+        )
+    )
+    return true
+}
+
+/**
+ * Navigate to the reference [entry], using the shared [navigateToLocation] helper
+ * (same-file vs cross-file resolution, position mapping, scroll into view).
+ *
+ * Ports upstream's reference-panel `showReference`.
+ */
+internal fun showReference(binding: ReferenceServer, entry: ReferenceEntry) {
+    navigateToLocation(
+        client = binding.client,
+        sourceUri = binding.uri,
+        targetUri = entry.location.uri,
+        position = entry.location.range.start,
+        userEvent = "select.reference"
+    )
+}
+
+/**
+ * The default find-references key bindings, matching upstream's
+ * `findReferencesKeymap`: `Shift-F12` runs [findReferences] (preventing the
+ * default action) and `Escape` runs [closeReferencePanel].
+ */
+val findReferencesKeymap: List<KeyBinding> = listOf(
+    KeyBinding(key = "Shift-F12", run = ::findReferences, preventDefault = true),
+    KeyBinding(key = "Escape", run = ::closeReferencePanel)
+)
+
+/**
+ * Build the editor [Extension] that enables LSP find-references for the file at
+ * [uri] served by [client].
+ *
+ * Mirrors how upstream `@codemirror/lsp-client` wires find-references: it carries
+ * this editor's per-editor binding through the [referenceServer] facet so
+ * [findReferences] resolves its client/uri from the session it runs in (no
+ * module-level mutable state), registers the reference-panel [StateField] plus
+ * its `showPanels` provider, and — unless [keymap] is false — installs the
+ * [findReferencesKeymap] (`Shift-F12` / `Escape`) at high precedence.
+ *
+ * @param client The LSP client wrapping the language server.
+ * @param uri The document URI for this editor's file.
+ * @param keymap When true (the default), the [findReferencesKeymap] bindings are
+ *   installed at high precedence. Pass false to bind the commands yourself.
+ */
+fun findReferencesExtension(client: LSPClient, uri: String, keymap: Boolean = true): Extension {
+    val extensions = buildList {
+        add(referenceServer.of(ReferenceServer(client, uri)))
+        add(referencePanel)
+        add(referencePanelProvider())
+        if (keymap) add(Prec.high(keymapFacet.of(findReferencesKeymap)))
+    }
+    return ExtensionList(extensions)
+}

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerReferencesTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerReferencesTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.lsp.Location
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.LanguageServer
+import java.lang.reflect.Proxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class ServerReferencesTest {
+
+    private fun pos(line: Int, char: Int): Position =
+        Position(line = line.toUInt(), character = char.toUInt())
+
+    private fun range(startLine: Int, startChar: Int, endLine: Int, endChar: Int): Range =
+        Range(start = pos(startLine, startChar), end = pos(endLine, endChar))
+
+    private fun loc(uri: String, startChar: Int, endChar: Int, line: Int = 0): Location =
+        Location(uri = uri, range = range(line, startChar, line, endChar))
+
+    private fun stubServer(): LanguageServer = Proxy.newProxyInstance(
+        LanguageServer::class.java.classLoader,
+        arrayOf(LanguageServer::class.java)
+    ) { _, method, _ ->
+        error("stub LanguageServer.${method.name} should not be called in this test")
+    } as LanguageServer
+
+    // --- response -> reference locations ---
+
+    @Test
+    fun mapsTypedLocationListPreservingOrder() {
+        val response = listOf(
+            loc("file:///a.kt", 0, 3),
+            loc("file:///b.kt", 4, 7)
+        )
+        val refs = toReferenceLocations(response)
+        assertEquals(2, refs.size)
+        assertEquals("file:///a.kt", refs[0].uri)
+        assertEquals(0u, refs[0].range.start.character)
+        assertEquals("file:///b.kt", refs[1].uri)
+    }
+
+    @Test
+    fun mapsEmptyResponseToEmptyList() {
+        assertTrue(toReferenceLocations(emptyList()).isEmpty())
+    }
+
+    // --- findCommonPrefix (ports upstream) ---
+
+    @Test
+    fun commonPrefixTrimsToLastSlash() {
+        val prefix = findCommonPrefix(
+            listOf("file:///proj/src/a.kt", "file:///proj/src/b.kt")
+        )
+        // shared up to "file:///proj/src/" -> length 17
+        assertEquals("file:///proj/src/".length, prefix)
+        assertEquals(
+            "a.kt",
+            "file:///proj/src/a.kt".substring(prefix)
+        )
+    }
+
+    @Test
+    fun commonPrefixDivergingDirectories() {
+        val prefix = findCommonPrefix(
+            listOf("file:///proj/src/a.kt", "file:///proj/test/b.kt")
+        )
+        assertEquals("file:///proj/".length, prefix)
+    }
+
+    @Test
+    fun commonPrefixSingleUriIsWholeDirectory() {
+        val prefix = findCommonPrefix(listOf("file:///proj/src/a.kt"))
+        assertEquals("file:///proj/src/".length, prefix)
+    }
+
+    @Test
+    fun commonPrefixEmptyListIsZero() {
+        assertEquals(0, findCommonPrefix(emptyList()))
+    }
+
+    // --- buildReferenceEntries: preview + line numbers ---
+
+    @Test
+    fun buildsPreviewWithMatchedSpanForOpenFile() {
+        val doc = Text.of(listOf("val foo = 1", "println(foo)"))
+        // "foo" on line 1 (0-based), chars 8..11
+        val locs = listOf(ReferenceLocation("file:///a.kt", range(1, 8, 1, 11)))
+        val entries = buildReferenceEntries(locs) { if (it == "file:///a.kt") doc else null }
+        val entry = entries.single()
+        assertEquals("a.kt", entry.fileName)
+        assertEquals(2, entry.lineNumber) // 1-based
+        assertEquals("println(", entry.before)
+        assertEquals("foo", entry.matched)
+        assertEquals(")", entry.after)
+    }
+
+    @Test
+    fun buildsEntryWithoutPreviewWhenFileNotOpen() {
+        val locs = listOf(ReferenceLocation("file:///closed.kt", range(0, 0, 0, 4)))
+        val entries = buildReferenceEntries(locs) { null }
+        val entry = entries.single()
+        assertNull(entry.lineNumber)
+        assertEquals("", entry.matched)
+        assertEquals("", entry.before)
+        assertEquals("", entry.after)
+    }
+
+    // --- navigation target resolution (same-file) ---
+
+    @Test
+    fun showReferenceMovesSelectionForSameFile() {
+        val client = LSPClient(stubServer())
+        val state = EditorState.create(
+            doc = "val foo = 1\nprintln(foo)\n",
+            extensions = findReferencesExtension(client, "file:///a.kt", keymap = false)
+        )
+        val session = EditorSession(state)
+        client.workspace.openFile("file:///a.kt", "kotlin", session)
+
+        val entry = buildReferenceEntries(
+            listOf(ReferenceLocation("file:///a.kt", range(1, 8, 1, 11)))
+        ) { session.state.doc }.single()
+
+        val binding = state.facet(referenceServer)!!
+        showReference(binding, entry)
+        // "val foo = 1\n" = 12, +8 = 20
+        assertEquals(20, session.state.selection.main.head.value)
+    }
+
+    @Test
+    fun showReferenceNoOpsForUnopenedCrossFile() {
+        val client = LSPClient(stubServer())
+        val state = EditorState.create(
+            doc = "x",
+            extensions = findReferencesExtension(client, "file:///a.kt", keymap = false)
+        )
+        val session = EditorSession(state)
+        client.workspace.openFile("file:///a.kt", "kotlin", session)
+        val binding = state.facet(referenceServer)!!
+        val entry = ReferenceEntry(
+            ReferenceLocation("file:///other.kt", range(0, 0, 0, 1)),
+            "other.kt", 1, "", "", ""
+        )
+        // Default single-file workspace cannot display an unopened file: no crash, no move.
+        showReference(binding, entry)
+        assertEquals(0, session.state.selection.main.head.value)
+    }
+
+    // --- panel open/close ---
+
+    @Test
+    fun closeReferencePanelReturnsFalseWhenClosed() {
+        val client = LSPClient(stubServer())
+        val state = EditorState.create(
+            doc = "x",
+            extensions = findReferencesExtension(client, "file:///a.kt", keymap = false)
+        )
+        val session = EditorSession(state)
+        assertNull(session.state.field(referencePanel, require = false))
+        assertFalse(closeReferencePanel(session))
+    }
+
+    @Test
+    fun setReferencePanelEffectOpensAndCloses() {
+        val client = LSPClient(stubServer())
+        val state = EditorState.create(
+            doc = "x",
+            extensions = findReferencesExtension(client, "file:///a.kt", keymap = false)
+        )
+        val session = EditorSession(state)
+        session.dispatch(
+            com.monkopedia.kodemirror.state.TransactionSpec(
+                effects = listOf(
+                    setReferencePanel.of(
+                        ReferencePanelState(listOf(ReferenceLocation("file:///a.kt", range(0, 0, 0, 1))))
+                    )
+                )
+            )
+        )
+        assertEquals(1, session.state.field(referencePanel, require = false)?.locations?.size)
+        assertTrue(closeReferencePanel(session))
+        assertNull(session.state.field(referencePanel, require = false))
+    }
+
+    // --- capability gating + no-binding ---
+
+    @Test
+    fun findReferencesReturnsFalseWithoutBinding() {
+        val state = EditorState.create(doc = "x")
+        val session = EditorSession(state)
+        assertFalse(findReferences(session))
+    }
+
+    @Test
+    fun editorWithoutFindReferencesHasNullBinding() {
+        val state = EditorState.create(doc = "x")
+        assertNull(state.facet(referenceServer))
+    }
+
+    // --- multi-instance: per-editor binding ---
+
+    @Test
+    fun twoEditorsKeepIndependentReferenceBindings() {
+        val clientA = LSPClient(stubServer())
+        val clientB = LSPClient(stubServer())
+
+        val stateA = EditorState.create(
+            doc = "a",
+            extensions = findReferencesExtension(clientA, "file:///a.kt", keymap = false)
+        )
+        val stateB = EditorState.create(
+            doc = "b",
+            extensions = findReferencesExtension(clientB, "file:///b.kt", keymap = false)
+        )
+
+        val bindingA = stateA.facet(referenceServer)
+        val bindingB = stateB.facet(referenceServer)
+
+        assertEquals("file:///a.kt", bindingA?.uri)
+        assertSame(clientA, bindingA?.client)
+        assertEquals("file:///b.kt", bindingB?.uri)
+        assertSame(clientB, bindingB?.client)
+        assertNotSame(bindingA, bindingB)
+        assertSame(clientA, stateA.facet(referenceServer)?.client)
+    }
+
+    // --- keymap ---
+
+    @Test
+    fun keymapBindsShiftF12AndEscape() {
+        assertEquals(2, findReferencesKeymap.size)
+        val find = findReferencesKeymap[0]
+        assertEquals("Shift-F12", find.key)
+        assertTrue(find.preventDefault)
+        val close = findReferencesKeymap[1]
+        assertEquals("Escape", close.key)
+    }
+}


### PR DESCRIPTION
## Summary
Eighth sub-issue of the LSP port epic #26. Closes #42. Ports upstream `findReferences`/`closeReferencePanel` + the reference panel. Builds on #41 (reuses navigation).

## What it does
- `findReferences` command: gates on `referencesProvider` (proceeds when caps unknown, per upstream's `=== false`), `client.sync()`, requests `textDocument/references` at the cursor (`includeDeclaration=true`), stores the `List<Location>` in a per-editor StateField and opens a panel. Suspend work on `client.scope`; cooperative cancellation.
- **Reference panel** (via `:view`'s `showPanels`, mirroring `:lint`): references grouped by file (common-prefix-trimmed), line number + ~50-char context with the matched span bolded; clicking navigates via the shared `navigateToLocation` helper (same-file → selection + scrollIntoView; cross-file → `Workspace.displayFile`). `closeReferencePanel` / `[Close]` clears it.
- `findReferencesKeymap`: `Shift-F12` → findReferences, `Escape` → close (matches upstream).

## Refactor
Extracted a shared `navigateToLocation` helper (new `Navigation.kt`) and pointed #41's `ServerDefinition` navigation at it — same-module dedup; `ServerDefinitionTest` still passes in the same run.

## Per-editor design (no multi-instance bug)
Client/uri via the `referenceServer` Facet; panel results in the per-editor `referencePanel` StateField; commands resolve via session state — no module-level mutable per-editor state. Test `twoEditorsKeepIndependentReferenceBindings` guards it.

## Public API added (tier-2)
- `fun findReferences(session): Boolean`, `fun closeReferencePanel(session): Boolean`
- `fun findReferencesExtension(client, uri, keymap = true): Extension`
- `val findReferencesKeymap: List<KeyBinding>`
- `data class ReferenceLocation(uri: String, range: Range)`
(No other modules touched.)

## Deviations (documented)
- References API is a typed `List<Location>` (no JSON union) → straightforward map.
- No live `WorkspaceMapping` held for the panel; previews/navigation resolve LSP positions against the current target doc at click time (same approach as #41). Cross-file opening depends on the consumer's `Workspace.displayFile` (default no-op for non-open files).
- In-panel keyboard list nav (Arrow/Enter) from upstream's DOM panel not reproduced (click nav + visual selection are; Escape-to-close handled via keymap).

## Verification
`:lsp-client:jvmTest` (16 tests incl. multi-instance guard + the unchanged definition tests), `compileKotlinJvm`/`compileKotlinWasmJs`/`compileDebugKotlinAndroid`, `:lsp-client:apiCheck` — all green. spotless/ktlint applied; apiDump committed. Apple/native not cross-compiled on Linux.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :lsp-client:jvmTest :lsp-client:compileKotlinWasmJs :lsp-client:compileDebugKotlinAndroid :lsp-client:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`