### PR TITLE
Make vim gj/gk move by visual (wrapped) row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Bumped `com.monkopedia.lsp` (`lsp` + `lsp-ksrpc`) from `1.0.0-RC2` to `1.0.0-RC3`. RC3 tightens several `Hover.contents` / `ServerCapabilities.textDocumentSync` fields from untyped `JsonElement` to strict union types, so `:lsp-client`'s `ServerHover` and `DocumentSync` now read the typed `HoverContents` and `ServerCapabilitiesTextDocumentSync` unions directly instead of hand-parsing `JsonElement` (internal parsing only; no public API change). The `:lsp-client` module remains pre-stable.
 
 ### Fixed
+- Vim gj/gk now move by visual (wrapped) row (#77)
 - Caret height and gutter alignment on wrapped lines (#75)
 - `KodeMirror` placed under an unbounded vertical constraint (a parent with `Modifier.verticalScroll(...)`, `wrapContentHeight()`, or another scrolling container) no longer collapses to zero height or crashes the inner `LazyColumn` (which disallows an infinite `maxHeight`). The editor now grows to its content height so the surrounding scroll container can scroll it. The `KodeMirror` KDoc documents the height contract: callers should give the editor a bounded height for in-editor scrolling and caret reveal (#33)
 - Cursor now scrolls horizontally into view in no-wrap mode (#69)

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/CursorMotion.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/CursorMotion.kt
@@ -199,14 +199,28 @@ fun moveVertically(
         coords.top - 1f
     }
     val rawPos = view.posAtCoords(coords.centerX, targetY)
-    val resultLine = rawPos?.let { doc.lineAt(DocPos(it)) }
 
-    // Determine target line number — if posAtCoords snapped back to the
-    // same line (e.g. inter-line gap), move to the adjacent line instead.
-    val targetLineNum = if (resultLine != null && resultLine.number != currentLine.number) {
-        resultLine.number.value
+    // posAtCoords is wrap-aware: targetY lands on the adjacent VISUAL row, which
+    // may be another wrapped row of the SAME logical line. Honor that result
+    // directly so vertical motion steps by visual row (this is what gj/gk and
+    // the default cursor up/down rely on for wrapped lines).
+    if (rawPos != null && rawPos != sel.head.value) {
+        val newPos = DocPos(rawPos)
+        val anchor = if (extend) sel.anchor else newPos
+        return if (extend) {
+            EditorSelection.range(anchor, newPos, goalColumn = goalCol)
+        } else {
+            EditorSelection.cursor(newPos, goalColumn = goalCol)
+        }
+    }
+
+    // Fallback: posAtCoords couldn't move (no layout geometry, or it snapped
+    // back to the same offset across an inter-line gap). Step by a whole logical
+    // line using the preserved goal column.
+    val targetLineNum = if (forward) {
+        currentLine.number.value + 1
     } else {
-        if (forward) currentLine.number.value + 1 else currentLine.number.value - 1
+        currentLine.number.value - 1
     }
 
     if (targetLineNum !in 1..doc.lines) return sel

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/CursorMotionTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/CursorMotionTest.kt
@@ -23,7 +23,12 @@ import com.monkopedia.kodemirror.state.DocPos
 import com.monkopedia.kodemirror.state.EditorSelection
 import com.monkopedia.kodemirror.state.EditorState
 import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.Line
+import com.monkopedia.kodemirror.state.Transaction
+import com.monkopedia.kodemirror.state.TransactionSpec
 import com.monkopedia.kodemirror.state.asDoc
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -135,6 +140,129 @@ class CursorMotionTest {
         assertEquals(DocPos.ZERO, moved.anchor)
         assertEquals(DocPos(5), moved.head)
     }
+
+    // -----------------------------------------------------------------------
+    // moveVertically — visual (wrapped) row vs. logical line. This is the
+    // primitive that vim gj/gk delegate to (#77). With wrap-aware geometry it
+    // must step by VISUAL row (staying on the same logical line when that line
+    // wraps); without geometry it must fall back to whole-logical-line motion.
+    // -----------------------------------------------------------------------
+
+    // A logical line "abcdefghij0123456789" (20 chars) that wraps into two
+    // visual rows of 10 columns, followed by a short logical line "second".
+    // Layout model: each visual row is 10px tall, each char is 1px wide.
+    //   row 0: line-0 offsets  0..9   y in [0,10)
+    //   row 1: line-0 offsets 10..19  y in [10,20)
+    //   row 2: line-1 ("second")      y in [20,30)
+    private val wrappedDoc = "abcdefghij0123456789\nsecond"
+
+    private fun wrappedGeometrySession(): EditorSession =
+        object : FakeEditorSession(state(wrappedDoc)) {
+            private val rowHeight = 10f
+
+            override fun coordsAtPos(pos: Int, side: Int): Rect? {
+                val line = state.doc.lineAt(DocPos(pos))
+                val offsetInLine = pos - line.from.value
+                val visualRowWithinLine = offsetInLine / 10
+                val col = offsetInLine % 10
+                // Logical line 1 (number 1) occupies visual rows 0 and 1;
+                // logical line 2 ("second") starts at visual row 2.
+                val absRow = if (line.number.value == 1) visualRowWithinLine else 2
+                val top = absRow * rowHeight
+                val x = col.toFloat()
+                return Rect(x, top, x, top + rowHeight)
+            }
+
+            override fun posAtCoords(x: Float, y: Float): Int? {
+                val absRow = (y / rowHeight).toInt().coerceIn(0, 2)
+                val col = x.toInt().coerceIn(0, 9)
+                return when (absRow) {
+                    0 -> col // line 0, row 0
+                    1 -> 10 + col // line 0, row 1 (same logical line!)
+                    else -> {
+                        // line "second" starts after "abc...789\n" = offset 21
+                        val secondStart = state.doc.line(
+                            com.monkopedia.kodemirror.state.LineNumber(2)
+                        ).from.value
+                        secondStart + col.coerceAtMost(5)
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun moveVerticallyStepsByVisualRowWithinWrappedLine() {
+        val session = wrappedGeometrySession()
+        // Start on the first visual row, column 3 (offset 3).
+        val sel = EditorSelection.cursor(DocPos(3))
+        val moved = moveVertically(session, sel, forward = true)
+        // Visual-row motion: lands on the SECOND wrapped row of the SAME
+        // logical line (offset 13), NOT on the next logical line "second".
+        assertEquals(DocPos(13), moved.head, "gj should move one VISUAL row down")
+        assertEquals(
+            1,
+            session.state.doc.lineAt(moved.head).number.value,
+            "should stay on the same logical line while it wraps"
+        )
+    }
+
+    @Test
+    fun moveVerticallyCrossesToNextLogicalLineAfterLastVisualRow() {
+        val session = wrappedGeometrySession()
+        // Start on the SECOND visual row (offset 13). One more visual row down
+        // exits the wrapped line and reaches the next logical line "second".
+        val sel = EditorSelection.cursor(DocPos(13))
+        val moved = moveVertically(session, sel, forward = true)
+        assertEquals(
+            2,
+            session.state.doc.lineAt(moved.head).number.value,
+            "from the last visual row, moving down crosses to the next logical line"
+        )
+    }
+
+    @Test
+    fun moveVerticallyUpStepsByVisualRow() {
+        val session = wrappedGeometrySession()
+        // From the second wrapped row (offset 13) up one visual row -> first row.
+        val sel = EditorSelection.cursor(DocPos(13))
+        val moved = moveVertically(session, sel, forward = false)
+        assertEquals(DocPos(3), moved.head, "gk should move one VISUAL row up")
+        assertEquals(1, session.state.doc.lineAt(moved.head).number.value)
+    }
+
+    @Test
+    fun moveVerticallyFallsBackToLogicalLineWithoutGeometry() {
+        // No layout geometry (coordsAtPos returns null) — must fall back to
+        // whole-logical-line motion rather than failing. This mirrors the
+        // headless path vim's moveByDisplayLines relies on.
+        val session = object : FakeEditorSession(state(wrappedDoc)) {
+            override fun coordsAtPos(pos: Int, side: Int): Rect? = null
+            override fun posAtCoords(x: Float, y: Float): Int? = null
+        }
+        val sel = EditorSelection.cursor(DocPos(3))
+        val moved = moveVertically(session, sel, forward = true)
+        // coordsAtPos == null -> moveVertically returns the input unchanged,
+        // signalling "no visual move possible" so callers can fall back.
+        assertEquals(DocPos(3), moved.head)
+    }
+}
+
+/**
+ * Minimal [EditorSession] for motion unit tests. Holds a fixed [EditorState];
+ * geometry methods default to "no layout available" and are overridden per test.
+ */
+private abstract class FakeEditorSession(override val state: EditorState) : EditorSession {
+    override fun dispatch(vararg specs: TransactionSpec) = Unit
+    override fun dispatchTransaction(tr: Transaction) = Unit
+    override fun <V : PluginValue> plugin(plugin: ViewPlugin<V>): V? = null
+    override fun coordsAtPos(pos: Int, side: Int): Rect? = null
+    override fun posAtCoords(x: Float, y: Float): Int? = null
+    override val coroutineScope: CoroutineScope = CoroutineScope(Job())
+    override val editable: Boolean = true
+    override val textDirection: Direction = Direction.LTR
+    override fun textDirectionAt(pos: Int): Direction = Direction.LTR
+    override fun bidiSpans(line: Line): List<BidiSpan> = emptyList()
+    override fun phrase(phrase: String, vararg insert: Any): String = phrase
 }
 
 private fun assertFalse(condition: Boolean) = kotlin.test.assertFalse(condition)

--- a/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimMotions.kt
+++ b/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimMotions.kt
@@ -18,6 +18,8 @@
  */
 package com.monkopedia.kodemirror.vim
 
+import com.monkopedia.kodemirror.state.EditorSelection
+import com.monkopedia.kodemirror.view.moveVertically
 import kotlin.math.floor
 
 // ---------------------------------------------------------------------------
@@ -275,7 +277,17 @@ internal val motions: MutableMap<String, MotionFn> = mutableMapOf(
     },
 
     "moveByDisplayLines" to { cm, head, motionArgs, vim, _inputState ->
-        val cur = head
+        // gj/gk move by VISUAL (wrapped) row, not by logical line. Drive the
+        // view's wrap-aware vertical motion (the same one cursorLineUp/Down use)
+        // so a count moves that many visual rows and the goal column is tracked
+        // by moveVertically itself. We deliberately do NOT apply vim's lastHPos
+        // sticky-column logic here (that's for the linewise moveByLines).
+        //
+        // Discoverability: plain j/k remain LINEWISE (moveByLines) — they jump a
+        // whole logical line at a time even when it wraps across multiple visual
+        // rows. Users who prefer j/k to follow visual rows can remap them with:
+        //     Vim.map("j", "gj")
+        //     Vim.map("k", "gk")
         when (vim.lastMotion) {
             motions["moveByDisplayLines"],
             motions["moveByScroll"],
@@ -290,19 +302,45 @@ internal val motions: MutableMap<String, MotionFn> = mutableMapOf(
                 vim.lastHSPos = 0 // charCoords not available
             }
         }
+        val forward = motionArgs.forward == true
         val repeat = motionArgs.repeat.coerceAtLeast(1)
-        var current = cur
-        for (i in 0 until repeat) {
-            // In Compose, display lines == logical lines (no wrapping info available)
-            val newLine = if (motionArgs.forward == true) {
-                current.line + 1
-            } else {
-                current.line - 1
+        val session = cm.session
+
+        // Start from the current head as a document offset and let the
+        // wrap-aware vertical motion walk visual rows.
+        var sel = EditorSelection.cursor(cm.indexFromPos(head))
+        var movedVisually = false
+        var i = 0
+        while (i < repeat) {
+            val next = moveVertically(session, sel, forward = forward)
+            if (next.head == sel.head) {
+                // No progress: either we hit the document edge or live layout
+                // geometry isn't available. Stop the visual walk; any remaining
+                // repeats fall back to logical-line movement below.
+                break
             }
-            if (newLine < cm.firstLine() || newLine > cm.lastLine()) break
-            current = LinePos(newLine, current.ch)
+            sel = next
+            movedVisually = true
+            i++
         }
-        if (!cursorEqual(current, head)) {
+
+        var current = cm.posFromIndex(sel.head)
+
+        // Graceful fallback: when geometry is unavailable, moveVertically can't
+        // move at all (returns the same position). Preserve the previous
+        // logical-line behavior for any iterations the visual walk couldn't do.
+        if (i < repeat) {
+            var fallback = current
+            for (j in i until repeat) {
+                val newLine = if (forward) fallback.line + 1 else fallback.line - 1
+                if (newLine < cm.firstLine() || newLine > cm.lastLine()) break
+                fallback = LinePos(newLine, fallback.ch)
+            }
+            current = fallback
+        }
+
+        if (movedVisually && !cursorEqual(current, head)) {
+            // Keep lastHPos roughly in sync for any subsequent linewise motion.
             vim.lastHPos = current.ch
         }
         MotionResult.from(current)

--- a/vim/src/jvmTest/kotlin/com/monkopedia/kodemirror/vim/VimDisplayLineMotionTest.kt
+++ b/vim/src/jvmTest/kotlin/com/monkopedia/kodemirror/vim/VimDisplayLineMotionTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.vim
+
+import com.monkopedia.kodemirror.commands.history
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.LineNumber
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.asDoc
+import com.monkopedia.kodemirror.state.extensionListOf
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.kodemirror.view.Rect
+import com.monkopedia.kodemirror.view.ViewUpdate
+import kotlin.test.Test
+
+/**
+ * Distinguishes vim's display-line motion (`gj`/`gk` -> `moveByDisplayLines`)
+ * from the linewise motion (`j`/`k` -> `moveByLines`) on a WRAPPED line (#77).
+ *
+ * The fixture wraps a real [EditorSession] so vim's motion machinery runs
+ * unchanged, and overrides only the layout geometry to model a single logical
+ * line that wraps across two visual rows:
+ *
+ *   logical line 1: "aaaaaaaaaa0123456789" (20 chars)
+ *     visual row 0: offsets  0..9   y in [0,10)
+ *     visual row 1: offsets 10..19  y in [10,20)
+ *   logical line 2: "next"          y in [20,30)
+ *
+ * `gj` must step DOWN one VISUAL row (staying on logical line 1); `j` must jump
+ * the whole logical line (to line 2).
+ */
+class VimDisplayLineMotionTest {
+
+    private val doc = "aaaaaaaaaa0123456789\nnext"
+
+    /**
+     * An [EditorSession] that delegates everything to a real session but
+     * supplies wrap-aware geometry for [coordsAtPos]/[posAtCoords].
+     */
+    private class WrappedGeometrySession(
+        private val delegate: EditorSession
+    ) : EditorSession by delegate {
+        private val rowHeight = 10f
+
+        override fun coordsAtPos(pos: Int, side: Int): Rect {
+            val line = state.doc.lineAt(DocPos(pos))
+            val offsetInLine = pos - line.from.value
+            val col = offsetInLine % 10
+            val absRow = if (line.number.value == 1) offsetInLine / 10 else 2
+            val top = absRow * rowHeight
+            val x = col.toFloat()
+            return Rect(x, top, x, top + rowHeight)
+        }
+
+        override fun posAtCoords(x: Float, y: Float): Int {
+            val absRow = (y / rowHeight).toInt().coerceIn(0, 2)
+            val col = x.toInt().coerceIn(0, 9)
+            return when (absRow) {
+                0 -> col
+                1 -> 10 + col
+                else -> {
+                    val secondStart = state.doc.line(LineNumber(2)).from.value
+                    secondStart + col.coerceAtMost(4)
+                }
+            }
+        }
+    }
+
+    private fun buildHelpers(): VimHelpers {
+        val state = EditorState.create(
+            EditorStateConfig(
+                doc = doc.asDoc(),
+                selection = SelectionSpec.CursorSpec(DocPos(3)),
+                extensions = extensionListOf(
+                    vimContextField,
+                    history(),
+                    EditorState.allowMultipleSelections.of(true)
+                )
+            )
+        )
+        var cm: VimEditor? = null
+        val real = EditorSession(state) { tr ->
+            val editor = cm ?: return@EditorSession
+            if (editor.vimPlugin != null) return@EditorSession
+            if (tr.docChanged) {
+                val update = ViewUpdate(
+                    session = editor.session,
+                    state = editor.session.state,
+                    transactions = listOf(tr)
+                )
+                editor.onChangeLight(update)
+            }
+        }
+        val session = WrappedGeometrySession(real)
+        val editor = VimEditor(session)
+        cm = editor
+        val vim = Vim.maybeInitVimState_(editor)
+        Vim.resetVimGlobalState_()
+        resetVimContext(editor)
+        return VimHelpers(editor, vim)
+    }
+
+    @Test
+    fun gjMovesByVisualRowStayingOnSameLogicalLine() {
+        val h = buildHelpers()
+        // Cursor starts at logical line 0, column 3 (first visual row).
+        h.assertCursorAt(0, 3)
+        h.doKeys("g", "j")
+        // gj steps DOWN one VISUAL row -> still logical line 0, column 13
+        // (column 3 of the second wrapped row). NOT the next logical line.
+        h.assertCursorAt(0, 13)
+    }
+
+    @Test
+    fun gkMovesByVisualRowUp() {
+        val h = buildHelpers()
+        h.doKeys("g", "j") // down to (0,13)
+        h.doKeys("g", "k") // up one visual row, back to (0,3)
+        h.assertCursorAt(0, 3)
+    }
+
+    @Test
+    fun jMovesByWholeLogicalLine() {
+        val h = buildHelpers()
+        h.assertCursorAt(0, 3)
+        h.doKeys("j")
+        // j is LINEWISE: it jumps the entire wrapped logical line and lands on
+        // the NEXT logical line ("next", line 1), NOT the second visual row.
+        h.assertCursorAt(1, 3)
+    }
+}


### PR DESCRIPTION
## Summary
- Vim `gj`/`gk` (`moveByDisplayLines`) now move by VISUAL (wrapped) row instead of by logical line. They delegate to the view's wrap-aware `moveVertically(cm.session, sel, forward)` once per repeat, with the goal column tracked by `moveVertically`. `j`/`k` (`moveByLines`) stay linewise (logical), matching upstream vim. Falls back gracefully to logical-line motion when live layout geometry is unavailable (headless).
- Fixed `moveVertically` (`view/.../CursorMotion.kt`): it was collapsing any same-logical-line `posAtCoords` result back to a whole-line jump, so it never actually stepped by visual row on a wrapped line (this also affected the default cursor up/down). It now honors the wrap-aware `posAtCoords` offset directly and only uses the logical-line fallback when no geometry is available or the offset didn't change.
- Removed the stale "display lines == logical lines" comment; added a KDoc note pointing users at `Vim.map("j","gj")` / `Vim.map("k","gk")` for `.vimrc`-style visual `j`/`k`.

## Tests
- `view` `CursorMotionTest`: a fake `EditorSession` models a 20-char logical line wrapping into two 10-col visual rows + a short next line. Asserts `moveVertically` steps by visual row (offset 3 -> 13, same logical line), crosses to the next logical line only after the last wrapped row, mirrors upward, and falls back to logical-line motion with no geometry.
- `vim` `VimDisplayLineMotionTest`: drives real `gj`/`gk`/`j` keystrokes over a wrapped-line geometry session. `gj`: (0,3) -> (0,13) (same logical line, second visual row); `gk` returns to (0,3); `j` jumps the whole logical line to (1,3).

## Verification (JAVA_HOME=java-21)
- `:vim:jvmTest` + `:view:jvmTest`: PASS
- `:vim:compileKotlinJvm :vim:compileKotlinWasmJs :view:compileKotlinWasmJs`: PASS
- `:vim:compileDebugKotlinAndroid :view:compileDebugKotlinAndroid` (ANDROID_HOME set): PASS
- `:vim:apiCheck :view:apiCheck`: PASS (no public API change)
- `:vim:spotlessApply :view:spotlessApply`: clean

Fixes #77