### PR TITLE
Bridge copy/cut/paste to the system clipboard on wasmJs (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - wasmJs editor no longer swallows browser-reserved keyboard shortcuts (Ctrl+Tab, Ctrl+Shift+Tab, Ctrl+PgUp/PgDn, Ctrl+1–9, Ctrl+W/T/L, …) — the document keydown listener now calls `preventDefault()` only when the editor's keymap actually handled the key, so unbound modified/special keys propagate to the browser (#49)
+- Copy/cut/paste did not reach the system clipboard on the Compose/wasm target (vim `y`, emacs, and default keymaps) — the canvas render has no DOM `contenteditable`, so the copy/cut commands now bridge to `navigator.clipboard.writeText` synchronously within the originating key gesture (with a hidden-textarea `execCommand` fallback) and paste primes its buffer from `navigator.clipboard.readText`; the in-editor buffer from #16 remains the immediate fallback. JVM/desktop continues to use Compose's `ClipboardManager` (#34)
 - Vim dot-repeat (`.`) dropped the inserted text of change/insert commands (`c`, `cw`, `s`, `i`, `a`, `o`, …) — the insert-mode change event was never wired up, so `lastInsertModeChanges` stayed empty and `.` replayed only the operator/delete (#21)
 - Vim change/insert commands (`c`, `cw`, `s`, …) were not a single undo unit — `u` took two steps to revert because the insert-entry cursor selection stamped a history boundary on the operator-delete event (#23)
 

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/ClipboardCommands.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/ClipboardCommands.kt
@@ -26,20 +26,36 @@ import com.monkopedia.kodemirror.state.TransactionSpec
 import com.monkopedia.kodemirror.state.asInsert
 
 /**
+ * Write [text] to the system clipboard, bridging the platform gap.
+ *
+ * On wasmJs [platformWriteClipboard] kicks off `navigator.clipboard.writeText`
+ * synchronously inside the originating key-event gesture (returns true). On
+ * JVM/Desktop it returns false, so we fall back to Compose's `ClipboardManager`,
+ * which writes the AWT system clipboard synchronously. In both cases the
+ * in-editor [EditorSessionImpl.internalClipboard] buffer is updated as an
+ * immediate, always-reliable fallback for paste within the same session.
+ */
+private fun writeClipboard(impl: EditorSessionImpl?, text: String) {
+    impl?.internalClipboard = text
+    val handledByPlatform = platformWriteClipboard(text)
+    if (!handledByPlatform) {
+        try {
+            impl?.clipboardManager?.setText(AnnotatedString(text))
+        } catch (_: Throwable) {
+            // Best-effort system clipboard write; the internal buffer is the
+            // reliable fallback.
+        }
+    }
+}
+
+/**
  * Copy the current selection to the system clipboard.
  */
 val clipboardCopy: (EditorSession) -> Boolean = { view ->
     val impl = view as? EditorSessionImpl
     val sel = view.state.selection.main
     if (!sel.empty) {
-        val text = view.state.doc.sliceString(sel.from, sel.to)
-        impl?.internalClipboard = text
-        try {
-            impl?.clipboardManager?.setText(AnnotatedString(text))
-        } catch (_: Throwable) {
-            // On wasmJs the browser clipboard API may fail (security policy,
-            // async limitations).  The internal buffer is the reliable fallback.
-        }
+        writeClipboard(impl, view.state.doc.sliceString(sel.from, sel.to))
     }
     true
 }
@@ -51,14 +67,7 @@ val clipboardCut: (EditorSession) -> Boolean = { view ->
     val impl = view as? EditorSessionImpl
     val sel = view.state.selection.main
     if (!sel.empty) {
-        val text = view.state.doc.sliceString(sel.from, sel.to)
-        impl?.internalClipboard = text
-        try {
-            impl?.clipboardManager?.setText(AnnotatedString(text))
-        } catch (_: Throwable) {
-            // Best-effort system clipboard write; internal buffer is the
-            // reliable fallback on wasmJs.
-        }
+        writeClipboard(impl, view.state.doc.sliceString(sel.from, sel.to))
         view.dispatch(
             TransactionSpec(
                 changes = ChangeSpec.Single(from = sel.from, to = sel.to)
@@ -73,9 +82,15 @@ val clipboardCut: (EditorSession) -> Boolean = { view ->
  */
 val clipboardPaste: (EditorSession) -> Boolean = { view ->
     val impl = view as? EditorSessionImpl
-    // Try the system clipboard first; fall back to the internal buffer.
-    // On wasmJs the browser clipboard API is async so getText() often
-    // returns null even after a successful setText().
+    // On wasmJs the browser Clipboard API read is asynchronous, so it cannot
+    // deliver a value within this synchronous key-event handler. Kick off an
+    // async read to refresh the internal buffer for the *next* paste, then use
+    // the best value currently available (Compose ClipboardManager on JVM, or
+    // the internal buffer — which holds the most recent in-editor copy/cut and
+    // any previously-read external clipboard contents).
+    platformReadClipboard { external ->
+        if (external.isNotEmpty()) impl?.internalClipboard = external
+    }
     val text = try {
         impl?.clipboardManager?.getText()?.text
     } catch (_: Throwable) {

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/Platform.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/Platform.kt
@@ -85,3 +85,35 @@ internal expect fun platformUnregisterKeyHandler(token: PlatformKeyHandlerToken)
  * On JVM/Desktop, this is a no-op since Compose manages focus natively.
  */
 internal expect fun platformFocusInput()
+
+/**
+ * Write [text] to the underlying system clipboard.
+ *
+ * On wasmJs the canvas-rendered editor has no DOM `contenteditable`, so the
+ * browser's native copy/cut machinery has nothing to read. This bridges the
+ * copy/cut commands to `navigator.clipboard.writeText`, which is asynchronous
+ * but must be invoked synchronously inside the originating user gesture (the
+ * keydown handler) to satisfy the browser's transient-activation requirement.
+ * The write itself completes asynchronously; the in-editor buffer is kept as
+ * an immediate fallback.
+ *
+ * On JVM/Desktop this is a no-op — Compose's `ClipboardManager` writes to the
+ * system clipboard synchronously, so the command layer handles it directly.
+ *
+ * @return true if the platform attempted a system-clipboard write, false if it
+ *   delegated entirely to the Compose `ClipboardManager` (e.g. JVM).
+ */
+internal expect fun platformWriteClipboard(text: String): Boolean
+
+/**
+ * Asynchronously read the system clipboard and deliver the contents to
+ * [onResult]. Because the browser clipboard API is async, the value cannot be
+ * returned synchronously inside a key-event handler; callers use this to prime
+ * the internal buffer so the *next* paste reflects external clipboard contents.
+ *
+ * On JVM/Desktop this is a no-op — the command layer reads the Compose
+ * `ClipboardManager` synchronously.
+ *
+ * @return true if an asynchronous read was started, false otherwise (e.g. JVM).
+ */
+internal expect fun platformReadClipboard(onResult: (String) -> Unit): Boolean

--- a/view/src/jvmMain/kotlin/com/monkopedia/kodemirror/view/Platform.jvm.kt
+++ b/view/src/jvmMain/kotlin/com/monkopedia/kodemirror/view/Platform.jvm.kt
@@ -63,3 +63,15 @@ internal actual fun platformUnregisterKeyHandler(token: PlatformKeyHandlerToken)
 internal actual fun platformFocusInput() {
     // No-op on JVM — Compose Desktop manages focus natively
 }
+
+internal actual fun platformWriteClipboard(text: String): Boolean {
+    // No-op on JVM — Compose's ClipboardManager writes the AWT system
+    // clipboard synchronously, so the command layer handles it directly.
+    return false
+}
+
+internal actual fun platformReadClipboard(onResult: (String) -> Unit): Boolean {
+    // No-op on JVM — the command layer reads the Compose ClipboardManager
+    // synchronously, so no async priming is needed.
+    return false
+}

--- a/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/ClipboardCommandsTest.kt
+++ b/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/ClipboardCommandsTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view
+
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.TransactionSpec
+import com.monkopedia.kodemirror.state.asDoc
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the clipboard commands' platform-independent logic.
+ *
+ * The wasmJs browser-clipboard path (`navigator.clipboard`) can only be
+ * verified in a real browser. These tests cover the JVM/Compose path and the
+ * internal-buffer fallback that the wasmJs path also relies on for paste.
+ */
+class ClipboardCommandsTest {
+
+    /** Minimal in-memory [ClipboardManager] standing in for the system clipboard. */
+    private class FakeClipboardManager : ClipboardManager {
+        var stored: AnnotatedString? = null
+        override fun setText(annotatedString: AnnotatedString) {
+            stored = annotatedString
+        }
+        override fun getText(): AnnotatedString? = stored
+    }
+
+    private fun session(doc: String): EditorSessionImpl {
+        val state = EditorState.create(EditorStateConfig(doc = doc.asDoc()))
+        return EditorSession(state) as EditorSessionImpl
+    }
+
+    private fun EditorSessionImpl.select(from: Int, to: Int) {
+        dispatch(TransactionSpec(selection = SelectionSpec.CursorSpec(DocPos(from), DocPos(to))))
+    }
+
+    private fun EditorSessionImpl.cursor(at: Int) {
+        dispatch(TransactionSpec(selection = SelectionSpec.CursorSpec(DocPos(at))))
+    }
+
+    @Test
+    fun copy_writesSelectionToClipboardAndInternalBuffer() {
+        val s = session("Hello world")
+        val cm = FakeClipboardManager()
+        s.clipboardManager = cm
+        s.select(0, 5)
+
+        assertTrue(clipboardCopy(s))
+
+        // On JVM platformWriteClipboard is a no-op, so the Compose
+        // ClipboardManager receives the text, and the internal buffer mirrors it.
+        assertEquals("Hello", cm.stored?.text)
+        assertEquals("Hello", s.internalClipboard)
+        // Copy must not mutate the document.
+        assertEquals("Hello world", s.state.doc.toString())
+    }
+
+    @Test
+    fun copy_emptySelection_doesNothing() {
+        val s = session("Hello world")
+        val cm = FakeClipboardManager()
+        s.clipboardManager = cm
+        s.cursor(3)
+
+        assertTrue(clipboardCopy(s))
+
+        assertNull(cm.stored)
+        assertNull(s.internalClipboard)
+    }
+
+    @Test
+    fun cut_writesToClipboardAndRemovesSelection() {
+        val s = session("Hello world")
+        val cm = FakeClipboardManager()
+        s.clipboardManager = cm
+        s.select(0, 6) // "Hello "
+
+        assertTrue(clipboardCut(s))
+
+        assertEquals("Hello ", cm.stored?.text)
+        assertEquals("Hello ", s.internalClipboard)
+        assertEquals("world", s.state.doc.toString())
+    }
+
+    @Test
+    fun paste_insertsClipboardTextAtCursor() {
+        val s = session("Hello world")
+        val cm = FakeClipboardManager()
+        cm.stored = AnnotatedString("ABC")
+        s.clipboardManager = cm
+        s.cursor(0)
+
+        assertTrue(clipboardPaste(s))
+
+        assertEquals("ABCHello world", s.state.doc.toString())
+        // Cursor advanced past the inserted text.
+        assertEquals(3, s.state.selection.main.head.value)
+    }
+
+    @Test
+    fun paste_replacesSelection() {
+        val s = session("Hello world")
+        val cm = FakeClipboardManager()
+        cm.stored = AnnotatedString("XYZ")
+        s.clipboardManager = cm
+        s.select(0, 5) // replace "Hello"
+
+        assertTrue(clipboardPaste(s))
+
+        assertEquals("XYZ world", s.state.doc.toString())
+    }
+
+    @Test
+    fun paste_fallsBackToInternalBufferWhenClipboardEmpty() {
+        // Simulates wasmJs: the Compose ClipboardManager.getText() returns null
+        // even after a copy, so paste relies on the internal buffer.
+        val s = session("Hello world")
+        val cm = FakeClipboardManager()
+        s.clipboardManager = cm
+        s.internalClipboard = "FROM_BUFFER"
+        s.cursor(0)
+
+        assertTrue(clipboardPaste(s))
+
+        assertEquals("FROM_BUFFERHello world", s.state.doc.toString())
+    }
+
+    @Test
+    fun paste_noClipboardOrBuffer_returnsFalse() {
+        val s = session("Hello world")
+        s.clipboardManager = FakeClipboardManager()
+        s.cursor(0)
+
+        // No text anywhere — should not consume the event so the browser's
+        // native paste path can take over.
+        assertEquals(false, clipboardPaste(s))
+        assertEquals("Hello world", s.state.doc.toString())
+    }
+
+    @Test
+    fun copyThenPaste_roundTripsThroughInternalBuffer() {
+        val s = session("abcdef")
+        val cm = FakeClipboardManager()
+        s.clipboardManager = cm
+        s.select(0, 3) // "abc"
+        clipboardCopy(s)
+        s.cursor(6) // end
+        clipboardPaste(s)
+
+        assertEquals("abcdefabc", s.state.doc.toString())
+    }
+}

--- a/view/src/nativeMain/kotlin/com/monkopedia/kodemirror/view/Platform.native.kt
+++ b/view/src/nativeMain/kotlin/com/monkopedia/kodemirror/view/Platform.native.kt
@@ -59,3 +59,15 @@ internal actual fun platformUnregisterKeyHandler(token: PlatformKeyHandlerToken)
 internal actual fun platformFocusInput() {
     // No-op on native — Compose manages focus natively
 }
+
+internal actual fun platformWriteClipboard(text: String): Boolean {
+    // No-op on native — Compose's ClipboardManager writes the system
+    // clipboard synchronously, so the command layer handles it directly.
+    return false
+}
+
+internal actual fun platformReadClipboard(onResult: (String) -> Unit): Boolean {
+    // No-op on native — the command layer reads the Compose ClipboardManager
+    // synchronously, so no async priming is needed.
+    return false
+}

--- a/view/src/wasmJsMain/kotlin/com/monkopedia/kodemirror/view/Platform.wasmJs.kt
+++ b/view/src/wasmJsMain/kotlin/com/monkopedia/kodemirror/view/Platform.wasmJs.kt
@@ -172,6 +172,60 @@ internal actual fun platformFocusInput() {
     platformFocusCanvas()
 }
 
+// Write to the system clipboard via the async Clipboard API. This must be
+// called synchronously inside the user gesture (the keydown handler) so the
+// browser's transient-activation check passes; the returned promise resolves
+// later. Falls back to the legacy execCommand('copy') path via a hidden
+// textarea when navigator.clipboard is unavailable (insecure context, older
+// browser).
+@JsFun(
+    """(text) => {
+    try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).catch(function() {});
+            return true;
+        }
+    } catch (e) {}
+    try {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        var ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        return ok;
+    } catch (e) {
+        return false;
+    }
+}"""
+)
+private external fun jsWriteClipboard(text: String): Boolean
+
+// Read the system clipboard asynchronously and deliver the text to the Kotlin
+// callback when the promise resolves. Returns true if a read was started.
+@JsFun(
+    """(cb) => {
+    try {
+        if (navigator.clipboard && navigator.clipboard.readText) {
+            navigator.clipboard.readText().then(function(text) {
+                cb(text == null ? '' : text);
+            }).catch(function() {});
+            return true;
+        }
+    } catch (e) {}
+    return false;
+}"""
+)
+private external fun jsReadClipboard(callback: (JsString) -> Unit): Boolean
+
+internal actual fun platformWriteClipboard(text: String): Boolean = jsWriteClipboard(text)
+
+internal actual fun platformReadClipboard(onResult: (String) -> Unit): Boolean =
+    jsReadClipboard { text -> onResult(text.toString()) }
+
 // Eagerly install the capture listener when this file is first loaded.
 // platformOsName() is called during currentOs initialization (before any
 // key events), which triggers loading of this file and runs this initializer.


### PR DESCRIPTION
## Summary
Fixes #34. Copy/cut/paste didn't reach the system clipboard on the Compose/wasm target (canvas render = no DOM `contenteditable`; the commands only wrote Compose's `LocalClipboardManager`, which doesn't reliably reach `navigator.clipboard`, and the #16 internal buffer never touched the real system clipboard).

## Fix (no public API change — internal `expect`/`actual` hooks)
- `Platform.kt`: new `internal expect fun platformWriteClipboard(text): Boolean` / `platformReadClipboard(onResult): Boolean`.
- **wasmJs** (`Platform.wasmJs.kt`): `writeClipboard` calls `navigator.clipboard.writeText` synchronously inside the originating key-event gesture (satisfies the browser transient-activation requirement), with a hidden-`textarea` + `execCommand('copy')` fallback for insecure contexts; `platformReadClipboard` runs `navigator.clipboard.readText().then(...)`.
- **JVM/native**: return `false` (no-op) → command layer keeps using Compose `ClipboardManager` (AWT system clipboard, synchronous) — **desktop behavior unchanged**.
- `ClipboardCommands.kt`: extracted `writeClipboard(impl, text)` (copy + cut) — updates the internal buffer, calls `platformWriteClipboard`, falls back to `ClipboardManager.setText` only when the platform didn't handle it. Paste fires an async `platformReadClipboard` to refresh the internal buffer for the *next* paste while using the best synchronously-available value now. The #16 internal buffer remains the immediate, always-reliable fallback. Wired to Ctrl/Meta-c/x/v (vim `y`/emacs route through the same commands).

## Verification
`:view:jvmTest` green incl. new `ClipboardCommandsTest` (8 tests: copy/cut/paste, empty-selection no-op, selection replacement, internal-buffer fallback, no-text→false, copy→paste round-trip). `:view:compileKotlinWasmJs` + `:view:apiCheck` green — no public API change. spotless/ktlint applied; CHANGELOG updated.

## Known limitation (inherent to the browser clipboard API)
The browser `readText()` is async, so the **first** external paste in a session may use the internal buffer until the promise resolves; subsequent pastes reflect the system clipboard. The actual `navigator.clipboard` behavior (permission prompts, cross-app paste, the `execCommand` fallback) can only be verified in a real browser — the JVM tests cover the shared command logic + buffer fallback.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ANDROID_HOME=$HOME/Android/Sdk ./gradlew :view:jvmTest :view:compileKotlinWasmJs :view:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`
- [ ] Manual (browser): copy in editor → paste into another app, and vice-versa.