### PR TITLE
LSP document formatting (#44)

### DIFF
--- a/lsp-client/api/android/lsp-client.api
+++ b/lsp-client/api/android/lsp-client.api
@@ -141,6 +141,13 @@ public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerFormatKt {
+	public static final fun formatDocument (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun formatDocumentExtension (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Z)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun formatDocumentExtension$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static final fun getFormatKeymap ()Ljava/util/List;
+}
+
 public final class com/monkopedia/kodemirror/lsp/ServerHoverKt {
 	public static final fun serverHover (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;J)Lcom/monkopedia/kodemirror/state/Extension;
 	public static synthetic fun serverHover$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;JILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;

--- a/lsp-client/api/jvm/lsp-client.api
+++ b/lsp-client/api/jvm/lsp-client.api
@@ -141,6 +141,13 @@ public final class com/monkopedia/kodemirror/lsp/ServerDiagnosticsKt {
 	public static final fun serverDiagnostics ()Lcom/monkopedia/kodemirror/state/Extension;
 }
 
+public final class com/monkopedia/kodemirror/lsp/ServerFormatKt {
+	public static final fun formatDocument (Lcom/monkopedia/kodemirror/view/EditorSession;)Z
+	public static final fun formatDocumentExtension (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;Z)Lcom/monkopedia/kodemirror/state/Extension;
+	public static synthetic fun formatDocumentExtension$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;
+	public static final fun getFormatKeymap ()Ljava/util/List;
+}
+
 public final class com/monkopedia/kodemirror/lsp/ServerHoverKt {
 	public static final fun serverHover (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;J)Lcom/monkopedia/kodemirror/state/Extension;
 	public static synthetic fun serverHover$default (Lcom/monkopedia/kodemirror/lsp/LSPClient;Ljava/lang/String;JILjava/lang/Object;)Lcom/monkopedia/kodemirror/state/Extension;

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/LanguageServerSupport.kt
@@ -62,8 +62,11 @@ fun languageServerSupport(client: LSPClient, uri: String, languageId: String): E
             findReferencesExtension(client, uri),
             // Rename the symbol at the cursor (textDocument/rename) via an input
             // prompt, applying the resulting WorkspaceEdit; F2 keymap — see #43.
-            renameSymbolExtension(client, uri)
-            // TODO(#44): formatting
+            renameSymbolExtension(client, uri),
+            // Format the whole document (textDocument/formatting), applying the
+            // returned edits as a single transaction; Shift-Alt-f keymap — see
+            // #44.
+            formatDocumentExtension(client, uri)
             // TODO(#45): code actions
         )
     )

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerFormat.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerFormat.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.Extension
+import com.monkopedia.kodemirror.state.ExtensionList
+import com.monkopedia.kodemirror.state.Facet
+import com.monkopedia.kodemirror.state.Prec
+import com.monkopedia.kodemirror.state.TransactionSpec
+import com.monkopedia.kodemirror.state.define
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.kodemirror.view.KeyBinding
+import com.monkopedia.kodemirror.view.keymap as keymapFacet
+import com.monkopedia.lsp.DocumentFormattingParams
+import com.monkopedia.lsp.FormattingOptions
+import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.TextDocumentIdentifier
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+/**
+ * The per-editor formatting binding: the [client] wrapping the language server
+ * and the document [uri] for this editor's file.
+ *
+ * Carried through state by [formatServer] so [formatDocument] reads its
+ * configuration from the editor session it runs in rather than capturing it at
+ * install time. This is what keeps the command per-editor when multiple editors
+ * are open — there is no module-level mutable per-editor state (mirroring the
+ * per-editor design used by [renameServer]/[definitionServer]).
+ */
+internal data class FormatServer(val client: LSPClient, val uri: String)
+
+/**
+ * The [Facet] carrying the per-editor [FormatServer] binding.
+ *
+ * Combines to the last non-null value, so an editor that installs
+ * [formatDocumentExtension] gets its own [client][FormatServer.client] /
+ * [uri][FormatServer.uri] while editors without it see null (and [formatDocument]
+ * no-ops, returning false).
+ */
+internal val formatServer: Facet<FormatServer?, FormatServer?> =
+    Facet.define(combine = { values -> values.lastOrNull { it != null } })
+
+/**
+ * Whether the server advertises the `documentFormattingProvider` capability.
+ *
+ * Matches upstream's `hasCapability("documentFormattingProvider")` gating:
+ * proceed when the client is not yet initialized (capabilities unknown) or when
+ * the capability is present and truthy; bail only when it is explicitly absent or
+ * `false`.
+ */
+private fun FormatServer.supportsFormatting(): Boolean {
+    val caps: ServerCapabilities = client.serverCapabilities ?: return true
+    return hasProvider(caps.documentFormattingProvider)
+}
+
+/**
+ * Derive the LSP [FormattingOptions] for [state].
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `formatDocument` option derivation:
+ * - [tabSize][FormattingOptions.tabSize] comes from the editor's
+ *   [tabSize][EditorState.tabSize] facet (default 4),
+ * - [insertSpaces][FormattingOptions.insertSpaces] defaults to true.
+ *
+ * **Deviation from upstream:** upstream computes `insertSpaces` from
+ * `!/\t/.test(state.facet(indentUnit))` — i.e. whether the language module's
+ * indent unit contains a tab. The `:lsp-client` module does not depend on
+ * `:language`, so the indent unit is not readily available here; per the issue
+ * we fall back to the sensible default `insertSpaces = true` (spaces) rather than
+ * pull in a module dependency just to inspect the indent string.
+ */
+internal fun formattingOptions(state: EditorState): FormattingOptions = FormattingOptions(
+    tabSize = state.tabSize.coerceAtLeast(1).toUInt(),
+    insertSpaces = true
+)
+
+/**
+ * Format the whole document via the language server.
+ *
+ * Ports upstream `@codemirror/lsp-client`'s `formatDocument` command:
+ * - resolves this editor's [FormatServer] binding from the [formatServer] facet;
+ *   returns false (command not handled) when none is installed,
+ * - returns false when the server explicitly lacks `documentFormattingProvider`,
+ * - otherwise flushes pending edits ([LSPClient.sync]), issues
+ *   `textDocument/formatting` with the derived [FormattingOptions]
+ *   ([formattingOptions]), and applies the returned `TextEdit[]` as a single
+ *   `format` [TransactionSpec] (via the shared [textEditsToChangeSpec]).
+ *
+ * The suspending work runs on the [client scope][LSPClient.scope] (consistent
+ * with the other LSP commands) so the request and its edit application outlive
+ * the synchronous command return. Cancellation of the in-flight LSP call is
+ * cooperative through structured concurrency.
+ *
+ * **Deviation from upstream:** range formatting and on-type formatting are out of
+ * scope for this command — only whole-document formatting is implemented (see
+ * issue #44).
+ *
+ * @return true when the command is handled (a binding exists and the server
+ *   advertises the capability), so the keymap stops here; false to fall through.
+ */
+fun formatDocument(session: EditorSession): Boolean {
+    val binding = session.state.facet(formatServer) ?: return false
+    if (!binding.supportsFormatting()) return false
+    val client = binding.client
+    val targetSession = client.workspace.getFile(binding.uri)?.session ?: session
+    val options = formattingOptions(session.state)
+    client.scope.launch {
+        client.sync()
+        val edits = try {
+            client.server.textDocumentFormatting(
+                DocumentFormattingParams(
+                    textDocument = TextDocumentIdentifier(uri = binding.uri),
+                    options = options
+                )
+            )
+        } catch (e: CancellationException) {
+            throw e
+        }
+        val spec = textEditsToChangeSpec(edits, targetSession.state.doc, mapping = null)
+            ?: return@launch
+        targetSession.dispatch(TransactionSpec(changes = spec, userEvent = "format"))
+    }
+    return true
+}
+
+/**
+ * The default formatting key bindings, matching upstream's `formatKeymap`:
+ * `Shift-Alt-f` runs [formatDocument] (preventing the default action).
+ */
+val formatKeymap: List<KeyBinding> = listOf(
+    KeyBinding(key = "Shift-Alt-f", run = ::formatDocument, preventDefault = true)
+)
+
+/**
+ * Build the editor [Extension] that enables LSP whole-document formatting for the
+ * file at [uri] served by [client].
+ *
+ * Mirrors how upstream `@codemirror/lsp-client` wires formatting: it carries this
+ * editor's per-editor binding through the [formatServer] facet so [formatDocument]
+ * resolves its client/uri from the session it runs in (no module-level mutable
+ * state), and — unless [keymap] is false — installs the [formatKeymap]
+ * (`Shift-Alt-f`) at high precedence.
+ *
+ * @param client The LSP client wrapping the language server.
+ * @param uri The document URI for this editor's file.
+ * @param keymap When true (the default), the [formatKeymap] binding is installed
+ *   at high precedence. Pass false to bind [formatDocument] yourself.
+ */
+fun formatDocumentExtension(client: LSPClient, uri: String, keymap: Boolean = true): Extension {
+    val extensions = buildList {
+        add(formatServer.of(FormatServer(client, uri)))
+        if (keymap) add(Prec.high(keymapFacet.of(formatKeymap)))
+    }
+    return ExtensionList(extensions)
+}

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerRename.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerRename.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import com.monkopedia.kodemirror.state.ChangeSpec
 import com.monkopedia.kodemirror.state.DocPos
 import com.monkopedia.kodemirror.state.Extension
 import com.monkopedia.kodemirror.state.ExtensionList
@@ -52,9 +51,7 @@ import com.monkopedia.kodemirror.state.Prec
 import com.monkopedia.kodemirror.state.StateEffect
 import com.monkopedia.kodemirror.state.StateEffectType
 import com.monkopedia.kodemirror.state.StateField
-import com.monkopedia.kodemirror.state.Text
 import com.monkopedia.kodemirror.state.TransactionSpec
-import com.monkopedia.kodemirror.state.asInsert
 import com.monkopedia.kodemirror.state.define
 import com.monkopedia.kodemirror.view.EditorSession
 import com.monkopedia.kodemirror.view.KeyBinding
@@ -381,43 +378,6 @@ internal fun collectFileEdits(edit: WorkspaceEdit): Map<String, List<TextEdit>> 
         }
     }
     return result
-}
-
-/**
- * Convert a file's [edits] to a single multi-change [ChangeSpec] against [doc].
- *
- * Each edit's LSP range is resolved to `[from, to)` offsets. For the requesting
- * file a live [mapping] (the in-flight [WorkspaceMapping]) is applied so offsets
- * stay valid under concurrent edits, matching upstream's `mapping.mapPosition`;
- * other files resolve directly against their current document.
- *
- * The edits are emitted highest-offset-first (by resolved `from`) so that an
- * earlier edit's offsets are never invalidated by the application of a later one
- * — the same ordering discipline the incremental document sync uses (see
- * [buildContentChanges]). Returns null when there is nothing to change.
- */
-internal fun textEditsToChangeSpec(
-    edits: List<TextEdit>,
-    doc: Text,
-    mapping: WorkspaceMapping?
-): ChangeSpec? {
-    if (edits.isEmpty()) return null
-    val resolved = edits.map { e ->
-        val from: Int
-        val to: Int
-        if (mapping != null) {
-            from = mapping.mapPosition(e.range.start, doc)
-            to = mapping.mapPosition(e.range.end, doc)
-        } else {
-            from = fromPosition(e.range.start, doc)
-            to = fromPosition(e.range.end, doc)
-        }
-        Triple(minOf(from, to), maxOf(from, to), e.newText)
-    }.sortedByDescending { it.first }
-    val specs = resolved.map { (from, to, insert) ->
-        ChangeSpec.Single(from = DocPos(from), to = DocPos(to), insert = insert.asInsert())
-    }
-    return ChangeSpec.Multi(specs)
 }
 
 /**

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/TextEdits.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/TextEdits.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.ChangeSpec
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.kodemirror.state.asInsert
+import com.monkopedia.lsp.TextEdit
+
+/**
+ * Convert a file's [edits] to a single multi-change [ChangeSpec] against [doc].
+ *
+ * Each edit's LSP range is resolved to `[from, to)` offsets. For the requesting
+ * file a live [mapping] (the in-flight [WorkspaceMapping]) is applied so offsets
+ * stay valid under concurrent edits, matching upstream's `mapping.mapPosition`;
+ * other files (and callers with no in-flight request, e.g. document formatting)
+ * resolve directly against the current document by passing `mapping = null`.
+ *
+ * The edits are emitted highest-offset-first (by resolved `from`) so that an
+ * earlier edit's offsets are never invalidated by the application of a later one
+ * — the same ordering discipline the incremental document sync uses (see
+ * [buildContentChanges]). Returns null when there is nothing to change.
+ *
+ * Shared by [applyWorkspaceEdit] (rename) and [formatDocument] (whole-document
+ * formatting): both consume an LSP `TextEdit[]` against a single document, so the
+ * range→offset resolution and the highest-offset-first ordering live here once.
+ */
+internal fun textEditsToChangeSpec(
+    edits: List<TextEdit>,
+    doc: Text,
+    mapping: WorkspaceMapping?
+): ChangeSpec? {
+    if (edits.isEmpty()) return null
+    val resolved = edits.map { e ->
+        val from: Int
+        val to: Int
+        if (mapping != null) {
+            from = mapping.mapPosition(e.range.start, doc)
+            to = mapping.mapPosition(e.range.end, doc)
+        } else {
+            from = fromPosition(e.range.start, doc)
+            to = fromPosition(e.range.end, doc)
+        }
+        Triple(minOf(from, to), maxOf(from, to), e.newText)
+    }.sortedByDescending { it.first }
+    val specs = resolved.map { (from, to, insert) ->
+        ChangeSpec.Single(from = DocPos(from), to = DocPos(to), insert = insert.asInsert())
+    }
+    return ChangeSpec.Multi(specs)
+}

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerFormatTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerFormatTest.kt
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.Text
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.lsp.BooleanOr
+import com.monkopedia.lsp.InitializeResult
+import com.monkopedia.lsp.LanguageServer
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.TextEdit
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.resume
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+class ServerFormatTest {
+
+    private fun pos(line: Int, char: Int): Position =
+        Position(line = line.toUInt(), character = char.toUInt())
+
+    private fun range(startLine: Int, startChar: Int, endLine: Int, endChar: Int): Range =
+        Range(start = pos(startLine, startChar), end = pos(endLine, endChar))
+
+    private fun edit(startLine: Int, startChar: Int, endLine: Int, endChar: Int, newText: String) =
+        TextEdit(range = range(startLine, startChar, endLine, endChar), newText = newText)
+
+    /**
+     * A do-nothing [LanguageServer] used only to construct distinct [LSPClient]s;
+     * [formatDocumentExtension] merely stores the client in the [formatServer]
+     * facet, it does not contact the server at install time.
+     */
+    private fun stubServer(): LanguageServer = Proxy.newProxyInstance(
+        LanguageServer::class.java.classLoader,
+        arrayOf(LanguageServer::class.java)
+    ) { _, method, _ ->
+        error("stub LanguageServer.${method.name} should not be called in this test")
+    } as LanguageServer
+
+    /**
+     * A [LanguageServer] that initializes (advertising [documentFormatting] via
+     * `documentFormattingProvider`) and answers `textDocument/formatting` with
+     * [editsToReturn]. All other suspend methods no-op via a coroutine-aware
+     * reflective handler. Used to exercise the async [formatDocument] path
+     * end-to-end.
+     */
+    private fun formattingServer(
+        documentFormatting: Boolean,
+        editsToReturn: List<TextEdit>
+    ): LanguageServer {
+        val handler = InvocationHandler { _, method: Method, args: Array<Any?>? ->
+            // Suspend methods receive a trailing Continuation; complete it
+            // synchronously with the result for that method.
+            @Suppress("UNCHECKED_CAST")
+            val continuation = args?.lastOrNull() as? Continuation<Any?>
+            val result: Any? = when (method.name) {
+                "initialize" -> InitializeResult(
+                    capabilities = ServerCapabilities(
+                        documentFormattingProvider = BooleanOr.BooleanValue(documentFormatting)
+                    )
+                )
+                "initialized" -> Unit
+                "textDocumentFormatting" -> editsToReturn
+                else -> Unit
+            }
+            continuation?.resume(result)
+            COROUTINE_SUSPENDED
+        }
+        return Proxy.newProxyInstance(
+            LanguageServer::class.java.classLoader,
+            arrayOf(LanguageServer::class.java),
+            handler
+        ) as LanguageServer
+    }
+
+    private fun openSession(client: LSPClient, doc: String, uri: String): EditorSession {
+        val state = EditorState.create(
+            doc = doc,
+            extensions = formatDocumentExtension(client, uri, keymap = false)
+        )
+        val session = EditorSession(state)
+        client.workspace.openFile(uri, "kotlin", session)
+        return session
+    }
+
+    /** Run [block], then wait (up to a second) for the session doc to reach [expected]. */
+    private fun awaitDoc(session: EditorSession, expected: String, block: () -> Unit) =
+        runBlocking {
+            block()
+            withTimeout(2000) {
+                while (session.state.doc.toString() != expected) {
+                    kotlinx.coroutines.yield()
+                }
+            }
+            assertEquals(expected, session.state.doc.toString())
+        }
+
+    // --- FormattingOptions derivation ---
+
+    @Test
+    fun formattingOptionsDerivesTabSizeFromState() {
+        val state = EditorState.create(
+            doc = "x",
+            extensions = EditorState.tabSize.of(2)
+        )
+        val options = formattingOptions(state)
+        assertEquals(2u, options.tabSize)
+        assertTrue(options.insertSpaces)
+    }
+
+    @Test
+    fun formattingOptionsDefaultTabSize() {
+        // Default tabSize facet value is 4.
+        val options = formattingOptions(EditorState.create(doc = "x"))
+        assertEquals(4u, options.tabSize)
+        assertTrue(options.insertSpaces)
+    }
+
+    // --- textEditsToChangeSpec applied to a document (apply TextEdits -> expected doc) ---
+
+    @Test
+    fun formatEditsRewriteWholeDocument() {
+        val doc = Text.of(listOf("val   x=1"))
+        // Server replaces the whole line with formatted text.
+        val edits = listOf(edit(0, 0, 0, 9, "val x = 1"))
+        val spec = textEditsToChangeSpec(edits, doc, mapping = null)!!
+        val result = EditorState.create(doc = "val   x=1").changes(spec).apply(doc)
+        assertEquals("val x = 1", result.toString())
+    }
+
+    @Test
+    fun formatEditsApplyMultipleHighestOffsetFirst() {
+        val doc = Text.of(listOf("a;b;c"))
+        val edits = listOf(
+            edit(0, 1, 0, 2, " ; "),
+            edit(0, 3, 0, 4, " ; ")
+        )
+        val spec = textEditsToChangeSpec(edits, doc, mapping = null)!!
+        val result = EditorState.create(doc = "a;b;c").changes(spec).apply(doc)
+        assertEquals("a ; b ; c", result.toString())
+    }
+
+    // --- formatDocument command gating ---
+
+    @Test
+    fun formatDocumentReturnsFalseWithoutBinding() {
+        val state = EditorState.create(doc = "x")
+        val session = EditorSession(state)
+        assertFalse(formatDocument(session))
+    }
+
+    @Test
+    fun formatDocumentReturnsFalseWhenCapabilityAbsent() {
+        val client =
+            LSPClient(formattingServer(documentFormatting = false, editsToReturn = listOf()))
+        // Initialize so serverCapabilities is populated (capability explicitly false).
+        runBlocking { client.initialize() }
+        val session = openSession(client, "val x=1", "file:///a.kt")
+        assertFalse(formatDocument(session))
+    }
+
+    @Test
+    fun formatDocumentProceedsWhenCapabilityPresent() {
+        val client = LSPClient(
+            formattingServer(
+                documentFormatting = true,
+                editsToReturn = listOf(edit(0, 0, 0, 7, "val x = 1"))
+            )
+        )
+        runBlocking { client.initialize() }
+        val session = openSession(client, "val x=1", "file:///a.kt")
+        awaitDoc(session, "val x = 1") {
+            assertTrue(formatDocument(session))
+        }
+    }
+
+    @Test
+    fun formatDocumentProceedsWhenUninitialized() {
+        // Not initialized: capabilities unknown -> command is handled (returns
+        // true), matching upstream's "proceed when capabilities unknown".
+        val client = LSPClient(
+            formattingServer(
+                documentFormatting = true,
+                editsToReturn = listOf(edit(0, 0, 0, 7, "val x = 1"))
+            )
+        )
+        val session = openSession(client, "val x=1", "file:///a.kt")
+        assertTrue(formatDocument(session))
+    }
+
+    // --- multi-instance: per-editor binding ---
+
+    @Test
+    fun editorWithoutFormatExtensionHasNullBinding() {
+        val state = EditorState.create(doc = "x")
+        assertNull(state.facet(formatServer))
+    }
+
+    @Test
+    fun twoEditorsKeepIndependentFormatBindings() {
+        val clientA = LSPClient(stubServer())
+        val clientB = LSPClient(stubServer())
+
+        val stateA = EditorState.create(
+            doc = "a",
+            extensions = formatDocumentExtension(clientA, "file:///a.kt", keymap = false)
+        )
+        val stateB = EditorState.create(
+            doc = "b",
+            extensions = formatDocumentExtension(clientB, "file:///b.kt", keymap = false)
+        )
+
+        val bindingA = stateA.facet(formatServer)
+        val bindingB = stateB.facet(formatServer)
+
+        assertEquals("file:///a.kt", bindingA?.uri)
+        assertSame(clientA, bindingA?.client)
+        assertEquals("file:///b.kt", bindingB?.uri)
+        assertSame(clientB, bindingB?.client)
+        assertNotSame(bindingA, bindingB)
+    }
+
+    // --- keymap ---
+
+    @Test
+    fun keymapBindsShiftAltF() {
+        assertEquals(1, formatKeymap.size)
+        val binding = formatKeymap[0]
+        assertEquals("Shift-Alt-f", binding.key)
+        assertTrue(binding.preventDefault)
+    }
+}


### PR DESCRIPTION
## Summary
Tenth sub-issue of the LSP port epic #26. Closes #44. Ports upstream `formatDocument` (whole-document formatting). Builds on #43 (reuses the TextEdit→ChangeSpec helper).

## What it does
- `formatDocument` command: skip if no `documentFormattingProvider` capability (proceed when caps uninitialized, bail on explicit absent/false — same as rename); `client.sync()`; request `textDocument/formatting` with `FormattingOptions(tabSize, insertSpaces)`; apply the returned `List<TextEdit>` via the shared `textEditsToChangeSpec` → one `TransactionSpec(userEvent="format")`. Suspend work on `client.scope`; cooperative cancellation.
- `formatKeymap` + `formatDocumentExtension(client, uri, keymap=true)` folded into `languageServerSupport`.
- Range/on-type formatting are out of scope (whole-document only, per #44).

## Shared-helper extraction
Moved `textEditsToChangeSpec` (TextEdit[] → highest-offset-first `ChangeSpec.Multi`) **verbatim** from `ServerRename.kt` into a new `TextEdits.kt`; both rename and format use it. `ServerRename` behavior unchanged — its tests (including the multi-edit ordering ones) pass in the same run.

## Per-editor design (no multi-instance bug)
Client/uri via `formatServer` Facet; command resolves via session state — no module-level mutable per-editor state. Test `twoEditorsKeepIndependentFormatBindings` guards it.

## Public API added (tier-2)
- `fun formatDocument(session): Boolean`, `fun formatDocumentExtension(client, uri, keymap = true): Extension`, `val formatKeymap: List<KeyBinding>`
(No other modules touched.)

## Deviation (documented)
`tabSize` from `EditorState.tabSize` (default 4); `insertSpaces = true` default. Upstream derives `insertSpaces` from the `indentUnit` facet, which lives in `:language` — `:lsp-client` doesn't depend on `:language`, so per the issue's allowance I used the sensible default rather than add a module dependency.

## Verification
`:lsp-client:jvmTest` (format tests + the unchanged rename/TextEdits tests + multi-instance guard), `compileKotlinJvm`/`compileKotlinWasmJs`/`compileDebugKotlinAndroid`, `:lsp-client:apiCheck` — all green; `spotlessCheck`/`ktlintCheck` pass. apiDump committed. Apple/native not cross-compiled on Linux.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :lsp-client:jvmTest :lsp-client:compileKotlinWasmJs :lsp-client:compileDebugKotlinAndroid :lsp-client:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`