### PR TITLE
Add horizontal scrollbar for long lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Horizontal scrollbar for long lines in no-wrap mode. The editor renders on a Skiko canvas with no native scrollbar, so long lines clipped at the right edge with horizontal scroll only reachable via shift+wheel/trackpad. A custom commonMain scrollbar (thin track + draggable thumb) is now shown whenever there is horizontal overflow and line wrapping is off; it is hidden when content fits or `lineWrapping` is enabled (#65)
+
 ### Changed
 - Bumped `com.monkopedia.lsp` (`lsp` + `lsp-ksrpc`) from `1.0.0-RC3` to `1.0.0-RC4`. RC4 tightens several `LanguageServer` method *result* types from untyped `JsonElement` to strict sealed unions, so `:lsp-client` now consumes the typed results directly instead of hand-parsing `JsonElement`: `textDocument/completion` reads `TextDocumentCompletionResult` (`CompletionListValue` / `CompletionItemArray`) and the go-to-definition family (`textDocument/{definition,declaration,typeDefinition,implementation}`) reads the strict `TextDocument{Definition,Declaration,TypeDefinition,Implementation}Result` (`DefinitionValue`/`DeclarationValue` wrapping `SingleOrArray<Location>`, and `DefinitionLinkArray`/`DeclarationLinkArray` wrapping `List<LocationLink>`). Internal parsing only; no public API change. The `:lsp-client` module remains pre-stable.
 - Bumped `com.monkopedia.lsp` (`lsp` + `lsp-ksrpc`) from `1.0.0-RC2` to `1.0.0-RC3`. RC3 tightens several `Hover.contents` / `ServerCapabilities.textDocumentSync` fields from untyped `JsonElement` to strict union types, so `:lsp-client`'s `ServerHover` and `DocumentSync` now read the typed `HoverContents` and `ServerCapabilitiesTextDocumentSync` unions directly instead of hand-parsing `JsonElement` (internal parsing only; no public API change). The `:lsp-client` module remains pre-stable.

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
@@ -23,7 +23,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.awaitTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
@@ -34,6 +37,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -44,6 +48,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.Composable
@@ -60,6 +65,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -78,6 +84,7 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
@@ -85,6 +92,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.monkopedia.kodemirror.state.ChangeSpec
 import com.monkopedia.kodemirror.state.DocPos
@@ -96,6 +104,8 @@ import com.monkopedia.kodemirror.state.Transaction
 import com.monkopedia.kodemirror.state.TransactionSpec
 import com.monkopedia.kodemirror.state.asDoc
 import com.monkopedia.kodemirror.state.asInsert
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
 
 /**
  * The main editor composable.
@@ -492,6 +502,19 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
                     textLayoutResults = textLayoutResults,
                     keyProcessedByCallback = keyProcessedByCallback
                 )
+                // Visible horizontal scrollbar for no-wrap mode (#65). Only
+                // shown when there is actual horizontal overflow and line
+                // wrapping is off — otherwise the long-line content clips at the
+                // right edge with no affordance on the Skiko canvas.
+                if (!wrapLines && horizontalScrollState.maxValue > 0) {
+                    HorizontalScrollbar(
+                        scrollState = horizontalScrollState,
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .fillMaxWidth()
+                            .padding(start = if (hasGutters) gutterWidthDp else 0.dp)
+                    )
+                }
             }
             for (panel in bottomPanels) {
                 Box(
@@ -823,6 +846,86 @@ private fun EditorContent(
 
     // Tooltip layer
     TooltipLayer(session = session)
+}
+
+/**
+ * A custom horizontal scrollbar built entirely from commonMain Compose
+ * primitives so it compiles on every target (jvm, android, wasmJs, native).
+ *
+ * The desktop/skiko `HorizontalScrollbar` is NOT usable here because the
+ * androidMain source set depends on jvmMain, and that API does not exist on
+ * Android. This draws a thin track with a draggable thumb instead.
+ *
+ * Thumb sizing: the visible fraction of the content is
+ * `viewportPx / (viewportPx + scrollState.maxValue)`, so the thumb width is
+ * `trackWidth * viewportFraction`. The thumb offset maps the scroll position
+ * onto the remaining track travel: `(value / maxValue) * (trackWidth - thumb)`.
+ *
+ * Dragging maps thumb-track pixels back to content pixels by the inverse ratio
+ * `(trackWidth - thumb)` of travel ↔ `maxValue` of scroll, so a full thumb
+ * sweep scrolls the full content.
+ */
+@Composable
+private fun HorizontalScrollbar(
+    scrollState: ScrollState,
+    modifier: Modifier = Modifier
+) {
+    val theme = LocalEditorTheme.current
+    val scope = rememberCoroutineScope()
+    val thumbColor = theme.foreground.copy(alpha = 0.35f)
+    val trackColor = theme.foreground.copy(alpha = 0.08f)
+
+    var trackWidthPx by remember { mutableStateOf(0) }
+
+    Box(
+        modifier = modifier
+            .testTag("KodeMirror_hscroll")
+            .height(10.dp)
+            .background(trackColor)
+            .onSizeChanged { trackWidthPx = it.width }
+    ) {
+        val maxValue = scrollState.maxValue
+        val trackWidth = trackWidthPx.toFloat()
+        if (trackWidth > 0f && maxValue > 0) {
+            // Visible fraction of the content -> thumb length as a fraction of
+            // the track. The total content width in px is viewport + maxValue.
+            val viewportFraction = trackWidth / (trackWidth + maxValue)
+            val minThumbPx = with(LocalDensity.current) { 24.dp.toPx() }
+            val thumbWidthPx = (trackWidth * viewportFraction)
+                .coerceIn(minThumbPx.coerceAtMost(trackWidth), trackWidth)
+            val travel = trackWidth - thumbWidthPx
+            val thumbOffsetPx = if (maxValue > 0 && travel > 0f) {
+                (scrollState.value.toFloat() / maxValue) * travel
+            } else {
+                0f
+            }
+            val density = LocalDensity.current
+            val thumbWidthDp = with(density) { thumbWidthPx.toDp() }
+
+            Box(
+                modifier = Modifier
+                    .offset { IntOffset(thumbOffsetPx.roundToInt(), 0) }
+                    .width(thumbWidthDp)
+                    .height(8.dp)
+                    .padding(vertical = 1.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(thumbColor)
+                    .draggable(
+                        orientation = Orientation.Horizontal,
+                        state = rememberDraggableState { deltaPx ->
+                            if (travel > 0f) {
+                                // Map thumb-track pixels back to content
+                                // pixels: full travel == full maxValue scroll.
+                                val scrollDelta = deltaPx * (maxValue / travel)
+                                scope.launch {
+                                    scrollState.scrollBy(scrollDelta)
+                                }
+                            }
+                        }
+                    )
+            )
+        }
+    }
 }
 
 /** Draw editor and gutter backgrounds behind content. */

--- a/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/HorizontalScrollTest.kt
+++ b/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/HorizontalScrollTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view.input
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.ScrollWheel
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import com.monkopedia.kodemirror.view.lineWrapping
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class HorizontalScrollTest {
+
+    private val longLine = (1..60).joinToString(" ") { "word$it" }
+
+    @Test
+    fun wheelScrollAdvancesClickOffset() = runEditorTest(
+        doc = longLine,
+        width = 300
+    ) { holder ->
+        // Click near the right edge before scrolling.
+        onNodeWithTag("KodeMirror").performMouseInput {
+            click(Offset(250f, 15f))
+        }
+        waitForIdle()
+        val before = holder.session.state.selection.main.head.value
+
+        // Scroll horizontally with the wheel, then click the same screen point.
+        onNodeWithTag("KodeMirror").performMouseInput {
+            moveTo(Offset(150f, 15f))
+            scroll(600f, ScrollWheel.Horizontal)
+        }
+        waitForIdle()
+
+        onNodeWithTag("KodeMirror").performMouseInput {
+            click(Offset(250f, 15f))
+        }
+        waitForIdle()
+        val after = holder.session.state.selection.main.head.value
+
+        assert(after > before + 50) {
+            "Expected click offset to advance after horizontal scroll, " +
+                "but before=$before after=$after"
+        }
+    }
+
+    @Test
+    fun scrollbarVisibleOnOverflow() = runEditorTest(
+        doc = longLine,
+        width = 300
+    ) {
+        onNodeWithTag("KodeMirror_hscroll").assertExists()
+    }
+
+    @Test
+    fun scrollbarHiddenWhenContentFits() = runEditorTest(
+        doc = "short",
+        width = 800
+    ) {
+        onNodeWithTag("KodeMirror_hscroll").assertDoesNotExist()
+    }
+
+    @Test
+    fun scrollbarHiddenWhenWrapping() = runEditorTest(
+        doc = longLine,
+        extensions = lineWrapping,
+        width = 300
+    ) {
+        onNodeWithTag("KodeMirror_hscroll").assertDoesNotExist()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a visible horizontal scrollbar for long lines in the default no-wrap mode. The editor renders on a Skiko canvas with no native scrollbar, so long lines clipped at the right edge and horizontal scroll was only reachable via shift+wheel/trackpad (the scroll engine from #20/#64 works but had no affordance).
- The scrollbar is a custom composable built entirely in `commonMain` from Compose foundation primitives (`Box`, `background`, `draggable`, `offset`, `onSizeChanged`, `clip`/`RoundedCornerShape`). It does NOT use the skiko/desktop `HorizontalScrollbar`, which is unavailable on Android (androidMain depends on jvmMain).
- Thumb length is proportional to the visible fraction `viewportPx / (viewportPx + maxValue)` of the measured track width (min 24.dp). Thumb offset = `(value / maxValue) * (trackWidth - thumbWidth)`. Dragging maps thumb-track pixels back to content pixels via `delta * (maxValue / travel)` and applies it with `scrollState.scrollBy` in a coroutine.
- Shown only when there is real horizontal overflow (`maxValue > 0`) and line wrapping is off; hidden when content fits or `lineWrapping` is enabled.
- The composable and mount are `private`, so there is no public-API change (apiCheck stays green, no apiDump).

## Test plan
- [x] `:view:jvmTest --tests "com.monkopedia.kodemirror.view.input.HorizontalScrollTest"` (4 tests: wheel-scroll advances click offset, scrollbar visible on overflow, hidden when content fits, hidden when wrapping)
- [x] `:view:jvmTest --tests "com.monkopedia.kodemirror.view.input.*"` (no regressions)
- [x] `:view:compileKotlinJvm`, `:view:compileKotlinWasmJs`, `:view:compileDebugKotlinAndroid`, `:view:compileKotlinIosSimulatorArm64` all compile (proves the commonMain scrollbar is portable)
- [x] `:view:apiCheck` green (no public-API change)
- [x] `:view:spotlessApply`

Fixes #65