### PR TITLE
Add LSPClient-core and LSPPlugin tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Tests
+- Add LSPClient-core and LSPPlugin test coverage (#80)
+
 ### Added
 - Horizontal scrollbar for long lines in no-wrap mode. The editor renders on a Skiko canvas with no native scrollbar, so long lines clipped at the right edge with horizontal scroll only reachable via shift+wheel/trackpad. A custom commonMain scrollbar (thin track + draggable thumb) is now shown whenever there is horizontal overflow and line wrapping is off; it is hidden when content fits or `lineWrapping` is enabled (#65)
 

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/LSPClientTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/LSPClientTest.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.lsp.HoverContents
+import com.monkopedia.lsp.HoverParams
+import com.monkopedia.lsp.MarkupContent
+import com.monkopedia.lsp.MarkupKind
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.PublishDiagnosticsParams
+import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.TextDocumentIdentifier
+import com.monkopedia.lsp.TextDocumentSyncKind
+import com.monkopedia.lsp.TextDocumentSyncOptions
+import com.monkopedia.lsp.Hover as LSPHover
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Exercises the [LSPClient] protocol/lifecycle seam against the scriptable
+ * [TestLanguageServer]. Maps the relevant upstream `webtest-client.ts` cases to
+ * our architecture (where the consumer provides a typed [com.monkopedia.lsp.LanguageServer]
+ * rather than a pluggable JSON-RPC transport). Position conversion and document
+ * sync mechanics are covered by [DocumentSyncTest] and are not duplicated here.
+ */
+class LSPClientTest {
+
+    /** A capability set that opts into open/close + change notifications. */
+    private fun syncingCaps() =
+        ServerCapabilities(textDocumentSync = TextDocumentSyncKind.INCREMENTAL)
+
+    private fun session(uri: String, doc: String, client: LSPClient): EditorSession {
+        val session = EditorSession(EditorState.create(doc = doc))
+        client.workspace.openFile(uri, "kotlin", session)
+        return session
+    }
+
+    // --- "can connect to a server": initialize handshake ---
+
+    @Test
+    fun initializePerformsHandshakeAndRecordsCapabilities() = runBlocking {
+        val fixture = TestLanguageServer(capabilities = syncingCaps())
+        val client = LSPClient(fixture.server)
+        assertFalse(client.isInitialized)
+
+        val result = client.initialize()
+
+        assertTrue(client.isInitialized)
+        assertSame(result, client.initializeResult)
+        assertEquals(1, fixture.initializeCount)
+        // initialize is followed by the initialized notification, per the spec.
+        assertTrue(fixture.initialized)
+        assertEquals(
+            TextDocumentSyncKind.INCREMENTAL,
+            client.serverCapabilities?.textDocumentSync
+        )
+    }
+
+    @Test
+    fun initializeIsIdempotent() = runBlocking {
+        val fixture = TestLanguageServer(capabilities = syncingCaps())
+        val client = LSPClient(fixture.server)
+        val first = client.initialize()
+        val second = client.initialize()
+        // Cached: the server is contacted exactly once.
+        assertSame(first, second)
+        assertEquals(1, fixture.initializeCount)
+    }
+
+    // --- "can open a file" ---
+
+    @Test
+    fun openFileSendsDidOpen() = runBlocking {
+        val fixture = TestLanguageServer(capabilities = syncingCaps())
+        val client = LSPClient(fixture.server)
+        client.initialize()
+        session("file:///a.kt", "val x = 1", client)
+
+        client.workspace.didOpenFile("file:///a.kt")
+
+        assertEquals(listOf("file:///a.kt"), fixture.didOpenUris)
+        assertEquals(listOf("file:///a.kt"), fixture.openFiles)
+    }
+
+    @Test
+    fun didOpenSuppressedWhenServerOmitsOpenClose() = runBlocking {
+        // A server that explicitly opts OUT of open/close notifications.
+        val fixture = TestLanguageServer(
+            capabilities = ServerCapabilities(
+                textDocumentSync = TextDocumentSyncOptions(openClose = false)
+            )
+        )
+        val client = LSPClient(fixture.server)
+        client.initialize()
+        session("file:///a.kt", "x", client)
+
+        client.workspace.didOpenFile("file:///a.kt")
+
+        assertTrue(fixture.didOpenUris.isEmpty())
+    }
+
+    // --- "can update/close a file" ---
+
+    @Test
+    fun updateThenSyncSendsDidChange() = runBlocking {
+        val fixture = TestLanguageServer(capabilities = syncingCaps())
+        val client = LSPClient(fixture.server)
+        client.initialize()
+        val session = session("file:///a.kt", "abc", client)
+        client.workspace.didOpenFile("file:///a.kt")
+
+        // Record an edit, then flush.
+        val changes = session.state.changes(
+            com.monkopedia.kodemirror.state.ChangeSpec.Single(
+                from = com.monkopedia.kodemirror.state.DocPos(3),
+                insert = com.monkopedia.kodemirror.state.InsertContent.StringContent("d")
+            )
+        )
+        client.workspace.updateFile("file:///a.kt", changes)
+        client.sync()
+
+        assertEquals(listOf("file:///a.kt"), fixture.didChangeUris)
+        // Version advanced past the version-1 baseline once the change flushed.
+        assertEquals(2, client.workspace.getFile("file:///a.kt")?.version)
+    }
+
+    @Test
+    fun closeFileSendsDidCloseAndDropsTracking() = runBlocking {
+        val fixture = TestLanguageServer(capabilities = syncingCaps())
+        val client = LSPClient(fixture.server)
+        client.initialize()
+        session("file:///a.kt", "x", client)
+        client.workspace.didOpenFile("file:///a.kt")
+
+        client.workspace.closeFile("file:///a.kt")
+        client.workspace.didCloseFile("file:///a.kt")
+
+        assertEquals(listOf("file:///a.kt"), fixture.didCloseUris)
+        assertTrue(fixture.openFiles.isEmpty())
+        assertNull(client.workspace.getFile("file:///a.kt"))
+    }
+
+    // --- "can open multiple files" ---
+
+    @Test
+    fun multipleFilesTrackedAndAnnouncedIndependently() = runBlocking {
+        val fixture = TestLanguageServer(capabilities = syncingCaps())
+        val client = LSPClient(fixture.server)
+        client.initialize()
+        session("file:///a.kt", "a", client)
+        session("file:///b.kt", "b", client)
+
+        client.workspace.didOpenFile("file:///a.kt")
+        client.workspace.didOpenFile("file:///b.kt")
+
+        assertEquals(setOf("file:///a.kt", "file:///b.kt"), fixture.openFiles.toSet())
+        assertEquals(
+            setOf("file:///a.kt", "file:///b.kt"),
+            client.workspace.openFiles.map { it.uri }.toSet()
+        )
+        // Closing one leaves the other open on both sides of the seam.
+        client.workspace.closeFile("file:///a.kt")
+        client.workspace.didCloseFile("file:///a.kt")
+        assertEquals(listOf("file:///b.kt"), fixture.openFiles)
+        assertEquals(listOf("file:///b.kt"), client.workspace.openFiles.map { it.uri })
+    }
+
+    // --- "can display messages in the editor" -> window/showMessage routing ---
+
+    @Test
+    fun showMessageNotificationIsHandledGracefully() = runBlocking {
+        // Our LSPLanguageClient currently treats window/showMessage as a no-op
+        // (spec-safe default until a message-surface feature lands); assert the
+        // notification is accepted without throwing. (See PR body: surfacing it
+        // into the editor UI is N/A in the current design.)
+        val fixture = TestLanguageServer(capabilities = syncingCaps())
+        val client = LSPClient(fixture.server)
+        client.languageClient.windowShowMessage(
+            com.monkopedia.lsp.ShowMessageParams(
+                type = com.monkopedia.lsp.MessageType.INFO,
+                message = "hello"
+            )
+        )
+    }
+
+    // --- unknown / out-of-feature server->client requests handled gracefully ---
+
+    @Test
+    fun unhandledServerRequestsReturnSpecSafeDefaults() = runBlocking {
+        // ksrpc's typed LanguageClient interface makes a truly "unknown method"
+        // impossible (it would not compile), so upstream's "reports invalid
+        // methods" has no analog. What we CAN assert is that server->client
+        // requests outside an implemented feature return the documented
+        // spec-safe defaults rather than crashing.
+        val fixture = TestLanguageServer()
+        val client = LSPClient(fixture.server)
+        val lc = client.languageClient
+        assertFalse(lc.windowShowDocument(com.monkopedia.lsp.ShowDocumentParams(uri = "file:///x")).success)
+        assertFalse(
+            lc.workspaceApplyEdit(
+                com.monkopedia.lsp.ApplyWorkspaceEditParams(
+                    edit = com.monkopedia.lsp.WorkspaceEdit()
+                )
+            ).applied
+        )
+        assertTrue(lc.workspaceWorkspaceFolders().isEmpty())
+    }
+
+    @Test
+    fun publishDiagnosticsForUnknownFileIsIgnored() = runBlocking {
+        // A server->client notification referencing a file the workspace does
+        // not track must be dropped, not crash.
+        val fixture = TestLanguageServer(capabilities = syncingCaps())
+        val client = LSPClient(fixture.server)
+        client.languageClient.textDocumentPublishDiagnostics(
+            PublishDiagnosticsParams(uri = "file:///never-opened.kt", diagnostics = emptyList())
+        )
+    }
+
+    // --- error routing: a throwing server method surfaces to the caller ---
+
+    @Test
+    fun serverInitializeExceptionPropagatesToCaller() {
+        val fixture = TestLanguageServer(
+            throwingMethods = setOf("initialize"),
+            throwable = IllegalStateException("Broken Pipe")
+        )
+        val client = LSPClient(fixture.server)
+        val thrown = assertFailsWith<IllegalStateException> {
+            runBlocking { client.initialize() }
+        }
+        assertEquals("Broken Pipe", thrown.message)
+        // The failed handshake left the client uninitialized.
+        assertFalse(client.isInitialized)
+    }
+
+    @Test
+    fun serverRequestExceptionPropagatesToCaller() {
+        // The analog of upstream's "routes exceptions from Transport.send to the
+        // request promise": a typed suspend call that the server fails rethrows
+        // to the caller rather than being swallowed.
+        val fixture = TestLanguageServer(
+            capabilities = syncingCaps(),
+            throwingMethods = setOf("textDocumentHover"),
+            throwable = IllegalStateException("File not open")
+        )
+        val client = LSPClient(fixture.server)
+        val thrown = assertFailsWith<IllegalStateException> {
+            runBlocking {
+                client.server.textDocumentHover(
+                    HoverParams(
+                        textDocument = TextDocumentIdentifier(uri = "file:///a.kt"),
+                        position = Position(0u, 0u)
+                    )
+                )
+            }
+        }
+        assertEquals("File not open", thrown.message)
+    }
+
+    @Test
+    fun serverHoverResponseRoutesValueToCaller() = runBlocking {
+        // Complement to the error-routing test: a value returned by the server
+        // reaches the caller through the same suspend bridge.
+        val hover = LSPHover(
+            contents = HoverContents.MarkupContentValue(
+                MarkupContent(kind = MarkupKind.MARKDOWN, value = "**docs**")
+            )
+        )
+        val fixture = TestLanguageServer(
+            capabilities = syncingCaps(),
+            responses = mapOf("textDocumentHover" to hover)
+        )
+        val client = LSPClient(fixture.server)
+        val result = client.server.textDocumentHover(
+            HoverParams(
+                textDocument = TextDocumentIdentifier(uri = "file:///a.kt"),
+                position = Position(0u, 0u)
+            )
+        )
+        assertSame(hover, result)
+    }
+}

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/LSPPluginTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/LSPPluginTest.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import com.monkopedia.kodemirror.lint.Severity
+import com.monkopedia.kodemirror.lint.diagnosticCount
+import com.monkopedia.kodemirror.lint.forEachDiagnostic
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.lsp.Diagnostic as LSPDiagnostic
+import com.monkopedia.lsp.DiagnosticSeverity
+import com.monkopedia.lsp.HoverContents
+import com.monkopedia.lsp.MarkedStringObject
+import com.monkopedia.lsp.MarkupContent
+import com.monkopedia.lsp.MarkupKind
+import com.monkopedia.lsp.Position
+import com.monkopedia.lsp.PublishDiagnosticsParams
+import com.monkopedia.lsp.Range
+import com.monkopedia.lsp.ServerCapabilities
+import com.monkopedia.lsp.StringOr
+import com.monkopedia.lsp.TextDocumentSyncKind
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Exercises the LSPPlugin rendering seam: the markdown/markup doc-string →
+ * Compose [androidx.compose.ui.text.AnnotatedString] conversion (upstream's
+ * `docToHTML`, replaced here because the editor renders on a Compose canvas with
+ * no DOM), and server-pushed diagnostics surfacing into the editor via the
+ * plugin's [LSPClient.languageClient] notification handler.
+ *
+ * Position conversion (covered by [DocumentSyncTest]) is not duplicated here.
+ */
+class LSPPluginTest {
+
+    // --- "can render doc strings": markdown -> Compose AnnotatedString ---
+
+    @Test
+    fun rendersMarkdownDocString() {
+        val contents = HoverContents.MarkupContentValue(
+            MarkupContent(kind = MarkupKind.MARKDOWN, value = "**bold** and `code`")
+        )
+        val blocks = parseHoverContents(contents)
+        assertEquals(1, blocks.size)
+        assertTrue(blocks[0].markdown)
+
+        val annotated = hoverBlockToAnnotatedString(blocks[0])
+        // The literal markdown markers are consumed, leaving the rendered text.
+        assertEquals("bold and code", annotated.text)
+        // "bold" is rendered with the bold span; "code" with the monospace span.
+        val boldRange = annotated.spanStyles.single { it.item.fontWeight == FontWeight.Bold }
+        assertEquals("bold", annotated.text.substring(boldRange.start, boldRange.end))
+        val codeRange = annotated.spanStyles.single { it.item.fontFamily == FontFamily.Monospace }
+        assertEquals("code", annotated.text.substring(codeRange.start, codeRange.end))
+    }
+
+    @Test
+    fun plainTextDocStringIsNotInterpretedAsMarkdown() {
+        // A bare MarkupContent of kind PLAINTEXT keeps markdown punctuation literal.
+        val contents = HoverContents.MarkupContentValue(
+            MarkupContent(kind = MarkupKind.PLAIN_TEXT, value = "**not bold**")
+        )
+        val blocks = parseHoverContents(contents)
+        assertEquals(1, blocks.size)
+        assertTrue(!blocks[0].markdown)
+        val annotated = hoverBlockToAnnotatedString(blocks[0])
+        assertEquals("**not bold**", annotated.text)
+        assertTrue(annotated.spanStyles.isEmpty())
+    }
+
+    @Test
+    fun rendersMarkdownHeadingAsBoldLine() {
+        val contents = HoverContents.MarkupContentValue(
+            MarkupContent(kind = MarkupKind.MARKDOWN, value = "# Title\nbody")
+        )
+        val annotated = hoverBlockToAnnotatedString(parseHoverContents(contents).single())
+        // The leading "# " marker is stripped; the title text is bolded.
+        assertEquals("Title\nbody", annotated.text)
+        val boldRange = annotated.spanStyles.single { it.item.fontWeight == FontWeight.Bold }
+        assertEquals("Title", annotated.text.substring(boldRange.start, boldRange.end))
+    }
+
+    // --- "can render doc strings with highlighting": code fences / typed code ---
+
+    @Test
+    fun rendersFencedCodeBlockAsMonospace() {
+        // A markdown fenced code block in the doc string is rendered monospace
+        // (the conversion's stand-in for upstream's syntax-highlighted code).
+        val contents = HoverContents.MarkupContentValue(
+            MarkupContent(
+                kind = MarkupKind.MARKDOWN,
+                value = "doc\n```kotlin\nval x = 1\n```"
+            )
+        )
+        val annotated = hoverBlockToAnnotatedString(parseHoverContents(contents).single())
+        // Fence delimiters are dropped; the code line survives.
+        assertTrue(annotated.text.contains("val x = 1"))
+        assertTrue(!annotated.text.contains("```"))
+        val mono = annotated.spanStyles.single { it.item.fontFamily == FontFamily.Monospace }
+        assertEquals("val x = 1", annotated.text.substring(mono.start, mono.end))
+    }
+
+    @Test
+    fun rendersTypedMarkedStringAsMonospaceCode() {
+        // A MarkedString with a language is a fenced code block: rendered entirely
+        // monospace with no markdown interpretation.
+        val contents = HoverContents.MarkedStringValue(
+            StringOr.Value(MarkedStringObject(language = "kotlin", value = "fun f() = 1"))
+        )
+        val block = parseHoverContents(contents).single()
+        assertEquals("kotlin", block.language)
+        val annotated = hoverBlockToAnnotatedString(block)
+        assertEquals("fun f() = 1", annotated.text)
+        val mono = annotated.spanStyles.single()
+        assertEquals(FontFamily.Monospace, mono.item.fontFamily)
+        assertEquals(0, mono.start)
+        assertEquals(annotated.text.length, mono.end)
+    }
+
+    @Test
+    fun signatureDocumentationReusesHoverRendering() {
+        // Signature-help documentation funnels through the same conversion: a
+        // MarkupContent markdown value renders as a markdown block.
+        val blocks = documentationBlocks(
+            StringOr.Value(MarkupContent(kind = MarkupKind.MARKDOWN, value = "*italic*"))
+        )
+        assertEquals(1, blocks.size)
+        val annotated = hoverBlockToAnnotatedString(blocks[0])
+        assertEquals("italic", annotated.text)
+        assertTrue(annotated.spanStyles.any { it.item.fontStyle != null })
+    }
+
+    @Test
+    fun customStylesAreAppliedDuringRendering() {
+        // The rendering is parameterized by HoverMarkdownStyles, so a caller's
+        // theme attributes flow into the produced spans.
+        val styles = HoverMarkdownStyles(
+            bold = SpanStyle(fontWeight = FontWeight.Black)
+        )
+        val annotated = hoverBlockToAnnotatedString(
+            HoverBlock(text = "**hi**", markdown = true),
+            styles
+        )
+        assertEquals("hi", annotated.text)
+        assertEquals(FontWeight.Black, annotated.spanStyles.single().item.fontWeight)
+    }
+
+    // --- "can display errors": server diagnostics surface through the plugin ---
+
+    @Test
+    fun publishDiagnosticsSurfacesErrorsIntoEditor() = runBlocking {
+        val fixture = TestLanguageServer(
+            capabilities = ServerCapabilities(textDocumentSync = TextDocumentSyncKind.INCREMENTAL)
+        )
+        val client = LSPClient(fixture.server)
+        // serverDiagnostics() installs the lint-display state the handler feeds.
+        val state = EditorState.create(doc = "let x", extensions = serverDiagnostics())
+        val session = EditorSession(state)
+        client.workspace.openFile("file:///a.kt", "kotlin", session)
+
+        client.languageClient.textDocumentPublishDiagnostics(
+            PublishDiagnosticsParams(
+                uri = "file:///a.kt",
+                diagnostics = listOf(
+                    LSPDiagnostic(
+                        range = Range(start = Position(0u, 0u), end = Position(0u, 3u)),
+                        severity = DiagnosticSeverity.ERROR,
+                        message = "unexpected token"
+                    )
+                )
+            )
+        )
+
+        assertEquals(1, diagnosticCount(session.state))
+        val collected = mutableListOf<String>()
+        var severity: Severity? = null
+        forEachDiagnostic(session.state) {
+            collected.add(it.message)
+            severity = it.severity
+        }
+        assertEquals(listOf("unexpected token"), collected)
+        assertEquals(Severity.ERROR, severity)
+    }
+
+    @Test
+    fun publishDiagnosticsClearsPreviousDiagnostics() = runBlocking {
+        val fixture = TestLanguageServer(
+            capabilities = ServerCapabilities(textDocumentSync = TextDocumentSyncKind.INCREMENTAL)
+        )
+        val client = LSPClient(fixture.server)
+        val state = EditorState.create(doc = "let x", extensions = serverDiagnostics())
+        val session = EditorSession(state)
+        client.workspace.openFile("file:///a.kt", "kotlin", session)
+        val lc = client.languageClient
+
+        lc.textDocumentPublishDiagnostics(
+            PublishDiagnosticsParams(
+                uri = "file:///a.kt",
+                diagnostics = listOf(
+                    LSPDiagnostic(
+                        range = Range(start = Position(0u, 0u), end = Position(0u, 1u)),
+                        message = "boom"
+                    )
+                )
+            )
+        )
+        assertEquals(1, diagnosticCount(session.state))
+
+        // An empty publish (the server resolved the problem) clears the editor.
+        lc.textDocumentPublishDiagnostics(
+            PublishDiagnosticsParams(uri = "file:///a.kt", diagnostics = emptyList())
+        )
+        assertEquals(0, diagnosticCount(session.state))
+    }
+
+    @Test
+    fun diagnosticsForFileWithoutSessionAreDropped() = runBlocking {
+        // A workspace file opened without an attached editor session has nowhere
+        // to render; the handler must no-op rather than crash.
+        val fixture = TestLanguageServer()
+        val client = LSPClient(fixture.server)
+        client.workspace.openFile("file:///headless.kt", "kotlin", session = null)
+        client.languageClient.textDocumentPublishDiagnostics(
+            PublishDiagnosticsParams(
+                uri = "file:///headless.kt",
+                diagnostics = listOf(
+                    LSPDiagnostic(
+                        range = Range(start = Position(0u, 0u), end = Position(0u, 1u)),
+                        message = "ignored"
+                    )
+                )
+            )
+        )
+        // No session to read from; assert the file is still tracked and nothing threw.
+        assertNull(client.workspace.getFile("file:///headless.kt")?.session)
+    }
+}

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/TestLanguageServer.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/TestLanguageServer.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lsp
+
+import com.monkopedia.lsp.DidChangeTextDocumentParams
+import com.monkopedia.lsp.DidCloseTextDocumentParams
+import com.monkopedia.lsp.DidOpenTextDocumentParams
+import com.monkopedia.lsp.InitializeResult
+import com.monkopedia.lsp.LanguageServer
+import com.monkopedia.lsp.ServerCapabilities
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * A reusable, scriptable stub [LanguageServer] for jvmTest, built with a
+ * coroutine-aware [Proxy] (suspend methods receive a trailing [Continuation]
+ * which the handler resolves synchronously — the same trick the per-feature
+ * `*Test` fixtures use).
+ *
+ * It mirrors the role of upstream `@codemirror/lsp-client`'s `test/server.ts`
+ * `DummyServer`: it advertises [capabilities], records the document-lifecycle
+ * calls the client drives (`textDocument/didOpen` / `didClose` / `didChange`),
+ * lets a test return a value for a named method, and lets a test make a named
+ * method *throw* so error-routing can be exercised. Restricted to jvmTest
+ * because `Proxy` is JVM-only.
+ *
+ * @param capabilities Capabilities reported from `initialize`.
+ * @param throwingMethods Method names (e.g. `"textDocumentHover"`) that should
+ *   raise [throwable] instead of returning, modelling upstream's `brokenPipe` /
+ *   `ServerError`. The exception surfaces to the suspend caller.
+ * @param throwable The exception thrown by [throwingMethods].
+ * @param responses Per-method canned return values, keyed by method name. A
+ *   method not listed here (and not a recorded lifecycle/handshake call)
+ *   resolves to [Unit].
+ */
+class TestLanguageServer(
+    private val capabilities: ServerCapabilities = ServerCapabilities(),
+    private val throwingMethods: Set<String> = emptySet(),
+    private val throwable: Throwable = RuntimeException("Broken Pipe"),
+    private val responses: Map<String, Any?> = emptyMap()
+) {
+    /** Number of times `initialize` was invoked. */
+    var initializeCount: Int = 0
+        private set
+
+    /** True once `initialized` has been received. */
+    var initialized: Boolean = false
+        private set
+
+    /** True once `shutdown` then `exit` have been received. */
+    var shutDown: Boolean = false
+        private set
+
+    /** URIs the server currently considers open, in arrival order. */
+    val openFiles: MutableList<String> = mutableListOf()
+
+    /** URIs the server saw a `didOpen` for, in arrival order (never pruned). */
+    val didOpenUris: MutableList<String> = mutableListOf()
+
+    /** URIs the server saw a `didClose` for, in arrival order. */
+    val didCloseUris: MutableList<String> = mutableListOf()
+
+    /** URIs the server saw a `didChange` for, in arrival order (may repeat). */
+    val didChangeUris: MutableList<String> = mutableListOf()
+
+    /** Every method name invoked through the proxy, in order. */
+    val calls: MutableList<String> = mutableListOf()
+
+    private fun handle(method: Method, args: Array<Any?>?): Any? {
+        val name = method.name
+        calls.add(name)
+        if (name in throwingMethods) throw throwable
+        return when (name) {
+            "initialize" -> {
+                initializeCount++
+                InitializeResult(capabilities = capabilities)
+            }
+            "initialized" -> {
+                initialized = true
+                Unit
+            }
+            "shutdown" -> Unit
+            "exit" -> {
+                shutDown = true
+                Unit
+            }
+            "textDocumentDidOpen" -> {
+                val uri = (args?.firstOrNull() as? DidOpenTextDocumentParams)?.textDocument?.uri
+                if (uri != null) {
+                    didOpenUris.add(uri)
+                    openFiles.add(uri)
+                }
+                Unit
+            }
+            "textDocumentDidClose" -> {
+                val uri = (args?.firstOrNull() as? DidCloseTextDocumentParams)?.textDocument?.uri
+                if (uri != null) {
+                    didCloseUris.add(uri)
+                    openFiles.remove(uri)
+                }
+                Unit
+            }
+            "textDocumentDidChange" -> {
+                val uri = (args?.firstOrNull() as? DidChangeTextDocumentParams)?.textDocument?.uri
+                if (uri != null) didChangeUris.add(uri)
+                Unit
+            }
+            else -> if (responses.containsKey(name)) responses[name] else Unit
+        }
+    }
+
+    /** The [LanguageServer] proxy backed by this fixture's scripted behavior. */
+    val server: LanguageServer = Proxy.newProxyInstance(
+        LanguageServer::class.java.classLoader,
+        arrayOf(LanguageServer::class.java),
+        InvocationHandler { _, method: Method, args: Array<Any?>? ->
+            @Suppress("UNCHECKED_CAST")
+            val continuation = args?.lastOrNull() as? Continuation<Any?>
+            try {
+                val result = handle(method, args)
+                continuation?.resume(result)
+            } catch (t: Throwable) {
+                // Route a server-side failure back to the suspend caller, the
+                // way a real transport surfaces a JSON-RPC error.
+                continuation?.resumeWithException(t)
+            }
+            COROUTINE_SUSPENDED
+        }
+    ) as LanguageServer
+}


### PR DESCRIPTION
Closes the LSPClient-core + LSPPlugin test gap (issue #80). The `:lsp-client` suite already covers the per-feature servers and `DocumentSyncTest` covers position conversion / document sync / workspace mapping, but the client-core protocol layer and the LSPPlugin rendering layer had no tests. This adds them.

All tests are jvmTest-only (the stub uses `java.lang.reflect.Proxy`, JVM-only). No public API change.

## New files
### `TestLanguageServer.kt` — shared scriptable mock-server fixture
A reusable stub `LanguageServer` built with a coroutine-aware `Proxy` (the suspend-method `Continuation` is resolved synchronously, matching the existing `*Test` fixtures). Mirrors upstream `test/server.ts`'s `DummyServer` role: parameterized server capabilities, per-method canned responses, methods that THROW (routed back to the suspend caller via `resumeWithException`), and recording of the document-lifecycle calls the client drives (`didOpen`/`didClose`/`didChange`, `initialize`/`initialized`/`shutdown`/`exit`). The existing 9 test files were intentionally NOT refactored onto it (out of scope).

### `LSPClientTest.kt` (13 tests) — client-core protocol/lifecycle
- `initializePerformsHandshakeAndRecordsCapabilities` — initialize → initialized handshake completes; `isInitialized`, `serverCapabilities` populated. ("can connect to a server")
- `initializeIsIdempotent` — second `initialize()` returns the cached result; server contacted once.
- `openFileSendsDidOpen` — `didOpenFile` emits `textDocument/didOpen`; server records the URI. ("can open a file")
- `didOpenSuppressedWhenServerOmitsOpenClose` — server advertising `TextDocumentSyncOptions(openClose=false)` suppresses didOpen.
- `updateThenSyncSendsDidChange` — `updateFile` + `sync()` emits `textDocument/didChange`; file version advances. ("can update a file")
- `closeFileSendsDidCloseAndDropsTracking` — `didCloseFile` emits `didClose`; workspace stops tracking. ("can close a file")
- `multipleFilesTrackedAndAnnouncedIndependently` — two files tracked/announced; closing one leaves the other open on both sides. ("can open multiple files")
- `showMessageNotificationIsHandledGracefully` — `window/showMessage` is accepted without throwing (see N/A note below).
- `unhandledServerRequestsReturnSpecSafeDefaults` — server→client requests outside an implemented feature (`window/showDocument`, `workspace/applyEdit`, `workspace/workspaceFolders`) return the documented spec-safe defaults rather than crashing.
- `publishDiagnosticsForUnknownFileIsIgnored` — a `publishDiagnostics` for an untracked URI is dropped, not crashed.
- `serverInitializeExceptionPropagatesToCaller` — a throwing `initialize` rethrows to the caller; client left uninitialized.
- `serverRequestExceptionPropagatesToCaller` — a throwing `textDocument/hover` rethrows to the caller (our analog of upstream's "routes exceptions from Transport.send to the request promise").
- `serverHoverResponseRoutesValueToCaller` — a value returned by the server reaches the caller through the same suspend bridge.

### `LSPPluginTest.kt` (10 tests) — rendering / diagnostics seam
- `rendersMarkdownDocString` — markdown `**bold**` / `` `code` `` doc string → `AnnotatedString` with the correct bold/monospace spans over the right substrings. ("can render doc strings")
- `plainTextDocStringIsNotInterpretedAsMarkdown` — `PLAIN_TEXT` MarkupContent keeps markdown punctuation literal, no spans.
- `rendersMarkdownHeadingAsBoldLine` — `#` heading marker stripped, title bolded.
- `rendersFencedCodeBlockAsMonospace` — a fenced code block inside the doc string is rendered monospace, fence delimiters dropped. ("with highlighting" — see note below)
- `rendersTypedMarkedStringAsMonospaceCode` — a `MarkedString` with a language renders entirely monospace.
- `signatureDocumentationReusesHoverRendering` — signature-help documentation funnels through the same conversion.
- `customStylesAreAppliedDuringRendering` — caller-supplied `HoverMarkdownStyles` flow into produced spans.
- `publishDiagnosticsSurfacesErrorsIntoEditor` — `LSPLanguageClient.textDocumentPublishDiagnostics` maps an LSP error diagnostic into `:lint` and it appears in the editor state (`diagnosticCount` / `forEachDiagnostic`, severity ERROR). ("can display errors")
- `publishDiagnosticsClearsPreviousDiagnostics` — an empty publish clears previously-shown diagnostics.
- `diagnosticsForFileWithoutSessionAreDropped` — a tracked file with no attached session no-ops gracefully.

## Upstream scenarios N/A in our design (with reason)
- **"reports invalid methods" / "can report unknown notifications"** — N/A. Upstream owns a JSON-RPC transport and can receive an arbitrary unknown method string. Our client instead wraps the typed `com.monkopedia.lsp.LanguageServer` / `LanguageClient` interfaces (ksrpc), so an "unknown method" cannot exist — it would not compile. The closest realizable behavior (server→client requests outside an implemented feature returning spec-safe defaults, and notifications for untracked files being dropped) is asserted by `unhandledServerRequestsReturnSpecSafeDefaults` and `publishDiagnosticsForUnknownFileIsIgnored`.
- **"can receive custom notifications"** — N/A. The typed `LanguageClient` interface has no extension point for arbitrary custom notifications in the current design.
- **"can display messages in the editor"** — partial. Our `LSPLanguageClient.windowShowMessage` is currently a spec-safe no-op (no message-surface UI feature has landed yet), so there is no editor surface to assert against. `showMessageNotificationIsHandledGracefully` asserts the notification is accepted without throwing; surfacing it into the editor UI is left for a future feature issue.

## Verification (env per CLAUDE.md)
- `:lsp-client:jvmTest` — BUILD SUCCESSFUL, 161 tests (138 existing + 23 new), all passing.
- `:lsp-client:compileKotlinWasmJs` — BUILD SUCCESSFUL (additions are jvmTest-only; main compile unaffected).
- `:lsp-client:apiCheck` — BUILD SUCCESSFUL (no public API change; no apiDump).
- `spotlessApply` — clean, no reformatting.

Fixes #80