### PR TITLE
Fix active-line highlight not filling viewport width in no-wrap mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Transactions with `scrollIntoView` now actually scroll the view: the editor was never reacting to the flag, so selection jumps that landed off-screen (vim `n`/`N` search-repeat, goto-line, history/undo, etc.) left the target invisible. The line list now scrolls the primary selection head into view, matching CodeMirror 6's `scrollIntoView` "nearest" behavior (#58, #33)
 - Vim dot-repeat (`.`) dropped the inserted text of change/insert commands (`c`, `cw`, `s`, `i`, `a`, `o`, …) — the insert-mode change event was never wired up, so `lastInsertModeChanges` stayed empty and `.` replayed only the operator/delete (#21)
 - Vim change/insert commands (`c`, `cw`, `s`, …) were not a single undo unit — `u` took two steps to revert because the insert-entry cursor selection stamped a history boundary on the operator-delete event (#23)
+- Active-line and line-decoration highlight backgrounds again fill the full editor width in no-wrap mode (regressed by the horizontal-scroll layout work) (#85)
 
 ## [0.2.0] - 2026-04-10
 

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/EditorSessionImpl.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/EditorSessionImpl.kt
@@ -80,6 +80,14 @@ internal class EditorSessionImpl(
      * assertions in tests.
      */
     internal var lastHorizontalScrollPx: Int = 0
+
+    /**
+     * Laid-out width, in pixels, of the most recently positioned active line's
+     * content box (the box carrying the line-decoration background highlight).
+     * In no-wrap mode this should reach the viewport width even for short
+     * content; used by the active-line-highlight regression test for #85.
+     */
+    internal var lastActiveLineContentWidthPx: Int = 0
     internal var lastLayoutHeight: Float = 0f
     internal var hasFocus: Boolean = false
     private var lastHasFocus: Boolean = false

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
@@ -647,6 +647,15 @@ private fun EditorContent(
     // range. Without it, short lines (laid out last) clobber the shared
     // ScrollState.maxValue to 0, breaking scrolling and the scrollbar (#67).
     val maxLineWidthPx = remember { mutableStateOf(0) }
+    // Laid-out width of the per-line viewport (the weight(1f) box). In no-wrap
+    // mode the content box scrolls horizontally, so it is measured with an
+    // infinite max width and cannot learn the viewport width itself. We capture
+    // the viewport's actual width here so a short line's content (and thus its
+    // line-decoration background highlight) can fill the full viewport width
+    // rather than stopping at the text width (#85). The viewport width is
+    // weight-determined (independent of content width), so feeding it back into
+    // the content min-width is loop-safe.
+    val viewportWidthPx = remember { mutableStateOf(0) }
     val density = LocalDensity.current
 
     // Hidden text field for receiving IME/text input and key events
@@ -797,10 +806,21 @@ private fun EditorContent(
                     }
                     var contentExtraModifier: Modifier = Modifier
                         .padding(start = 6.dp, end = 2.dp)
+                    var hasLineBackground = false
                     for (deco in item.lineDecorations) {
                         val bg = deco.spec.style?.background
                         if (bg != null && bg != Color.Unspecified) {
                             contentExtraModifier = contentExtraModifier.background(bg)
+                            hasLineBackground = true
+                        }
+                    }
+                    // Test hook (#85): record the laid-out width of a
+                    // background-highlighted line's content box so the
+                    // regression test can assert the highlight fills the
+                    // viewport in no-wrap mode rather than stopping at the text.
+                    if (hasLineBackground && !wrapLines) {
+                        contentExtraModifier = contentExtraModifier.onSizeChanged {
+                            impl.lastActiveLineContentWidthPx = it.width
                         }
                     }
                     Row(
@@ -830,7 +850,13 @@ private fun EditorContent(
                             .weight(1f)
                             .fillMaxHeight()
                         if (!wrapLines) {
+                            // Capture the viewport's actual visible width from
+                            // the weight(1f) box (before the horizontalScroll,
+                            // which would otherwise measure the child with an
+                            // infinite max width). Used as an additional content
+                            // min-width so highlights fill the viewport (#85).
                             viewportModifier = viewportModifier
+                                .onSizeChanged { viewportWidthPx.value = it.width }
                                 .horizontalScroll(horizontalScrollState)
                         }
                         Box(modifier = viewportModifier) {
@@ -845,8 +871,17 @@ private fun EditorContent(
                             contentModifier = if (wrapLines) {
                                 contentModifier.fillMaxWidth()
                             } else {
+                                // Min width = the wider of the widest line and
+                                // the viewport. The first keeps long lines at
+                                // their full natural width (uniform scroll range,
+                                // #68); the second makes a short line's content
+                                // (and its line-decoration background) fill the
+                                // viewport instead of stopping at the text (#85).
                                 val minW = with(density) {
-                                    maxLineWidthPx.value.toDp()
+                                    maxOf(
+                                        maxLineWidthPx.value,
+                                        viewportWidthPx.value
+                                    ).toDp()
                                 }
                                 contentModifier
                                     .wrapContentWidth(

--- a/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/ActiveLineHighlightWidthTest.kt
+++ b/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/ActiveLineHighlightWidthTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view.input
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.monkopedia.kodemirror.view.highlightActiveLine
+import org.junit.Test
+
+/**
+ * Regression guard for #85: in no-wrap mode the active-line (and any
+ * line-decoration) background highlight must fill the full viewport width, not
+ * stop at the text width.
+ *
+ * The horizontal-scroll layout work (#20/#64/#68) sized each line's content box
+ * to the natural content width (clamped to the widest line), so when content
+ * was narrower than the viewport the highlight stopped just past the text. The
+ * fix makes the no-wrap content min-width `max(widestLine, viewport)` so the
+ * background fills the viewport.
+ *
+ * With a 2-char document ("hi") in an 800px-wide editor, the text occupies only
+ * a few dozen pixels. Pre-fix the highlighted content box measured roughly the
+ * text width (well under 100px); post-fix it measures ~the viewport width
+ * (close to 800px). The 600px threshold is comfortably between the two.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ActiveLineHighlightWidthTest {
+
+    @Test
+    fun activeLineHighlightFillsViewportWidthInNoWrapMode() = runEditorTest(
+        doc = "hi",
+        extensions = highlightActiveLine,
+        width = 800,
+        height = 600
+    ) { holder ->
+        waitForIdle()
+        val contentWidth = holder.activeLineContentWidthPx()
+        assert(contentWidth > 600) {
+            "Expected the active-line highlight content box to fill ~the 800px " +
+                "viewport in no-wrap mode, but it was only ${contentWidth}px wide " +
+                "(stopping at the text width — regression #85)."
+        }
+    }
+}

--- a/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/InputTestHelper.kt
+++ b/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/InputTestHelper.kt
@@ -135,6 +135,14 @@ fun SessionHolder.visibleItemCount(): Int = (session as EditorSessionImpl).lastV
 /** Current horizontal scroll offset of the content area, in pixels. */
 fun SessionHolder.horizontalScrollPx(): Int = (session as EditorSessionImpl).lastHorizontalScrollPx
 
+/**
+ * Laid-out width, in pixels, of the most recently positioned line whose content
+ * box carries a line-decoration background highlight (e.g. the active line). In
+ * no-wrap mode this should reach the viewport width even for short content (#85).
+ */
+fun SessionHolder.activeLineContentWidthPx(): Int =
+    (session as EditorSessionImpl).lastActiveLineContentWidthPx
+
 /** Whether the given column-item index is within the currently laid-out range. */
 fun SessionHolder.isIndexVisible(index: Int): Boolean {
     val impl = session as EditorSessionImpl


### PR DESCRIPTION
## Summary
In no-wrap mode the active-line highlight (and any line `style.background` decoration) only spanned the **content/text width** instead of the full **viewport width**. At v0.2.0 the active-line band reached the full editor width; after the horizontal-scroll layout work (#20/#64 natural-width content + #68 `widthIn(min = maxLineWidthPx)`) it stopped just past the text. (#85)

## Root cause
In `KodeMirror.kt`'s per-line layout, the line-decoration background lives on the content `Box`. In no-wrap mode that box's min-width was `maxLineWidthPx` (the widest line's natural width). When content is narrower than the viewport, the highlight therefore stopped at the text.

## The fix
No-wrap content min-width is now `max(widestLineWidth, viewportWidth)`:
- `max(widestLine, …)` preserves the #68 uniform full-natural-width behavior so a genuinely long line still lays out at its full width and scrolls horizontally.
- `max(…, viewport)` makes a short line's content (and its background highlight + selection overlay) fill the viewport.

**Measuring viewport width:** the viewport `Box` has `.horizontalScroll(...)`, which measures its child with an *infinite* max width, so `BoxWithConstraints` inside the scroll would report Infinity. Instead the viewport's actual laid-out width is captured from the `weight(1f)` viewport box itself via `.onSizeChanged { viewportWidthPx.value = it.width }` (added before the `horizontalScroll`). The viewport width is weight-determined, independent of content width, so deriving content min-width from it is loop-safe. The existing `contentExtraModifier.background` and `drawSelectionOverlay` then paint the full width automatically.

**SelectionDrawing.kt: no change needed.** The `extendsToNextLine` path already draws to `size.width`; with the content box now min-width = viewport, `size.width` is the viewport-or-wider width, so a multi-line selection reaches the viewport edge automatically.

## verifyRoborazzi compare images (the real visual confirmation)
`:view:verifyRoborazzi` still reports a mismatch — that is **font-glyph drift** from baselines recorded on another machine (expected, not re-recorded here). In `active-line_compare.png` and `basic-light_compare.png` the **New** panel's active-line band now reaches the full editor width, matching **Reference**. The large solid red bar that previously spanned the un-highlighted region in the Diff panel is **gone** — only thin font-glyph drift on the text remains. This confirms the highlight-width regression is fixed.

## Regression test
`ActiveLineHighlightWidthTest` (jvmTest, CI-gated): a 2-char doc (`"hi"`) in an 800px-wide editor with `highlightActiveLine`. It asserts the highlighted line's content-box width > 600px (≈ viewport). Measured via a test-scoped `internal` hook (`EditorSessionImpl.lastActiveLineContentWidthPx`, set from `onSizeChanged` on background-decorated lines in no-wrap mode; no public API change — `apiCheck` green).
- Pre-fix: content box measured **19px** (just the text) → test FAILS.
- Post-fix: ≈ viewport width → test PASSES.

## Verification
- `:view:jvmTest` — all pass incl. the new regression test
- `:view:compileKotlinWasmJs`, `:view:compileDebugKotlinAndroid` — green
- `:view:apiCheck` — green (no apiDump; fix + test hook are internal)
- `:view:spotlessApply` — applied
- `:view:verifyRoborazzi` — expected font-drift mismatch only; highlight-width red bar gone in active-line/basic-light compares

Fixes #85