### PR TITLE
Fix Line Wrapping demo crash (missing language extension)

### DIFF
--- a/samples/showcase/build.gradle.kts
+++ b/samples/showcase/build.gradle.kts
@@ -69,6 +69,11 @@ kotlin {
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
         }
+        val desktopTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }
 

--- a/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/demos/WrappingDemo.kt
+++ b/samples/showcase/src/commonMain/kotlin/com/monkopedia/kodemirror/samples/showcase/demos/WrappingDemo.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.monkopedia.kodemirror.basicsetup.basicSetup
+import com.monkopedia.kodemirror.lang.markdown.markdown
 import com.monkopedia.kodemirror.samples.showcase.DemoScaffold
 import com.monkopedia.kodemirror.samples.showcase.SampleDocs
 import com.monkopedia.kodemirror.state.Compartment
@@ -49,6 +50,7 @@ fun WrappingDemo() {
     val session = rememberEditorSession(
         doc = SampleDocs.wrapping,
         extensions = basicSetup +
+            markdown().extension +
             wrapCompartment.of(if (wrap) lineWrapping else ExtensionList(emptyList()))
     )
 

--- a/samples/showcase/src/desktopTest/kotlin/com/monkopedia/kodemirror/samples/showcase/demos/WrappingDemoStateTest.kt
+++ b/samples/showcase/src/desktopTest/kotlin/com/monkopedia/kodemirror/samples/showcase/demos/WrappingDemoStateTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.monkopedia.kodemirror.samples.showcase.demos
+
+import com.monkopedia.kodemirror.basicsetup.basicSetup
+import com.monkopedia.kodemirror.lang.markdown.markdown
+import com.monkopedia.kodemirror.samples.showcase.SampleDocs
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.asDoc
+import com.monkopedia.kodemirror.state.plus
+import com.monkopedia.kodemirror.view.lineWrapping
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Regression test for the Line Wrapping demo crash.
+ *
+ * [basicSetup] installs a runtime guard (a StateField) that throws
+ * `IllegalStateException("No language extension configured...")` from inside
+ * [EditorState.create] when no language extension is present. The Line Wrapping
+ * demo originally configured `basicSetup + lineWrapping` with no language and
+ * crashed on load. This compiles fine, so a compile check alone never caught it.
+ *
+ * This test realizes the exact extension list the demo now uses and asserts that
+ * creating the state does NOT throw.
+ */
+class WrappingDemoStateTest {
+
+    @Test
+    fun wrappingDemoExtensionsCreateStateWithoutThrowing() {
+        // Mirror WrappingDemo: basicSetup + markdown language + lineWrapping (wrap on).
+        val extensions = basicSetup + markdown().extension + lineWrapping
+        val state = EditorState.create(
+            EditorStateConfig(
+                doc = SampleDocs.wrapping.asDoc(),
+                extensions = extensions
+            )
+        )
+        assertNotNull(state)
+    }
+
+    @Test
+    fun wrappingDemoExtensionsCreateStateNoWrapWithoutThrowing() {
+        // Mirror the "No wrap" branch: language present, wrap compartment empty.
+        val extensions = basicSetup + markdown().extension
+        val state = EditorState.create(
+            EditorStateConfig(
+                doc = SampleDocs.wrapping.asDoc(),
+                extensions = extensions
+            )
+        )
+        assertNotNull(state)
+    }
+}


### PR DESCRIPTION
The Line Wrapping demo (#71) crashed on load: `basicSetup` installs a runtime guard requiring a language extension and the demo configured none (`basicSetup + wrapCompartment.of(...)`), throwing `IllegalStateException: No language extension configured`. This compiles fine, so the showcase's compile-only checks never caught it.

## Fix
- Adds `markdown().extension` to the demo's extension list, placed before the wrap compartment (mirrors `ConfigDemo`'s `basicSetup + langCompartment.of(...) + ...` ordering). Markdown suits the prose document and best demonstrates soft-wrap vs horizontal scroll.

## Build dependency
- No new build dependency needed: `samples/showcase/build.gradle.kts` already declares `:lang-markdown` (used by the language gallery). Only addition to the build file is a `desktopTest` source set for the regression test below.

## Runtime verification
The bug is a runtime-only failure inside `EditorState.create`, so compile checks are insufficient. Added a permanent JVM regression test (`WrappingDemoStateTest`) in the new `:samples:showcase` `desktopTest` source set that realizes the exact extension list the demo uses (`basicSetup + markdown().extension + lineWrapping`, plus the no-wrap branch) and calls `EditorState.create(...)`, asserting it does not throw.

Verified locally (`JAVA_HOME=/usr/lib/jvm/java-21-openjdk`, `-Xmx6g`):
- `:samples:showcase:compileKotlinWasmJs` — BUILD SUCCESSFUL
- `:samples:showcase:compileKotlinDesktop` — BUILD SUCCESSFUL
- `:samples:showcase:desktopTest` — BUILD SUCCESSFUL (2 tests, 0 failures)

Fixes #71