### PR TITLE
Add Line Wrapping showcase demo

### DIFF
--- a/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/SampleDocs.kt
+++ b/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/SampleDocs.kt
@@ -264,6 +264,21 @@ object SampleDocs {
         }
     """.trimIndent()
 
+    val wrapping = """
+        Line wrapping in KodeMirror
+
+        This paragraph is intentionally a single very long line of prose so that the difference between soft-wrapping and horizontal scrolling is immediately obvious: when the lineWrapping extension is enabled the text reflows to fit the available width, but when it is disabled the line simply continues off the right edge of the viewport and a horizontal scrollbar appears instead, while the caret keeps the cursor in view as you move along it.
+
+        Short line.
+
+        Another paragraph with enough words to clearly exceed the width of a typical editor viewport, demonstrating that wrapping applies to every visual line in the document rather than just the first one, and that toggling the mode reflows or unflows all of them at once.
+
+        // A long code-ish comment line that also runs well past the right edge so that even monospace content shows the wrap-vs-scroll behavior without needing any syntax highlighting at all to make the point.
+        val longString = "this is a deliberately long string literal value that does not contain any line breaks and therefore stretches far beyond the visible editor width when wrapping is turned off"
+
+        End.
+    """.trimIndent()
+
     val largeDocument: String by lazy {
         buildString {
             repeat(10_000) { i ->

--- a/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/ShowcaseApp.kt
+++ b/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/ShowcaseApp.kt
@@ -51,6 +51,7 @@ import com.monkopedia.kodemirror.samples.showcase.demos.TabDemo
 import com.monkopedia.kodemirror.samples.showcase.demos.TooltipDemo
 import com.monkopedia.kodemirror.samples.showcase.demos.TranslateDemo
 import com.monkopedia.kodemirror.samples.showcase.demos.VimModeDemo
+import com.monkopedia.kodemirror.samples.showcase.demos.WrappingDemo
 import com.monkopedia.kodemirror.samples.showcase.demos.ZebraDemo
 
 enum class DemoCategory(val title: String) {
@@ -95,6 +96,10 @@ val allDemos: List<DemoItem> = listOf(
         "readonly", "Read-Only Mode", "Toggle editable",
         DemoCategory.CONFIGURATION
     ) { ReadOnlyDemo() },
+    DemoItem(
+        "wrapping", "Line Wrapping", "Soft-wrap vs horizontal scroll",
+        DemoCategory.CONFIGURATION
+    ) { WrappingDemo() },
     DemoItem(
         "keybindings", "Keybindings", "Keymap presets & reference",
         DemoCategory.CONFIGURATION

--- a/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/demos/WrappingDemo.kt
+++ b/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/demos/WrappingDemo.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.kodemirror.samples.showcase.demos
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.monkopedia.kodemirror.basicsetup.basicSetup
+import com.monkopedia.kodemirror.samples.showcase.DemoScaffold
+import com.monkopedia.kodemirror.samples.showcase.SampleDocs
+import com.monkopedia.kodemirror.state.Compartment
+import com.monkopedia.kodemirror.state.ExtensionList
+import com.monkopedia.kodemirror.state.TransactionSpec
+import com.monkopedia.kodemirror.state.plus
+import com.monkopedia.kodemirror.view.KodeMirror
+import com.monkopedia.kodemirror.view.lineWrapping
+import com.monkopedia.kodemirror.view.rememberEditorSession
+
+@Composable
+fun WrappingDemo() {
+    var wrap by remember { mutableStateOf(true) }
+
+    val wrapCompartment = remember { Compartment() }
+
+    val session = rememberEditorSession(
+        doc = SampleDocs.wrapping,
+        extensions = basicSetup +
+            wrapCompartment.of(if (wrap) lineWrapping else ExtensionList(emptyList()))
+    )
+
+    DemoScaffold(
+        title = "Line Wrapping",
+        description = "Toggle the lineWrapping extension. Default no-wrap mode scrolls long " +
+            "lines horizontally (with a scrollbar and caret-follow); lineWrapping soft-wraps " +
+            "them to fit the width instead.",
+        controls = {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                FilterChip(
+                    selected = wrap,
+                    onClick = {
+                        wrap = true
+                        session.dispatch(
+                            TransactionSpec(
+                                effects = listOf(
+                                    wrapCompartment.reconfigure(lineWrapping)
+                                )
+                            )
+                        )
+                    },
+                    label = { Text("Wrap") }
+                )
+                FilterChip(
+                    selected = !wrap,
+                    onClick = {
+                        wrap = false
+                        session.dispatch(
+                            TransactionSpec(
+                                effects = listOf(
+                                    wrapCompartment.reconfigure(ExtensionList(emptyList()))
+                                )
+                            )
+                        )
+                    },
+                    label = { Text("No wrap") }
+                )
+            }
+        }
+    ) {
+        KodeMirror(
+            session = session,
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a "Line Wrapping" demo to the showcase app under the Configuration category, mirroring the `ConfigDemo` Compartment + `FilterChip` pattern.
- The demo wraps the public `com.monkopedia.kodemirror.view.lineWrapping` extension in a `Compartment`, defaulting to wrap ON. A "Wrap" / "No wrap" chip toggle reconfigures the compartment between `lineWrapping` and an empty `ExtensionList`.
- Adds `SampleDocs.wrapping`, a purpose-built document with long prose lines, a long comment line, and a long string literal mixed with short lines so the soft-wrap vs horizontal-scroll difference is obvious.
- Registers the demo in `allDemos` with id `wrapping` (subtitle "Soft-wrap vs horizontal scroll"), placed after the read-only entry.

## Verification
- `:samples:showcase:compileKotlinWasmJs` (with `-Xmx6g`): BUILD SUCCESSFUL
- `:samples:showcase:compileKotlinDesktop`: BUILD SUCCESSFUL
- No ktlint/spotless task exists for the showcase module (it does not apply the `kodemirror.library` convention); code mirrors the existing `ConfigDemo.kt` formatting.

Fixes #71