### PR TITLE
Bump :lsp-client to lsp 1.0.0-RC4 (strict method-result types) + repair showcase stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- Bumped `com.monkopedia.lsp` (`lsp` + `lsp-ksrpc`) from `1.0.0-RC3` to `1.0.0-RC4`. RC4 tightens several `LanguageServer` method *result* types from untyped `JsonElement` to strict sealed unions, so `:lsp-client` now consumes the typed results directly instead of hand-parsing `JsonElement`: `textDocument/completion` reads `TextDocumentCompletionResult` (`CompletionListValue` / `CompletionItemArray`) and the go-to-definition family (`textDocument/{definition,declaration,typeDefinition,implementation}`) reads the strict `TextDocument{Definition,Declaration,TypeDefinition,Implementation}Result` (`DefinitionValue`/`DeclarationValue` wrapping `SingleOrArray<Location>`, and `DefinitionLinkArray`/`DeclarationLinkArray` wrapping `List<LocationLink>`). Internal parsing only; no public API change. The `:lsp-client` module remains pre-stable.
 - Bumped `com.monkopedia.lsp` (`lsp` + `lsp-ksrpc`) from `1.0.0-RC2` to `1.0.0-RC3`. RC3 tightens several `Hover.contents` / `ServerCapabilities.textDocumentSync` fields from untyped `JsonElement` to strict union types, so `:lsp-client`'s `ServerHover` and `DocumentSync` now read the typed `HoverContents` and `ServerCapabilitiesTextDocumentSync` unions directly instead of hand-parsing `JsonElement` (internal parsing only; no public API change). The `:lsp-client` module remains pre-stable.
 
 ### Fixed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kover = "0.9.8"
 dokka = "2.2.0"
 bcv = "0.18.1"
 vanniktech = "0.35.0"
-lsp = "1.0.0-RC3"
+lsp = "1.0.0-RC4"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletion.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletion.kt
@@ -47,14 +47,9 @@ import com.monkopedia.lsp.InsertTextFormat
 import com.monkopedia.lsp.MarkupContent
 import com.monkopedia.lsp.Range
 import com.monkopedia.lsp.StringOr
+import com.monkopedia.lsp.TextDocumentCompletionResult
 import com.monkopedia.lsp.TextDocumentIdentifier
 import com.monkopedia.lsp.TextEdit
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Configuration for [serverCompletion].
@@ -381,30 +376,26 @@ internal fun completionResultRange(
     return from to to
 }
 
-private val completionJson = Json {
-    ignoreUnknownKeys = true
-    isLenient = true
-}
-
 /**
- * Parse the raw `textDocument/completion` result (which the typed
- * [LanguageServer][com.monkopedia.lsp.LanguageServer] returns as a
- * [JsonElement]) into a [CompletionList]. The LSP result is
- * `CompletionItem[] | CompletionList | null`; arrays are wrapped into a list
- * with `isIncomplete = false`, and `null`/JSON-null become null.
+ * Normalize the typed `textDocument/completion` result into a [CompletionList].
+ *
+ * Since the RC4 lsp bump the typed
+ * [LanguageServer][com.monkopedia.lsp.LanguageServer] returns the strict sealed
+ * [TextDocumentCompletionResult] (was a raw `JsonElement`). The LSP result union
+ * is still `CompletionItem[] | CompletionList | null`:
+ * - [CompletionListValue][TextDocumentCompletionResult.CompletionListValue]
+ *   carries the [CompletionList] verbatim (preserving its `isIncomplete`),
+ * - [CompletionItemArray][TextDocumentCompletionResult.CompletionItemArray] is
+ *   wrapped into a list with `isIncomplete = false`,
+ * - a `null` result (the server returning nothing) becomes null here.
  */
-internal fun parseCompletionResult(element: JsonElement?): CompletionList? = when (element) {
-    null, JsonNull -> null
-    is JsonArray -> CompletionList(
-        isIncomplete = false,
-        items = completionJson.decodeFromJsonElement(
-            ListSerializer(CompletionItem.serializer()),
-            element
-        )
-    )
-    is JsonObject -> completionJson.decodeFromJsonElement(CompletionList.serializer(), element)
-    else -> null
-}
+internal fun parseCompletionResult(result: TextDocumentCompletionResult?): CompletionList? =
+    when (result) {
+        null -> null
+        is TextDocumentCompletionResult.CompletionListValue -> result.value
+        is TextDocumentCompletionResult.CompletionItemArray ->
+            CompletionList(isIncomplete = false, items = result.value)
+    }
 
 /**
  * The suspend completion source that requests completions from the language

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinition.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinition.kt
@@ -28,22 +28,22 @@ import com.monkopedia.kodemirror.view.KeyBinding
 import com.monkopedia.kodemirror.view.keymap as keymapFacet
 import com.monkopedia.lsp.BooleanOr
 import com.monkopedia.lsp.DeclarationParams
+import com.monkopedia.lsp.DefinitionLink
 import com.monkopedia.lsp.DefinitionParams
 import com.monkopedia.lsp.ImplementationParams
 import com.monkopedia.lsp.Location
-import com.monkopedia.lsp.LocationLink
 import com.monkopedia.lsp.Position
 import com.monkopedia.lsp.Range
 import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.SingleOrArray
+import com.monkopedia.lsp.TextDocumentDeclarationResult
+import com.monkopedia.lsp.TextDocumentDefinitionResult
 import com.monkopedia.lsp.TextDocumentIdentifier
+import com.monkopedia.lsp.TextDocumentImplementationResult
+import com.monkopedia.lsp.TextDocumentTypeDefinitionResult
 import com.monkopedia.lsp.TypeDefinitionParams
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
 
 /**
  * The per-editor go-to-definition binding: the [client] wrapping the language
@@ -82,53 +82,78 @@ internal val definitionServer: Facet<DefinitionServer?, DefinitionServer?> =
  */
 internal data class JumpTarget(val uri: String, val range: Range)
 
-private val definitionJson = Json {
-    ignoreUnknownKeys = true
-    isLenient = true
+/**
+ * Collapse a `Definition`/`Declaration` value — the LSP `Location | Location[]`
+ * union, modelled by the lsp library as [SingleOrArray]`<`[Location]`>` — into
+ * the first navigable [JumpTarget].
+ *
+ * For the array shape the **first** element is used, matching upstream's
+ * `Array.isArray(response) ? response[0] : response`; an empty array yields null.
+ */
+internal fun SingleOrArray<Location>.firstJumpTarget(): JumpTarget? {
+    val location = when (this) {
+        is SingleOrArray.Single -> value
+        is SingleOrArray.Multiple -> value.firstOrNull()
+    } ?: return null
+    return JumpTarget(location.uri, location.range)
 }
 
 /**
- * Parse the raw definition-family result (which the typed
- * [LanguageServer][com.monkopedia.lsp.LanguageServer] returns as a [JsonElement])
- * into the first navigable [JumpTarget], or null when there is nothing to jump
- * to.
+ * Collapse a `DefinitionLink[]`/`DeclarationLink[]` value (a list of
+ * [DefinitionLink], which is [LocationLink]) into the first navigable
+ * [JumpTarget], or null for an empty list.
  *
- * Handles every shape the result union allows:
- * - `null` / JSON `null` → null,
- * - a single `Location` object (`{uri, range}`),
- * - a single `LocationLink` object (`{targetUri, targetSelectionRange, ...}`),
- * - an array of `Location` or `LocationLink` (the **first** element is used,
- *   matching upstream's `Array.isArray(response) ? response[0] : response`).
- *
- * For a [LocationLink] the [targetSelectionRange][LocationLink.targetSelectionRange]
- * is used (the range that should be revealed/selected when the link is followed,
- * per the LSP spec), with its [targetUri][LocationLink.targetUri].
+ * For a [LocationLink][com.monkopedia.lsp.LocationLink] the
+ * `targetSelectionRange` is used (the range that should be revealed/selected when
+ * the link is followed, per the LSP spec), with its `targetUri`.
  */
-internal fun parseDefinitionResult(element: JsonElement?): JumpTarget? = when (element) {
-    null, JsonNull -> null
-    is JsonObject -> parseLocationElement(element)
-    is JsonArray -> element.firstOrNull()?.let { parseLocationElement(it) }
-    else -> null
+internal fun List<DefinitionLink>.firstJumpTarget(): JumpTarget? {
+    val link = firstOrNull() ?: return null
+    return JumpTarget(link.targetUri, link.targetSelectionRange)
 }
 
 /**
- * Parse a single element of a definition-family result — either a [Location]
- * (`{uri, range}`) or a [LocationLink] (`{targetUri, targetSelectionRange, …}`),
- * disambiguated by which key is present (`uri` vs `targetUri`).
+ * Collapse a `textDocument/definition` result into the first navigable
+ * [JumpTarget].
+ *
+ * Since the RC4 lsp bump the typed
+ * [LanguageServer][com.monkopedia.lsp.LanguageServer] returns the strict sealed
+ * [TextDocumentDefinitionResult] (was a raw `JsonElement`). The
+ * [DefinitionValue][TextDocumentDefinitionResult.DefinitionValue] branch carries
+ * a `Location | Location[]`; the
+ * [DefinitionLinkArray][TextDocumentDefinitionResult.DefinitionLinkArray] branch
+ * carries a `LocationLink[]`. A `null` result (server returned nothing) → null.
  */
-private fun parseLocationElement(element: JsonElement): JumpTarget? {
-    val obj = element as? JsonObject ?: return null
-    if (obj.containsKey("targetUri")) {
-        val link = runCatching {
-            definitionJson.decodeFromJsonElement(LocationLink.serializer(), obj)
-        }.getOrNull() ?: return null
-        return JumpTarget(link.targetUri, link.targetSelectionRange)
+internal fun parseDefinitionResult(result: TextDocumentDefinitionResult?): JumpTarget? =
+    when (result) {
+        null -> null
+        is TextDocumentDefinitionResult.DefinitionValue -> result.value.firstJumpTarget()
+        is TextDocumentDefinitionResult.DefinitionLinkArray -> result.value.firstJumpTarget()
     }
-    val loc = runCatching {
-        definitionJson.decodeFromJsonElement(Location.serializer(), obj)
-    }.getOrNull() ?: return null
-    return JumpTarget(loc.uri, loc.range)
-}
+
+/** As [parseDefinitionResult], for the `textDocument/declaration` result. */
+internal fun parseDeclarationResult(result: TextDocumentDeclarationResult?): JumpTarget? =
+    when (result) {
+        null -> null
+        is TextDocumentDeclarationResult.DeclarationValue -> result.value.firstJumpTarget()
+        is TextDocumentDeclarationResult.DeclarationLinkArray -> result.value.firstJumpTarget()
+    }
+
+/** As [parseDefinitionResult], for the `textDocument/typeDefinition` result. */
+internal fun parseTypeDefinitionResult(result: TextDocumentTypeDefinitionResult?): JumpTarget? =
+    when (result) {
+        null -> null
+        is TextDocumentTypeDefinitionResult.DefinitionValue -> result.value.firstJumpTarget()
+        is TextDocumentTypeDefinitionResult.DefinitionLinkArray -> result.value.firstJumpTarget()
+    }
+
+/** As [parseDefinitionResult], for the `textDocument/implementation` result. */
+internal fun parseImplementationResult(result: TextDocumentImplementationResult?): JumpTarget? =
+    when (result) {
+        null -> null
+        is TextDocumentImplementationResult.DefinitionValue -> result.value.firstJumpTarget()
+        is TextDocumentImplementationResult.DefinitionLinkArray -> result.value.firstJumpTarget()
+    }
 
 /**
  * Whether a [ServerCapabilities] field carrying one of the definition-family
@@ -161,8 +186,8 @@ private inline fun DefinitionServer.serverSupports(
  *   facet; returns false (command not handled) when none is installed,
  * - returns false when the server explicitly lacks the [capability],
  * - otherwise flushes pending edits ([LSPClient.sync]), issues [request] at the
- *   cursor, parses the result union ([parseDefinitionResult]) and navigates
- *   ([navigateToTarget]).
+ *   cursor (each caller maps its strict sealed result to a [JumpTarget]) and
+ *   navigates ([navigateToTarget]).
  *
  * The suspending work runs on the [client scope][LSPClient.scope] (not the
  * session's) because a cross-file jump targets a different editor session, and
@@ -177,7 +202,7 @@ private inline fun DefinitionServer.serverSupports(
 private inline fun jumpToOrigin(
     session: EditorSession,
     crossinline capability: (ServerCapabilities) -> BooleanOr<*>?,
-    crossinline request: suspend (DefinitionServer, Position) -> JsonElement
+    crossinline request: suspend (DefinitionServer, Position) -> JumpTarget?
 ): Boolean {
     val binding = session.state.facet(definitionServer) ?: return false
     if (!binding.serverSupports(capability)) return false
@@ -185,12 +210,11 @@ private inline fun jumpToOrigin(
     binding.client.scope.launch {
         binding.client.sync()
         val position = toPosition(pos, session.state.doc)
-        val result = try {
+        val target = try {
             request(binding, position)
         } catch (e: CancellationException) {
             throw e
-        }
-        val target = parseDefinitionResult(result) ?: return@launch
+        } ?: return@launch
         navigateToTarget(binding, target)
     }
     return true
@@ -224,10 +248,12 @@ fun jumpToDefinition(session: EditorSession): Boolean = jumpToOrigin(
     session,
     capability = { it.definitionProvider },
     request = { binding, position ->
-        binding.client.server.textDocumentDefinition(
-            DefinitionParams(
-                textDocument = TextDocumentIdentifier(uri = binding.uri),
-                position = position
+        parseDefinitionResult(
+            binding.client.server.textDocumentDefinition(
+                DefinitionParams(
+                    textDocument = TextDocumentIdentifier(uri = binding.uri),
+                    position = position
+                )
             )
         )
     }
@@ -243,10 +269,12 @@ fun jumpToDeclaration(session: EditorSession): Boolean = jumpToOrigin(
     session,
     capability = { it.declarationProvider },
     request = { binding, position ->
-        binding.client.server.textDocumentDeclaration(
-            DeclarationParams(
-                textDocument = TextDocumentIdentifier(uri = binding.uri),
-                position = position
+        parseDeclarationResult(
+            binding.client.server.textDocumentDeclaration(
+                DeclarationParams(
+                    textDocument = TextDocumentIdentifier(uri = binding.uri),
+                    position = position
+                )
             )
         )
     }
@@ -262,10 +290,12 @@ fun jumpToTypeDefinition(session: EditorSession): Boolean = jumpToOrigin(
     session,
     capability = { it.typeDefinitionProvider },
     request = { binding, position ->
-        binding.client.server.textDocumentTypeDefinition(
-            TypeDefinitionParams(
-                textDocument = TextDocumentIdentifier(uri = binding.uri),
-                position = position
+        parseTypeDefinitionResult(
+            binding.client.server.textDocumentTypeDefinition(
+                TypeDefinitionParams(
+                    textDocument = TextDocumentIdentifier(uri = binding.uri),
+                    position = position
+                )
             )
         )
     }
@@ -281,10 +311,12 @@ fun jumpToImplementation(session: EditorSession): Boolean = jumpToOrigin(
     session,
     capability = { it.implementationProvider },
     request = { binding, position ->
-        binding.client.server.textDocumentImplementation(
-            ImplementationParams(
-                textDocument = TextDocumentIdentifier(uri = binding.uri),
-                position = position
+        parseImplementationResult(
+            binding.client.server.textDocumentImplementation(
+                ImplementationParams(
+                    textDocument = TextDocumentIdentifier(uri = binding.uri),
+                    position = position
+                )
             )
         )
     }

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletionTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletionTest.kt
@@ -25,6 +25,7 @@ import com.monkopedia.kodemirror.state.Text
 import com.monkopedia.lsp.CompletionItem
 import com.monkopedia.lsp.CompletionItemKind
 import com.monkopedia.lsp.CompletionItemLabelDetails
+import com.monkopedia.lsp.CompletionList
 import com.monkopedia.lsp.InsertReplaceEdit
 import com.monkopedia.lsp.InsertTextFormat
 import com.monkopedia.lsp.MarkupContent
@@ -32,6 +33,7 @@ import com.monkopedia.lsp.MarkupKind
 import com.monkopedia.lsp.Position
 import com.monkopedia.lsp.Range
 import com.monkopedia.lsp.StringOr
+import com.monkopedia.lsp.TextDocumentCompletionResult
 import com.monkopedia.lsp.TextEdit
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -309,10 +311,10 @@ class ServerCompletionTest {
 
     @Test
     fun parseArrayResult() {
-        val json = kotlinx.serialization.json.Json.parseToJsonElement(
-            """[{"label":"a"},{"label":"b"}]"""
+        val result = TextDocumentCompletionResult.CompletionItemArray(
+            listOf(CompletionItem(label = "a"), CompletionItem(label = "b"))
         )
-        val list = parseCompletionResult(json)
+        val list = parseCompletionResult(result)
         assertNotNull(list)
         assertEquals(false, list.isIncomplete)
         assertEquals(2, list.items.size)
@@ -321,10 +323,10 @@ class ServerCompletionTest {
 
     @Test
     fun parseCompletionListResult() {
-        val json = kotlinx.serialization.json.Json.parseToJsonElement(
-            """{"isIncomplete":true,"items":[{"label":"x"}]}"""
+        val result = TextDocumentCompletionResult.CompletionListValue(
+            CompletionList(isIncomplete = true, items = listOf(CompletionItem(label = "x")))
         )
-        val list = parseCompletionResult(json)
+        val list = parseCompletionResult(result)
         assertNotNull(list)
         assertTrue(list.isIncomplete)
         assertEquals(1, list.items.size)

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinitionTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/ServerDefinitionTest.kt
@@ -24,6 +24,15 @@ import com.monkopedia.kodemirror.view.EditorSession
 import com.monkopedia.lsp.BooleanOr
 import com.monkopedia.lsp.DefinitionOptions
 import com.monkopedia.lsp.LanguageServer
+import com.monkopedia.lsp.Location
+import com.monkopedia.lsp.LocationLink
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.SingleOrArray
+import com.monkopedia.lsp.TextDocumentDeclarationResult
+import com.monkopedia.lsp.TextDocumentDefinitionResult
+import com.monkopedia.lsp.TextDocumentImplementationResult
+import com.monkopedia.lsp.TextDocumentTypeDefinitionResult
 import java.lang.reflect.Proxy
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -32,50 +41,36 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 class ServerDefinitionTest {
 
-    private fun rangeJson(startLine: Int, startChar: Int, endLine: Int, endChar: Int): JsonObject =
-        buildJsonObject {
-            put(
-                "start",
-                buildJsonObject {
-                    put("line", startLine)
-                    put("character", startChar)
-                }
-            )
-            put(
-                "end",
-                buildJsonObject {
-                    put("line", endLine)
-                    put("character", endChar)
-                }
-            )
-        }
+    private fun range(startLine: Int, startChar: Int, endLine: Int, endChar: Int): Range = Range(
+        start = Position(line = startLine.toUInt(), character = startChar.toUInt()),
+        end = Position(line = endLine.toUInt(), character = endChar.toUInt())
+    )
 
-    private fun locationJson(uri: String, line: Int, char: Int): JsonObject = buildJsonObject {
-        put("uri", uri)
-        put("range", rangeJson(line, char, line, char + 1))
-    }
+    private fun location(uri: String, line: Int, char: Int): Location =
+        Location(uri = uri, range = range(line, char, line, char + 1))
 
-    private fun locationLinkJson(uri: String, line: Int, char: Int): JsonObject = buildJsonObject {
-        put("targetUri", uri)
-        put("targetRange", rangeJson(line, 0, line, 20))
-        put("targetSelectionRange", rangeJson(line, char, line, char + 4))
-    }
+    private fun locationLink(uri: String, line: Int, char: Int): LocationLink = LocationLink(
+        targetUri = uri,
+        targetRange = range(line, 0, line, 20),
+        targetSelectionRange = range(line, char, line, char + 4)
+    )
+
+    private fun definitionValue(value: SingleOrArray<Location>): TextDocumentDefinitionResult =
+        TextDocumentDefinitionResult.DefinitionValue(value)
+
+    private fun definitionLinks(value: List<LocationLink>): TextDocumentDefinitionResult =
+        TextDocumentDefinitionResult.DefinitionLinkArray(value)
 
     // --- result-union parsing: Location vs Location[] vs LocationLink[] vs null ---
 
     @Test
     fun parsesSingleLocation() {
-        val target = parseDefinitionResult(locationJson("file:///a.kt", 3, 7))
+        val target = parseDefinitionResult(
+            definitionValue(SingleOrArray.Single(location("file:///a.kt", 3, 7)))
+        )
         assertEquals("file:///a.kt", target?.uri)
         assertEquals(3u, target?.range?.start?.line)
         assertEquals(7u, target?.range?.start?.character)
@@ -83,11 +78,13 @@ class ServerDefinitionTest {
 
     @Test
     fun parsesLocationArrayPicksFirst() {
-        val arr = buildJsonArray {
-            add(locationJson("file:///first.kt", 1, 2))
-            add(locationJson("file:///second.kt", 9, 9))
-        }
-        val target = parseDefinitionResult(arr)
+        val target = parseDefinitionResult(
+            definitionValue(
+                SingleOrArray.Multiple(
+                    listOf(location("file:///first.kt", 1, 2), location("file:///second.kt", 9, 9))
+                )
+            )
+        )
         // Upstream uses response[0] for arrays.
         assertEquals("file:///first.kt", target?.uri)
         assertEquals(1u, target?.range?.start?.line)
@@ -95,7 +92,9 @@ class ServerDefinitionTest {
 
     @Test
     fun parsesSingleLocationLinkUsesTargetSelectionRange() {
-        val target = parseDefinitionResult(locationLinkJson("file:///b.kt", 5, 4))
+        val target = parseDefinitionResult(
+            definitionLinks(listOf(locationLink("file:///b.kt", 5, 4)))
+        )
         assertEquals("file:///b.kt", target?.uri)
         // targetSelectionRange start (not targetRange).
         assertEquals(5u, target?.range?.start?.line)
@@ -104,21 +103,51 @@ class ServerDefinitionTest {
 
     @Test
     fun parsesLocationLinkArrayPicksFirst() {
-        val arr = buildJsonArray {
-            add(locationLinkJson("file:///x.kt", 2, 1))
-            add(locationLinkJson("file:///y.kt", 8, 8))
-        }
-        val target = parseDefinitionResult(arr)
+        val target = parseDefinitionResult(
+            definitionLinks(
+                listOf(locationLink("file:///x.kt", 2, 1), locationLink("file:///y.kt", 8, 8))
+            )
+        )
         assertEquals("file:///x.kt", target?.uri)
         assertEquals(2u, target?.range?.start?.line)
     }
 
     @Test
-    fun parsesNullResults() {
+    fun parsesNullAndEmptyResults() {
         assertNull(parseDefinitionResult(null))
-        assertNull(parseDefinitionResult(JsonNull))
-        assertNull(parseDefinitionResult(JsonArray(emptyList())))
-        assertNull(parseDefinitionResult(JsonPrimitive("nonsense")))
+        assertNull(parseDefinitionResult(definitionValue(SingleOrArray.Multiple(emptyList()))))
+        assertNull(parseDefinitionResult(definitionLinks(emptyList())))
+    }
+
+    @Test
+    fun declarationTypeDefinitionImplementationParseSameShapes() {
+        val declaration = parseDeclarationResult(
+            TextDocumentDeclarationResult.DeclarationValue(
+                SingleOrArray.Single(location("file:///d.kt", 1, 1))
+            )
+        )
+        assertEquals("file:///d.kt", declaration?.uri)
+
+        val typeDef = parseTypeDefinitionResult(
+            TextDocumentTypeDefinitionResult.DefinitionLinkArray(
+                listOf(locationLink("file:///t.kt", 2, 3))
+            )
+        )
+        assertEquals("file:///t.kt", typeDef?.uri)
+        assertEquals(3u, typeDef?.range?.start?.character)
+
+        val impl = parseImplementationResult(
+            TextDocumentImplementationResult.DefinitionValue(
+                SingleOrArray.Multiple(
+                    listOf(location("file:///i.kt", 4, 0), location("file:///j.kt", 9, 9))
+                )
+            )
+        )
+        assertEquals("file:///i.kt", impl?.uri)
+
+        assertNull(parseDeclarationResult(null))
+        assertNull(parseTypeDefinitionResult(null))
+        assertNull(parseImplementationResult(null))
     }
 
     // --- target-range -> document offset resolution ---
@@ -127,7 +156,9 @@ class ServerDefinitionTest {
     fun targetRangeStartResolvesToOffset() {
         val doc = Text.of(listOf("line0", "line1", "XXXXXX"))
         // Target on line 2 (0-based), character 3 -> offset of "X" + 3.
-        val target = parseDefinitionResult(locationJson("file:///a.kt", 2, 3))!!
+        val target = parseDefinitionResult(
+            definitionValue(SingleOrArray.Single(location("file:///a.kt", 2, 3)))
+        )!!
         val offset = fromPosition(target.range.start, doc)
         // "line0\n" = 6, "line1\n" = 12, +3 = 15.
         assertEquals(15, offset)
@@ -136,7 +167,9 @@ class ServerDefinitionTest {
     @Test
     fun targetRangeStartFromLocationLinkResolvesToOffset() {
         val doc = Text.of(listOf("abc", "defgh"))
-        val target = parseDefinitionResult(locationLinkJson("file:///a.kt", 1, 2))!!
+        val target = parseDefinitionResult(
+            definitionLinks(listOf(locationLink("file:///a.kt", 1, 2)))
+        )!!
         val offset = fromPosition(target.range.start, doc)
         // "abc\n" = 4, +2 = 6.
         assertEquals(6, offset)

--- a/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/demos/StubLanguageServer.kt
+++ b/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/demos/StubLanguageServer.kt
@@ -30,6 +30,7 @@ import com.monkopedia.lsp.ColorPresentation
 import com.monkopedia.lsp.ColorPresentationParams
 import com.monkopedia.lsp.CompletionItem
 import com.monkopedia.lsp.CompletionItemKind
+import com.monkopedia.lsp.CompletionList
 import com.monkopedia.lsp.CompletionOptions
 import com.monkopedia.lsp.CompletionParams
 import com.monkopedia.lsp.CreateFilesParams
@@ -65,6 +66,7 @@ import com.monkopedia.lsp.ExecuteCommandParams
 import com.monkopedia.lsp.FoldingRange
 import com.monkopedia.lsp.FoldingRangeParams
 import com.monkopedia.lsp.Hover
+import com.monkopedia.lsp.HoverContents
 import com.monkopedia.lsp.HoverParams
 import com.monkopedia.lsp.ImplementationParams
 import com.monkopedia.lsp.InitializeParams
@@ -109,9 +111,19 @@ import com.monkopedia.lsp.SignatureHelp
 import com.monkopedia.lsp.SignatureHelpOptions
 import com.monkopedia.lsp.SignatureHelpParams
 import com.monkopedia.lsp.SignatureInformation
+import com.monkopedia.lsp.SingleOrArray
 import com.monkopedia.lsp.StringOr
 import com.monkopedia.lsp.TextDocumentCodeActionResult
+import com.monkopedia.lsp.TextDocumentCompletionResult
+import com.monkopedia.lsp.TextDocumentDeclarationResult
+import com.monkopedia.lsp.TextDocumentDefinitionResult
+import com.monkopedia.lsp.TextDocumentDocumentSymbolResult
+import com.monkopedia.lsp.TextDocumentImplementationResult
+import com.monkopedia.lsp.TextDocumentInlineCompletionResult
 import com.monkopedia.lsp.TextDocumentSemanticTokensFullDeltaResult
+import com.monkopedia.lsp.TextDocumentSyncKind
+import com.monkopedia.lsp.TextDocumentSyncOptions
+import com.monkopedia.lsp.TextDocumentTypeDefinitionResult
 import com.monkopedia.lsp.TextEdit
 import com.monkopedia.lsp.TypeDefinitionParams
 import com.monkopedia.lsp.TypeHierarchyItem
@@ -125,11 +137,9 @@ import com.monkopedia.lsp.WorkspaceDiagnosticReport
 import com.monkopedia.lsp.WorkspaceEdit
 import com.monkopedia.lsp.WorkspaceSymbol
 import com.monkopedia.lsp.WorkspaceSymbolParams
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.encodeToJsonElement
 
 /**
  * An in-memory [LanguageServer] used by [LspDemo] to drive the `:lsp-client`
@@ -168,7 +178,10 @@ class StubLanguageServer : LanguageServer {
         capabilities = ServerCapabilities(
             // Incremental text sync ({ openClose: true, change: 2 }, 2 = Incremental)
             // so didOpen/didChange flow with ranged edits.
-            textDocumentSync = Json.parseToJsonElement("""{"openClose":true,"change":2}"""),
+            textDocumentSync = TextDocumentSyncOptions(
+                openClose = true,
+                change = TextDocumentSyncKind.INCREMENTAL
+            ),
             completionProvider = CompletionOptions(
                 triggerCharacters = listOf(".")
             ),
@@ -235,7 +248,9 @@ class StubLanguageServer : LanguageServer {
 
     // ── completion ──
 
-    override suspend fun textDocumentCompletion(params: CompletionParams): JsonElement {
+    override suspend fun textDocumentCompletion(
+        params: CompletionParams
+    ): TextDocumentCompletionResult {
         val items = listOf(
             CompletionItem(
                 label = "greet",
@@ -262,9 +277,8 @@ class StubLanguageServer : LanguageServer {
                 insertText = "name"
             )
         )
-        return Json.encodeToJsonElement(
-            kotlinx.serialization.builtins.ListSerializer(CompletionItem.serializer()),
-            items
+        return TextDocumentCompletionResult.CompletionListValue(
+            CompletionList(isIncomplete = false, items = items)
         )
     }
 
@@ -273,8 +287,7 @@ class StubLanguageServer : LanguageServer {
     // ── hover ──
 
     override suspend fun textDocumentHover(params: HoverParams): Hover = Hover(
-        contents = Json.encodeToJsonElement(
-            MarkupContent.serializer(),
+        contents = HoverContents.MarkupContentValue(
             MarkupContent(
                 kind = MarkupKind.MARKDOWN,
                 value = buildString {
@@ -303,11 +316,11 @@ class StubLanguageServer : LanguageServer {
                     ),
                     parameters = listOf(
                         ParameterInformation(
-                            label = Json.encodeToJsonElement("name: String"),
+                            label = StringOr.StringValue("name: String"),
                             documentation = StringOr.StringValue("The name to greet.")
                         ),
                         ParameterInformation(
-                            label = Json.encodeToJsonElement("polite: Boolean = true"),
+                            label = StringOr.StringValue("polite: Boolean = true"),
                             documentation = StringOr.StringValue("Whether to be polite.")
                         )
                     )
@@ -319,12 +332,14 @@ class StubLanguageServer : LanguageServer {
 
     // ── definition ──
 
-    override suspend fun textDocumentDefinition(params: DefinitionParams): JsonElement =
-        Json.encodeToJsonElement(
-            Location.serializer(),
-            // Jump to the definition of `greet` on the first line of the sample doc.
+    override suspend fun textDocumentDefinition(
+        params: DefinitionParams
+    ): TextDocumentDefinitionResult = TextDocumentDefinitionResult.DefinitionValue(
+        // Jump to the definition of `greet` on the first line of the sample doc.
+        SingleOrArray.Single(
             Location(uri = params.textDocument.uri, range = range(0u, 4u, 0u, 9u))
         )
+    )
 
     // ── references ──
 
@@ -361,11 +376,15 @@ class StubLanguageServer : LanguageServer {
     // these are never reached in this demo; they exist to satisfy the interface.
     // ─────────────────────────────────────────────────────────────────────────
 
-    override suspend fun textDocumentImplementation(params: ImplementationParams): JsonElement =
-        JsonNull
+    override suspend fun textDocumentImplementation(
+        params: ImplementationParams
+    ): TextDocumentImplementationResult =
+        TextDocumentImplementationResult.DefinitionLinkArray(emptyList())
 
-    override suspend fun textDocumentTypeDefinition(params: TypeDefinitionParams): JsonElement =
-        JsonNull
+    override suspend fun textDocumentTypeDefinition(
+        params: TypeDefinitionParams
+    ): TextDocumentTypeDefinitionResult =
+        TextDocumentTypeDefinitionResult.DefinitionLinkArray(emptyList())
 
     override suspend fun textDocumentDocumentColor(
         params: DocumentColorParams
@@ -379,7 +398,10 @@ class StubLanguageServer : LanguageServer {
         params: FoldingRangeParams
     ): List<FoldingRange> = emptyList()
 
-    override suspend fun textDocumentDeclaration(params: DeclarationParams): JsonElement = JsonNull
+    override suspend fun textDocumentDeclaration(
+        params: DeclarationParams
+    ): TextDocumentDeclarationResult =
+        TextDocumentDeclarationResult.DeclarationLinkArray(emptyList())
 
     override suspend fun textDocumentSelectionRange(
         params: SelectionRangeParams
@@ -456,7 +478,8 @@ class StubLanguageServer : LanguageServer {
 
     override suspend fun textDocumentInlineCompletion(
         params: InlineCompletionParams
-    ): JsonElement = JsonNull
+    ): TextDocumentInlineCompletionResult =
+        TextDocumentInlineCompletionResult.InlineCompletionItemArray(emptyList())
 
     override suspend fun textDocumentWillSaveWaitUntil(
         params: WillSaveTextDocumentParams
@@ -466,8 +489,10 @@ class StubLanguageServer : LanguageServer {
         params: DocumentHighlightParams
     ): List<DocumentHighlight> = emptyList()
 
-    override suspend fun textDocumentDocumentSymbol(params: DocumentSymbolParams): JsonElement =
-        buildJsonArray { }
+    override suspend fun textDocumentDocumentSymbol(
+        params: DocumentSymbolParams
+    ): TextDocumentDocumentSymbolResult =
+        TextDocumentDocumentSymbolResult.SymbolInformationArray(emptyList())
 
     override suspend fun textDocumentCodeAction(
         params: CodeActionParams
@@ -504,7 +529,7 @@ class StubLanguageServer : LanguageServer {
 
     override suspend fun textDocumentPrepareRename(
         params: PrepareRenameParams
-    ): PrepareRenameResult = Json.encodeToJsonElement(Range.serializer(), range(0u, 4u, 0u, 9u))
+    ): PrepareRenameResult = range(0u, 4u, 0u, 9u)
 
     override suspend fun workspaceExecuteCommand(params: ExecuteCommandParams): LSPAny = JsonNull
 


### PR DESCRIPTION
## Summary
Bumps `com.monkopedia.lsp` **RC3 → RC4** and adopts RC4's strict method-*result* types, replacing the hand-decoded `JsonElement` returns in `ServerCompletion`/`ServerDefinition` with sealed-branch matching (a simplification). **Also repairs `:samples:showcase`** (see below). No public API change (apiCheck green). `:lsp-ksrpc`/wasmJs targets unchanged. (`:lsp-client` stays pre-stable.)

## Adapted result types (read from the RC4 lsp-kotlin source)
- **`ServerCompletion`** — `textDocument/completion` → sealed `TextDocumentCompletionResult` (`CompletionListValue` | `CompletionItemArray`).
- **`ServerDefinition`** — definition/typeDefinition/implementation → `TextDocument{X}Result` (`DefinitionValue(Definition=SingleOrArray<Location>)` | `DefinitionLinkArray`); **declaration uses distinct branch names** `DeclarationValue` | `DeclarationLinkArray`. Same `JumpTarget` resolution (first element; LocationLink→targetSelectionRange).
- `ServerHover`/`DocumentSync`/`ServerSignatureHelp` (adapted in #62) needed no changes — stable on RC4.
- `workspace/symbol` genuinely stays `JsonElement` in RC4 (we don't consume it).

## Showcase repair (important)
The RC3 bump (#62) verified only `:lsp-client` and **left `main`'s `:samples:showcase` un-compilable against RC3** — its `StubLanguageServer` implements the full `LanguageServer` interface and still returned `JsonElement` for hover/textDocumentSync/parameter-label/prepareRename. This PR fixes all of those **plus** the RC4 result-type changes (completion, definition family, and RC4's `documentSymbol`/`inlineCompletion` results). `:samples:showcase` now compiles (wasmJs + desktop) again.

## Verification
`:lsp-client:jvmTest` (ServerCompletionTest 24, ServerDefinitionTest 13, full module 0 failures), `compileKotlinJvm`/`compileKotlinWasmJs`/`compileDebugKotlinAndroid`, `:lsp-client:apiCheck` (no public API change), **`:samples:showcase:compileKotlinWasmJs` + `:compileKotlinDesktop`** — all green. spotless/ktlint applied; CHANGELOG updated. Apple/native not cross-compiled on Linux.

## Reviewer note
Please re-verify `:samples:showcase:compileKotlinWasmJs` (NOT just `:lsp-client`) — this PR repairs a showcase breakage that the prior RC3 PR's `:lsp-client`-only verification missed.

## Test plan
- [ ] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ANDROID_HOME=$HOME/Android/Sdk ./gradlew :lsp-client:jvmTest :lsp-client:apiCheck :samples:showcase:compileKotlinWasmJs :samples:showcase:compileKotlinDesktop -Dorg.gradle.jvmargs="-Xmx6g"`