### PR TITLE
Bump version to 0.3.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-29
+
 ### Tests
 - Add LSPClient-core and LSPPlugin test coverage (#80)
 

--- a/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.2.1-SNAPSHOT"
+version = "0.3.0"
 
 android {
     namespace = "com.monkopedia.kodemirror.${project.name.replace("-", ".")}"

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.2.1-SNAPSHOT"
+version = "0.3.0"
 
 dependencies {
     constraints {


### PR DESCRIPTION
Release version bump for **0.3.0** (minor). Metadata only — no code changes.

## Changes
- Version flip `0.2.1-SNAPSHOT` -> `0.3.0` in the two (and only) version definitions:
  - `convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts`
  - `kodemirror-bom/build.gradle.kts`
- `CHANGELOG.md`: finalized — added a `## [0.3.0] - 2026-05-29` section holding the prior `[Unreleased]` entries (Tests / Added / Changed / Fixed, unchanged), with a fresh empty `## [Unreleased]` kept at the top. (This file uses no bottom-of-file compare links, so none were added.)

## 0.3.0 highlights
- **Added:** horizontal scrollbar for long lines in no-wrap mode (#65)
- **Changed:** lsp dependency bumped to stable 1.0.0 (#82); typed LSP result unions consumed directly (RC3/RC4)
- **Fixed:** line wrapping + no-wrap horizontal scroll/caret-follow (#20, #67, #69), vim gj/gk visual-row motion (#77), caret height/gutter alignment on wrapped lines (#75), unbounded-height collapse/LazyColumn crash (#33), scrollIntoView handling (#58), browser-reserved shortcuts on wasmJs (#49), system clipboard copy/cut/paste on wasm (#34), vim dot-repeat (#21) and change/insert undo grouping (#23)
- **Tests:** LSPClient-core and LSPPlugin coverage (#80)

No breaking public API this cycle.

Publishing to Maven Central is a separate manual step (not part of this PR); the git tag is created after merge, separately.