### PR TITLE
Fix editor swallowing browser-reserved keyboard shortcuts on wasmJs (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- wasmJs editor no longer swallows browser-reserved keyboard shortcuts (Ctrl+Tab, Ctrl+Shift+Tab, Ctrl+PgUp/PgDn, Ctrl+1–9, Ctrl+W/T/L, …) — the document keydown listener now calls `preventDefault()` only when the editor's keymap actually handled the key, so unbound modified/special keys propagate to the browser (#49)
 - Vim dot-repeat (`.`) dropped the inserted text of change/insert commands (`c`, `cw`, `s`, `i`, `a`, `o`, …) — the insert-mode change event was never wired up, so `lastInsertModeChanges` stayed empty and `.` replayed only the operator/delete (#21)
 - Vim change/insert commands (`c`, `cw`, `s`, …) were not a single undo unit — `u` took two steps to revert because the insert-entry cursor selection stamped a history boundary on the operator-delete event (#23)
 

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/RawKeyEventHandlingTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/RawKeyEventHandlingTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view
+
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.asDoc
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the "consume only when handled" decision in
+ * [handleRawKeyEvent]. On wasmJs the document-level keydown listener only
+ * calls `preventDefault()` when this function returns true, so a key with no
+ * editor binding must return false to fall through to the browser (#49).
+ */
+class RawKeyEventHandlingTest {
+
+    private fun sessionWith(vararg bindings: KeyBinding): EditorSession {
+        val state = EditorState.create(
+            EditorStateConfig(
+                doc = "hello".asDoc(),
+                extensions = keymapOf(*bindings)
+            )
+        )
+        return EditorSession(state)
+    }
+
+    @Test
+    fun boundModifiedKeyIsConsumed() {
+        var ran = false
+        val session = sessionWith(
+            KeyBinding(key = "Ctrl-s", run = {
+                ran = true
+                true
+            })
+        )
+        val handled = handleRawKeyEvent(
+            session,
+            key = "s",
+            ctrl = true,
+            alt = false,
+            meta = false,
+            shift = false
+        )
+        assertTrue(handled, "Ctrl-s has a binding, so it must be consumed")
+        assertTrue(ran, "the bound command should have executed")
+    }
+
+    @Test
+    fun unboundCtrlTabFallsThroughToBrowser() {
+        // Ctrl+Tab is a browser-reserved shortcut with no editor binding.
+        val session = sessionWith(
+            KeyBinding(key = "Ctrl-s", run = { true })
+        )
+        val handled = handleRawKeyEvent(
+            session,
+            key = "Tab",
+            ctrl = true,
+            alt = false,
+            meta = false,
+            shift = false
+        )
+        assertFalse(handled, "Ctrl+Tab has no binding and must fall through to the browser")
+    }
+
+    @Test
+    fun unboundCtrlWFallsThroughToBrowser() {
+        val session = sessionWith(
+            KeyBinding(key = "Ctrl-s", run = { true })
+        )
+        val handled = handleRawKeyEvent(
+            session,
+            key = "w",
+            ctrl = true,
+            alt = false,
+            meta = false,
+            shift = false
+        )
+        assertFalse(handled, "Ctrl+W (close tab) has no binding and must fall through")
+    }
+
+    @Test
+    fun unboundCtrlDigitFallsThroughToBrowser() {
+        val session = sessionWith(
+            KeyBinding(key = "Ctrl-s", run = { true })
+        )
+        val handled = handleRawKeyEvent(
+            session,
+            key = "1",
+            ctrl = true,
+            alt = false,
+            meta = false,
+            shift = false
+        )
+        assertFalse(handled, "Ctrl+1 (switch tab) has no binding and must fall through")
+    }
+
+    @Test
+    fun unboundSpecialKeyFallsThroughToBrowser() {
+        // A special key (PageUp) with a modifier and no binding must not be consumed.
+        val session = sessionWith(
+            KeyBinding(key = "Ctrl-s", run = { true })
+        )
+        val handled = handleRawKeyEvent(
+            session,
+            key = "PageUp",
+            ctrl = true,
+            alt = false,
+            meta = false,
+            shift = false
+        )
+        assertFalse(handled, "Ctrl+PageUp has no binding and must fall through")
+    }
+
+    @Test
+    fun modifierOnlyKeyIsNotConsumed() {
+        val session = sessionWith()
+        assertFalse(
+            handleRawKeyEvent(
+                session,
+                key = "Control",
+                ctrl = true,
+                alt = false,
+                meta = false,
+                shift = false
+            )
+        )
+    }
+}

--- a/view/src/wasmJsMain/kotlin/com/monkopedia/kodemirror/view/Platform.wasmJs.kt
+++ b/view/src/wasmJsMain/kotlin/com/monkopedia/kodemirror/view/Platform.wasmJs.kt
@@ -41,30 +41,33 @@ private external fun detectOsFromBrowser(): String
 // Routes ALL keys through __kodeKeyCallback because Playwright (and some
 // headless environments) dispatch key events to BODY rather than the canvas
 // in the shadow DOM, so Skiko never generates Compose KeyEvents for them.
-// The callback receives (key, ctrlKey, altKey, metaKey, shiftKey) and should
-// return true if the key was handled (to prevent default browser behavior).
+// The callback receives (key, ctrlKey, altKey, metaKey, shiftKey) and returns
+// true if the editor's keymap actually handled the key.
+//
+// preventDefault() is called ONLY when the callback reports the key was
+// handled. This is critical: previously every modified/special key was
+// prevented unconditionally, which swallowed browser-reserved shortcuts the
+// editor has no binding for (Ctrl+Tab, Ctrl+W, Ctrl+1-9, etc.) so the browser
+// never saw them (#49). Unhandled keys must fall through to the browser.
+//
 // For real users (events targeting the canvas), both this callback AND
 // onPreviewKeyEvent may fire; a Kotlin-side flag prevents double-handling.
 @JsFun(
     """() => {
     globalThis.__kodeKey = '';
     globalThis.__kodeKeyCallback = null;
-    var special = ['Home','End','Tab','Backspace','Delete','Enter','Escape',
-        'ArrowUp','ArrowDown','ArrowLeft','ArrowRight',
-        'PageUp','PageDown','F1','F2','F3','F4','F5','F6',
-        'F7','F8','F9','F10','F11','F12'];
     document.addEventListener('keydown', function(e) {
         globalThis.__kodeKey = e.key;
-        var isModified = e.ctrlKey || e.metaKey || e.altKey;
-        if (isModified || special.indexOf(e.key) !== -1) {
-            e.preventDefault();
-        }
         // Route all keys through the Kotlin callback. This is necessary
         // because Playwright (and some headless environments) dispatch key
         // events to BODY rather than the canvas in the shadow DOM, so Skiko
         // never converts them to Compose KeyEvents. The Kotlin callback
         // sets a flag so onPreviewKeyEvent skips if Skiko also processes
         // the same event (preventing double-handling).
+        //
+        // Only consume the event (preventDefault) when the editor's keymap
+        // actually handled it. Keys with no editor binding propagate to the
+        // browser so reserved shortcuts (Ctrl+Tab, Ctrl+W, ...) still work.
         if (globalThis.__kodeKeyCallback) {
             var handled = globalThis.__kodeKeyCallback(
                 e.key, e.ctrlKey, e.altKey, e.metaKey, e.shiftKey


### PR DESCRIPTION
## Summary
Fixes #49. On wasmJs the editor swallowed browser-reserved shortcuts (Ctrl+Tab/Shift+Tab, Ctrl+PgUp/PgDn, Ctrl+1–9, Ctrl+W/T/L) so the browser never saw them — e.g. you couldn't switch Chrome tabs while the editor was focused.

## Root cause + fix
`view/.../Platform.wasmJs.kt`'s document keydown listener had **two** `preventDefault()` decisions: an **unconditional** one firing on every modified/special key before anything handled it, plus the correct callback-gated one. Removed the unconditional block (and the now-unused `special` key array), leaving only the callback-gated `preventDefault()`. The callback (`handleRawKeyEvent`) already returns `false` for any key with no matching keymap binding, so unbound modified keys now fall through to the browser while bound keys (e.g. a registered Ctrl+S) are still consumed. Matches the JVM model (Compose consumes only what it handles).

## Verification
- `:view:jvmTest` green, incl. a new `RawKeyEventHandlingTest` (6 cases: bound Ctrl+S consumed + runs; unbound Ctrl+Tab/Ctrl+W/Ctrl+1/Ctrl+PgUp fall through; modifier-only not consumed).
- `:view:compileKotlinWasmJs` green (fix is wasmJs-specific); `:view:apiCheck` green — **no public API change**.
- The raw browser keydown path isn't unit-testable headless; tests cover the `handleRawKeyEvent` decision logic it gates on.
- spotless/ktlint applied. CHANGELOG updated.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :view:jvmTest :view:compileKotlinWasmJs :view:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`
- [ ] Manual (browser): focus the editor, confirm Ctrl+Tab switches tabs, Ctrl+W/T/L work, while editor key bindings still function.