### PR TITLE
Bump :lsp-client to lsp 1.0.0-RC3 and adopt the strict union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Bumped `com.monkopedia.lsp` (`lsp` + `lsp-ksrpc`) from `1.0.0-RC2` to `1.0.0-RC3`. RC3 tightens several `Hover.contents` / `ServerCapabilities.textDocumentSync` fields from untyped `JsonElement` to strict union types, so `:lsp-client`'s `ServerHover` and `DocumentSync` now read the typed `HoverContents` and `ServerCapabilitiesTextDocumentSync` unions directly instead of hand-parsing `JsonElement` (internal parsing only; no public API change). The `:lsp-client` module remains pre-stable.
+
 ### Fixed
 - wasmJs editor no longer swallows browser-reserved keyboard shortcuts (Ctrl+Tab, Ctrl+Shift+Tab, Ctrl+PgUp/PgDn, Ctrl+1–9, Ctrl+W/T/L, …) — the document keydown listener now calls `preventDefault()` only when the editor's keymap actually handled the key, so unbound modified/special keys propagate to the browser (#49)
 - Copy/cut/paste did not reach the system clipboard on the Compose/wasm target (vim `y`, emacs, and default keymaps) — the canvas render has no DOM `contenteditable`, so the copy/cut commands now bridge to `navigator.clipboard.writeText` synchronously within the originating key gesture (with a hidden-textarea `execCommand` fallback) and paste primes its buffer from `navigator.clipboard.readText`; the in-editor buffer from #16 remains the immediate fallback. JVM/desktop continues to use Compose's `ClipboardManager` (#34)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kover = "0.9.8"
 dokka = "2.2.0"
 bcv = "0.18.1"
 vanniktech = "0.35.0"
-lsp = "1.0.0-RC2"
+lsp = "1.0.0-RC3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/DocumentSync.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/DocumentSync.kt
@@ -25,14 +25,12 @@ import com.monkopedia.kodemirror.state.Text
 import com.monkopedia.lsp.Position
 import com.monkopedia.lsp.Range
 import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.ServerCapabilitiesTextDocumentSync
 import com.monkopedia.lsp.TextDocumentContentChangeEvent
 import com.monkopedia.lsp.TextDocumentContentChangeEventRange
 import com.monkopedia.lsp.TextDocumentContentChangeEventVariant
 import com.monkopedia.lsp.TextDocumentSyncKind
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.intOrNull
+import com.monkopedia.lsp.TextDocumentSyncOptions
 
 /**
  * Convert a kodemirror document offset to an LSP [Position].
@@ -104,31 +102,22 @@ data class DocumentSyncMode(
          *
          * The `textDocumentSync` capability is, per the LSP spec, either the
          * [TextDocumentSyncKind] number (legacy form) or a
-         * `TextDocumentSyncOptions` object (`{openClose, change}`). When it is
-         * absent the spec defaults to no syncing; we follow upstream and still
-         * advertise open/close while defaulting [change] to
-         * [TextDocumentSyncKind.NONE].
+         * [TextDocumentSyncOptions] object (`{openClose, change}`), modelled by
+         * the [ServerCapabilitiesTextDocumentSync] union. When it is absent the
+         * spec defaults to no syncing; we follow upstream and still advertise
+         * open/close while defaulting [change] to [TextDocumentSyncKind.NONE].
          */
-        fun forCapabilities(capabilities: ServerCapabilities?): DocumentSyncMode {
-            val sync = capabilities?.textDocumentSync
-                ?: return DocumentSyncMode(openClose = true, change = TextDocumentSyncKind.NONE)
-            return when (sync) {
-                is JsonPrimitive -> {
-                    val kind = sync.intOrNull?.toUInt()?.let { TextDocumentSyncKind(it) }
-                        ?: TextDocumentSyncKind.NONE
-                    DocumentSyncMode(openClose = true, change = kind)
-                }
-                is JsonObject -> {
-                    val openClose = (sync["openClose"] as? JsonPrimitive)
-                        ?.booleanOrNull ?: false
-                    val change = (sync["change"] as? JsonPrimitive)?.intOrNull
-                        ?.toUInt()?.let { TextDocumentSyncKind(it) }
-                        ?: TextDocumentSyncKind.NONE
-                    DocumentSyncMode(openClose = openClose, change = change)
-                }
-                else -> DocumentSyncMode(openClose = true, change = TextDocumentSyncKind.NONE)
+        fun forCapabilities(capabilities: ServerCapabilities?): DocumentSyncMode =
+            when (val sync = capabilities?.textDocumentSync) {
+                null -> DocumentSyncMode(openClose = true, change = TextDocumentSyncKind.NONE)
+                is TextDocumentSyncKind ->
+                    DocumentSyncMode(openClose = true, change = sync)
+                is TextDocumentSyncOptions ->
+                    DocumentSyncMode(
+                        openClose = sync.openClose ?: false,
+                        change = sync.change ?: TextDocumentSyncKind.NONE
+                    )
             }
-        }
     }
 }
 

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerHover.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerHover.kt
@@ -37,26 +37,21 @@ import com.monkopedia.kodemirror.view.LocalEditorTheme
 import com.monkopedia.kodemirror.view.Tooltip
 import com.monkopedia.kodemirror.view.hoverTooltip
 import com.monkopedia.lsp.Hover
+import com.monkopedia.lsp.HoverContents
 import com.monkopedia.lsp.HoverParams
+import com.monkopedia.lsp.MarkedString
 import com.monkopedia.lsp.MarkupContent
 import com.monkopedia.lsp.MarkupKind
 import com.monkopedia.lsp.StringOr
 import com.monkopedia.lsp.TextDocumentIdentifier
 import kotlinx.coroutines.CancellationException
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.contentOrNull
 
 /**
  * A single rendered block of LSP hover content.
  *
  * The LSP `Hover.contents` field is a union (`MarkupContent | MarkedString |
- * MarkedString[] | string`); [parseHoverContents] flattens it into an ordered
- * list of these blocks for rendering.
+ * MarkedString[]`, modelled by [HoverContents]); [parseHoverContents] flattens
+ * it into an ordered list of these blocks for rendering.
  *
  * @param text The textual body of the block.
  * @param language When non-null, the block is a fenced code block tagged with
@@ -72,71 +67,55 @@ internal data class HoverBlock(
     val markdown: Boolean = false
 )
 
-private val hoverJson = Json {
-    ignoreUnknownKeys = true
-    isLenient = true
-}
-
 /**
- * Parse the raw `textDocument/hover` result (which the typed
- * [LanguageServer][com.monkopedia.lsp.LanguageServer] returns as a [Hover] whose
- * [contents][Hover.contents] is an untyped [JsonElement]) into an ordered list
- * of [HoverBlock]s.
+ * Parse the typed `textDocument/hover` result's [contents][Hover.contents]
+ * (a strict [HoverContents] union) into an ordered list of [HoverBlock]s.
  *
- * Handles every shape the LSP `Hover.contents` union allows:
- * - a plain `string` (non-markdown prose),
- * - a `MarkupContent` object `{kind, value}` (markdown when
- *   [kind][MarkupContent.kind] is [MARKDOWN][MarkupKind.MARKDOWN]),
- * - a `MarkedString`, i.e. either a `string` (rendered as a markdown block, per
- *   the LSP spec) or `{language, value}` (a fenced code block in that language),
- * - an array of `MarkedString` (each element handled as above).
+ * Handles every variant the LSP `Hover.contents` union allows:
+ * - [MarkupContentValue][HoverContents.MarkupContentValue] — a `MarkupContent`
+ *   `{kind, value}` (markdown when [kind][MarkupContent.kind] is
+ *   [MARKDOWN][MarkupKind.MARKDOWN]),
+ * - [MarkedStringValue][HoverContents.MarkedStringValue] — a `MarkedString`,
+ *   i.e. either a `string` (rendered as a markdown block, per the LSP spec) or
+ *   `{language, value}` (a fenced code block in that language),
+ * - [MarkedStringArray][HoverContents.MarkedStringArray] — an array of
+ *   `MarkedString` (each element handled as above).
  *
  * Empty/blank blocks are dropped. Returns an empty list when there is nothing to
  * show (which the caller treats as "no tooltip").
  */
-internal fun parseHoverContents(contents: JsonElement): List<HoverBlock> = when (contents) {
-    is JsonNull -> emptyList()
-    is JsonPrimitive -> {
-        // Plain `string` form of the union.
-        contents.contentOrNull
-            ?.takeIf { it.isNotBlank() }
-            ?.let { listOf(HoverBlock(text = it, markdown = false)) }
-            ?: emptyList()
-    }
-    is JsonObject -> parseHoverObject(contents)?.let { listOf(it) } ?: emptyList()
-    is JsonArray -> contents.flatMap { element ->
-        when (element) {
-            is JsonPrimitive ->
-                element.contentOrNull
-                    ?.takeIf { it.isNotBlank() }
-                    // Per the spec, a bare string inside a MarkedString[] is markdown.
-                    ?.let { listOf(HoverBlock(text = it, markdown = true)) }
-                    ?: emptyList()
-            is JsonObject -> parseHoverObject(element)?.let { listOf(it) } ?: emptyList()
-            else -> emptyList()
-        }
-    }
+internal fun parseHoverContents(contents: HoverContents): List<HoverBlock> = when (contents) {
+    is HoverContents.MarkupContentValue ->
+        markupContentBlock(contents.value)?.let { listOf(it) } ?: emptyList()
+    is HoverContents.MarkedStringValue ->
+        markedStringBlock(contents.value)?.let { listOf(it) } ?: emptyList()
+    is HoverContents.MarkedStringArray ->
+        contents.value.mapNotNull { markedStringBlock(it) }
 }
 
 /**
- * Parse a single object element of `Hover.contents` — either a
- * [MarkupContent] (`{kind, value}`) or a `MarkedString` (`{language, value}`).
- * The two are disambiguated by which key is present (`kind` vs `language`).
+ * Convert one [MarkupContent] to a [HoverBlock], rendering it as markdown only
+ * when its [kind][MarkupContent.kind] is [MARKDOWN][MarkupKind.MARKDOWN]. Blank
+ * content yields `null` (dropped).
  */
-private fun parseHoverObject(obj: JsonObject): HoverBlock? {
-    val value = (obj["value"] as? JsonPrimitive)?.contentOrNull ?: return null
-    if (value.isBlank()) return null
-    val language = (obj["language"] as? JsonPrimitive)?.contentOrNull
-    if (language != null) {
-        // MarkedString {language, value}: a fenced code block.
-        return HoverBlock(text = value, language = language, markdown = false)
-    }
-    // MarkupContent {kind, value}.
-    val markup = runCatching {
-        hoverJson.decodeFromJsonElement(MarkupContent.serializer(), obj)
-    }.getOrNull()
-    val markdown = markup?.kind == MarkupKind.MARKDOWN
-    return HoverBlock(text = value, markdown = markdown)
+private fun markupContentBlock(markup: MarkupContent): HoverBlock? = markup.value
+    .takeIf { it.isNotBlank() }
+    ?.let { HoverBlock(text = it, markdown = markup.kind == MarkupKind.MARKDOWN) }
+
+/**
+ * Convert one `MarkedString` to a [HoverBlock]: a bare `string` becomes a
+ * markdown block (per the LSP spec), while `{language, value}` becomes a fenced
+ * code block in that language. Blank content yields `null` (dropped).
+ */
+private fun markedStringBlock(marked: MarkedString): HoverBlock? = when (marked) {
+    is StringOr.StringValue ->
+        marked.value
+            .takeIf { it.isNotBlank() }
+            ?.let { HoverBlock(text = it, markdown = true) }
+    is StringOr.Value ->
+        marked.value.value
+            .takeIf { it.isNotBlank() }
+            ?.let { HoverBlock(text = it, language = marked.value.language, markdown = false) }
 }
 
 /**
@@ -352,7 +331,8 @@ internal fun hoverTooltipPos(
  * 3. captures a [WorkspaceMapping] so the response range can be remapped if the
  *    document changes while the request is in flight,
  * 4. issues `textDocument/hover` at the pointer position,
- * 5. parses the [contents][Hover.contents] union ([parseHoverContents]) and
+ * 5. parses the [contents][Hover.contents] [HoverContents] union
+ *    ([parseHoverContents]) and
  *    renders it to Compose ([HoverContent]; see its HTML→Compose deviation
  *    note), anchored at the [Hover.range] start when present.
  *

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelp.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelp.kt
@@ -53,6 +53,7 @@ import com.monkopedia.lsp.SignatureHelpContext
 import com.monkopedia.lsp.SignatureHelpParams
 import com.monkopedia.lsp.SignatureHelpTriggerKind
 import com.monkopedia.lsp.SignatureInformation
+import com.monkopedia.lsp.StringOr
 import com.monkopedia.lsp.TextDocumentIdentifier
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -60,10 +61,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.intOrNull
 
 /**
  * Configuration for [signatureHelp].
@@ -131,17 +128,19 @@ internal fun activeParamRange(
     val params = signature.parameters ?: return null
     val index = (signature.activeParameter ?: helpActiveParameter)?.toInt() ?: return null
     val param = params.getOrNull(index) ?: return null
-    val label = param.label
-    if (label is JsonArray && label.size == 2) {
-        val from = (label[0] as? JsonPrimitive)?.intOrNull
-        val to = (label[1] as? JsonPrimitive)?.intOrNull
-        if (from != null && to != null) return ActiveParamRange(from, to)
-        return null
+    return when (val label = param.label) {
+        is StringOr.Value -> {
+            val offsets = label.value
+            if (offsets.size != 2) return null
+            ActiveParamRange(offsets[0].toInt(), offsets[1].toInt())
+        }
+        is StringOr.StringValue -> {
+            val str = label.value
+            val found = signature.label.indexOf(str)
+            if (found < 0) return null
+            ActiveParamRange(found, found + str.length)
+        }
     }
-    val str = (label as? JsonPrimitive)?.contentOrNull ?: return null
-    val found = signature.label.indexOf(str)
-    if (found < 0) return null
-    return ActiveParamRange(found, found + str.length)
 }
 
 /**

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/DocumentSyncTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/DocumentSyncTest.kt
@@ -28,11 +28,10 @@ import com.monkopedia.lsp.ServerCapabilities
 import com.monkopedia.lsp.TextDocumentContentChangeEventRange
 import com.monkopedia.lsp.TextDocumentContentChangeEventVariant
 import com.monkopedia.lsp.TextDocumentSyncKind
+import com.monkopedia.lsp.TextDocumentSyncOptions
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
 
 class DocumentSyncTest {
     private fun doc(vararg lines: String): Text = Text.of(lines.toList())
@@ -88,7 +87,7 @@ class DocumentSyncTest {
 
     @Test
     fun syncModeFromNumberCapability() {
-        val caps = ServerCapabilities(textDocumentSync = JsonPrimitive(2))
+        val caps = ServerCapabilities(textDocumentSync = TextDocumentSyncKind.INCREMENTAL)
         val mode = DocumentSyncMode.forCapabilities(caps)
         assertEquals(TextDocumentSyncKind.INCREMENTAL, mode.change)
         assertTrue(mode.openClose)
@@ -97,10 +96,10 @@ class DocumentSyncTest {
     @Test
     fun syncModeFromOptionsCapability() {
         val caps = ServerCapabilities(
-            textDocumentSync = buildJsonObject {
-                put("openClose", JsonPrimitive(true))
-                put("change", JsonPrimitive(1))
-            }
+            textDocumentSync = TextDocumentSyncOptions(
+                openClose = true,
+                change = TextDocumentSyncKind.FULL
+            )
         )
         val mode = DocumentSyncMode.forCapabilities(caps)
         assertEquals(TextDocumentSyncKind.FULL, mode.change)

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerHoverTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerHoverTest.kt
@@ -24,36 +24,47 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import com.monkopedia.kodemirror.state.Text
 import com.monkopedia.lsp.Hover
+import com.monkopedia.lsp.HoverContents
+import com.monkopedia.lsp.MarkedString
+import com.monkopedia.lsp.MarkedStringObject
+import com.monkopedia.lsp.MarkupContent
+import com.monkopedia.lsp.MarkupKind
 import com.monkopedia.lsp.Position
 import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.StringOr
+import com.monkopedia.lsp.markdown
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 
 class ServerHoverTest {
-    private val json = Json { ignoreUnknownKeys = true }
+    private fun markedString(value: String): MarkedString = StringOr.StringValue(value)
 
-    private fun element(raw: String): JsonElement = json.parseToJsonElement(raw)
+    private fun markedString(language: String, value: String): MarkedString =
+        StringOr.Value(MarkedStringObject(language = language, value = value))
 
-    // --- parseHoverContents: union shapes ---
+    // --- parseHoverContents: union variants ---
 
     @Test
     fun parsesPlainString() {
-        val blocks = parseHoverContents(element("\"hello world\""))
+        // A bare-string MarkedString is markdown per the LSP spec.
+        val blocks = parseHoverContents(
+            HoverContents.MarkedStringValue(markedString("hello world"))
+        )
         assertEquals(1, blocks.size)
         assertEquals("hello world", blocks[0].text)
-        assertFalse(blocks[0].markdown)
+        assertTrue(blocks[0].markdown)
         assertNull(blocks[0].language)
     }
 
     @Test
     fun parsesMarkupContentMarkdown() {
         val blocks = parseHoverContents(
-            element("""{"kind":"markdown","value":"**bold** text"}""")
+            HoverContents.MarkupContentValue(
+                MarkupContent(kind = MarkupKind.MARKDOWN, value = "**bold** text")
+            )
         )
         assertEquals(1, blocks.size)
         assertEquals("**bold** text", blocks[0].text)
@@ -64,7 +75,9 @@ class ServerHoverTest {
     @Test
     fun parsesMarkupContentPlainText() {
         val blocks = parseHoverContents(
-            element("""{"kind":"plaintext","value":"*not* bold"}""")
+            HoverContents.MarkupContentValue(
+                MarkupContent(kind = MarkupKind.PLAIN_TEXT, value = "*not* bold")
+            )
         )
         assertEquals(1, blocks.size)
         assertFalse(blocks[0].markdown)
@@ -73,7 +86,7 @@ class ServerHoverTest {
     @Test
     fun parsesMarkedStringObject() {
         val blocks = parseHoverContents(
-            element("""{"language":"kotlin","value":"fun foo()"}""")
+            HoverContents.MarkedStringValue(markedString("kotlin", "fun foo()"))
         )
         assertEquals(1, blocks.size)
         assertEquals("fun foo()", blocks[0].text)
@@ -84,8 +97,8 @@ class ServerHoverTest {
     @Test
     fun parsesMarkedStringArray() {
         val blocks = parseHoverContents(
-            element(
-                """[{"language":"kotlin","value":"fun foo()"},"some *markdown*"]"""
+            HoverContents.MarkedStringArray(
+                listOf(markedString("kotlin", "fun foo()"), markedString("some *markdown*"))
             )
         )
         assertEquals(2, blocks.size)
@@ -96,12 +109,15 @@ class ServerHoverTest {
     }
 
     @Test
-    fun dropsBlankAndNullBlocks() {
-        assertTrue(parseHoverContents(element("\"   \"")).isEmpty())
-        assertTrue(parseHoverContents(element("null")).isEmpty())
-        assertTrue(parseHoverContents(element("[]")).isEmpty())
+    fun dropsBlankBlocks() {
+        assertTrue(
+            parseHoverContents(HoverContents.MarkedStringValue(markedString("   "))).isEmpty()
+        )
+        assertTrue(parseHoverContents(HoverContents.MarkedStringArray(emptyList())).isEmpty())
         val blocks = parseHoverContents(
-            element("""[{"language":"kotlin","value":"x"},"  "]""")
+            HoverContents.MarkedStringArray(
+                listOf(markedString("kotlin", "x"), markedString("  "))
+            )
         )
         assertEquals(1, blocks.size)
     }
@@ -187,7 +203,7 @@ class ServerHoverTest {
     @Test
     fun usesPointerPosWhenNoRange() {
         val d = doc("line one\nline two")
-        val hover = Hover(contents = json.parseToJsonElement("\"x\""), range = null)
+        val hover = Hover(contents = HoverContents.markdown("x"), range = null)
         assertEquals(5, hoverTooltipPos(hover, 5, d, null))
     }
 
@@ -196,7 +212,7 @@ class ServerHoverTest {
         val d = doc("line one\nline two")
         // Range starts at line 1 (0-based), char 0 -> offset 9.
         val hover = Hover(
-            contents = json.parseToJsonElement("\"x\""),
+            contents = HoverContents.markdown("x"),
             range = Range(
                 start = Position(line = 1u, character = 0u),
                 end = Position(line = 1u, character = 4u)

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelpTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerSignatureHelpTest.kt
@@ -24,6 +24,7 @@ import com.monkopedia.lsp.LanguageServer
 import com.monkopedia.lsp.ParameterInformation
 import com.monkopedia.lsp.SignatureHelp
 import com.monkopedia.lsp.SignatureInformation
+import com.monkopedia.lsp.StringOr
 import java.lang.reflect.Proxy
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -32,18 +33,15 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonPrimitive
 
 class ServerSignatureHelpTest {
 
-    private fun param(label: kotlinx.serialization.json.JsonElement) =
-        ParameterInformation(label = label)
+    private fun param(label: StringOr<List<UInt>>) = ParameterInformation(label = label)
 
-    private fun strParam(label: String) = param(JsonPrimitive(label))
+    private fun strParam(label: String) = param(StringOr.StringValue(label))
 
     private fun offsetParam(from: Int, to: Int) =
-        param(JsonArray(listOf(JsonPrimitive(from), JsonPrimitive(to))))
+        param(StringOr.Value(listOf(from.toUInt(), to.toUInt())))
 
     private fun signature(
         label: String,


### PR DESCRIPTION
## Summary
Bumps `com.monkopedia.lsp:lsp`/`:lsp-ksrpc` **RC2 → RC3** and replaces the manual `JsonElement` union parsing with RC3's strict types. Net simplification (−16 lines). No public API change (apiCheck green). The `:lsp-ksrpc`/wasmJs target set is unchanged, so the web relay model is unaffected.

(The `:lsp-client` module stays pre-stable — we keep taking RCs and iterating until it's proven against real servers.)

## Adapted read sites (RC3 tightened these struct *fields*; no `LanguageServer`/`LanguageClient` method signatures changed, so `ServerCompletion`/`ServerDefinition` return-value parsing is untouched)
1. **`Hover.contents`** `JsonElement` → sealed **`HoverContents`** — `ServerHover.parseHoverContents` now `when`s over `MarkupContentValue` / `MarkedStringValue` (`MarkedString = StringOr<MarkedStringObject>`) / `MarkedStringArray`.
2. **`ServerCapabilities.textDocumentSync`** `JsonElement` → sealed **`ServerCapabilitiesTextDocumentSync`** — `DocumentSync.forCapabilities` now `when`s over `TextDocumentSyncKind` (legacy number) / `TextDocumentSyncOptions(openClose, change)` / null. Same `DocumentSyncMode` results.
3. **`ParameterInformation.label`** `JsonElement` → **`StringOr<List<UInt>>`** (caught at compile time — the old `JsonArray`/`JsonPrimitive` parse had become dead code under RC3). `ServerSignatureHelp.activeParamRange` now handles `StringOr.Value(List<UInt>)` (offset pair) / `StringOr.StringValue` (substring).

## Minor behavior note
Under the strict `HoverContents`, a top-level bare-string `MarkedString` is indistinguishable from an in-array string, so a plain-string hover now renders as **markdown=true** (was treated as non-markdown). This matches the LSP spec (a `MarkedString` plain string *is* markdown). Test assertion updated accordingly.

## Verification
`:lsp-client:jvmTest` (ServerHover/DocumentSync/ServerSignatureHelp fixtures rebuilt with the strict types), `compileKotlinJvm`/`compileKotlinWasmJs`/`compileDebugKotlinAndroid`, `:lsp-client:apiCheck` — all green. apiCheck confirms no public API change. spotless/ktlint applied; CHANGELOG updated (Changed). Apple/native not cross-compiled on Linux.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ANDROID_HOME=$HOME/Android/Sdk ./gradlew :lsp-client:jvmTest :lsp-client:compileKotlinWasmJs :lsp-client:compileDebugKotlinAndroid :lsp-client:apiCheck -Dorg.gradle.jvmargs="-Xmx6g"`