### PR TITLE
Preserve goal column across vertical cursor motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Bumped `com.monkopedia.lsp` (`lsp` + `lsp-ksrpc`) from `1.0.0-RC2` to `1.0.0-RC3`. RC3 tightens several `Hover.contents` / `ServerCapabilities.textDocumentSync` fields from untyped `JsonElement` to strict union types, so `:lsp-client`'s `ServerHover` and `DocumentSync` now read the typed `HoverContents` and `ServerCapabilitiesTextDocumentSync` unions directly instead of hand-parsing `JsonElement` (internal parsing only; no public API change). The `:lsp-client` module remains pre-stable.
 
 ### Fixed
+- Goal/sticky-column ("column memory") is preserved across vertical cursor moves again (regressed by the visual-row motion change) (#87)
 - Vim gj/gk now move by visual (wrapped) row (#77)
 - Caret height and gutter alignment on wrapped lines (#75)
 - `KodeMirror` placed under an unbounded vertical constraint (a parent with `Modifier.verticalScroll(...)`, `wrapContentHeight()`, or another scrolling container) no longer collapses to zero height or crashes the inner `LazyColumn` (which disallows an infinite `maxHeight`). The editor now grows to its content height so the surrounding scroll container can scroll it. The `KodeMirror` KDoc documents the height contract: callers should give the editor a bounded height for in-editor scrolling and caret reveal (#33)

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/CursorMotion.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/CursorMotion.kt
@@ -186,26 +186,56 @@ fun moveVertically(
     val doc = view.state.doc
     val currentLine = doc.lineAt(sel.head)
 
-    // Preserve goalColumn across consecutive vertical moves so that
-    // moving down through a short line and back up remembers the
-    // original column.
+    // Preserve goalColumn across consecutive vertical moves so that moving down
+    // through a short line and back up remembers the original column. The goal
+    // column is the REMEMBERED horizontal position; it is captured on the first
+    // vertical move and must NOT be overwritten by subsequent vertical moves.
     val goalCol = sel.goalColumn
         ?: (sel.head.value - currentLine.from.value)
 
     val coords = view.coordsAtPos(sel.head.value, if (forward) 1 else -1) ?: return sel
+
+    // Vertical motion targets the adjacent visual row at the REMEMBERED goal
+    // column's x, not the current head's x. When a stored goalColumn differs
+    // from the head's column (e.g. after End landed the cursor short on a short
+    // line), resolve the goal column to an x on the current logical line and use
+    // that as the horizontal target so wrap-aware posAtCoords lands at the goal.
+    val headCol = sel.head.value - currentLine.from.value
+    val goalX = if (goalCol != headCol) {
+        val goalPos = (currentLine.from.value + goalCol)
+            .coerceAtMost(currentLine.to.value)
+        view.coordsAtPos(goalPos, 1)?.centerX ?: coords.centerX
+    } else {
+        coords.centerX
+    }
     val targetY = if (forward) {
         coords.bottom + 1f
     } else {
         coords.top - 1f
     }
-    val rawPos = view.posAtCoords(coords.centerX, targetY)
+    val rawPos = view.posAtCoords(goalX, targetY)
 
     // posAtCoords is wrap-aware: targetY lands on the adjacent VISUAL row, which
     // may be another wrapped row of the SAME logical line. Honor that result
     // directly so vertical motion steps by visual row (this is what gj/gk and
     // the default cursor up/down rely on for wrapped lines).
     if (rawPos != null && rawPos != sel.head.value) {
-        val newPos = DocPos(rawPos)
+        val resultLine = doc.lineAt(DocPos(rawPos))
+        // When the target visual row is a DIFFERENT logical line, re-project the
+        // remembered goal column onto that line (clamped) rather than trusting the
+        // x-derived offset. This is what restores column memory: posAtCoords can
+        // only resolve goalX as far as the current (possibly short) line extends,
+        // so on a short intermediate line goalX under-reports the goal. Snapping
+        // to the clamped goal column keeps the cursor at the remembered column and
+        // lets it spring back out to the goal on the next, longer line.
+        // Within the SAME wrapped logical line, honor posAtCoords so motion stays
+        // by visual row.
+        val newPos = if (resultLine.number != currentLine.number) {
+            val targetCol = goalCol.coerceAtMost(resultLine.text.length)
+            DocPos(resultLine.from.value + targetCol)
+        } else {
+            DocPos(rawPos)
+        }
         val anchor = if (extend) sel.anchor else newPos
         return if (extend) {
             EditorSelection.range(anchor, newPos, goalColumn = goalCol)

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/CursorMotionTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/CursorMotionTest.kt
@@ -24,6 +24,7 @@ import com.monkopedia.kodemirror.state.EditorSelection
 import com.monkopedia.kodemirror.state.EditorState
 import com.monkopedia.kodemirror.state.EditorStateConfig
 import com.monkopedia.kodemirror.state.Line
+import com.monkopedia.kodemirror.state.LineNumber
 import com.monkopedia.kodemirror.state.Transaction
 import com.monkopedia.kodemirror.state.TransactionSpec
 import com.monkopedia.kodemirror.state.asDoc
@@ -228,6 +229,91 @@ class CursorMotionTest {
         val moved = moveVertically(session, sel, forward = false)
         assertEquals(DocPos(3), moved.head, "gk should move one VISUAL row up")
         assertEquals(1, session.state.doc.lineAt(moved.head).number.value)
+    }
+
+    // -----------------------------------------------------------------------
+    // Goal column ("column memory") across vertical moves (#87). After landing
+    // on a SHORT line (cursor clamped to its end), the goal column must be
+    // remembered so the next move to a longer line springs back to the goal
+    // column — matching CM6/vim/standard editors. Regressed by the visual-row
+    // motion change (#78), which targeted the current head's x instead of the
+    // remembered goal column's x.
+    // -----------------------------------------------------------------------
+
+    // Three NON-wrapping logical lines (each fits in one visual row):
+    //   line 1: "a long first line here"  (22 chars)
+    //   line 2: "shrt"                    (4 chars)
+    //   line 3: "another long line here"  (22 chars)
+    // Layout model: char width 1px, row height 10px, one visual row per line.
+    private val columnMemoryDoc = "a long first line here\nshrt\nanother long line here"
+
+    private fun columnMemorySession(startPos: Int): EditorSession =
+        object : FakeEditorSession(state(columnMemoryDoc, startPos)) {
+            private val rowHeight = 10f
+
+            override fun coordsAtPos(pos: Int, side: Int): Rect? {
+                val line = state.doc.lineAt(DocPos(pos))
+                val col = pos - line.from.value
+                val top = (line.number.value - 1) * rowHeight
+                val x = col.toFloat()
+                return Rect(x, top, x, top + rowHeight)
+            }
+
+            override fun posAtCoords(x: Float, y: Float): Int? {
+                val rowIndex = (y / rowHeight).toInt().coerceIn(0, state.doc.lines - 1)
+                val line = state.doc.line(LineNumber(rowIndex + 1))
+                val col = x.toInt().coerceIn(0, line.text.length)
+                return line.from.value + col
+            }
+        }
+
+    @Test
+    fun goalColumnPreservedAcrossShortIntermediateLine() {
+        // Cursor starts at the END of line 1 (offset 22, column 22). This is the
+        // remembered goal column once vertical motion begins.
+        val session = columnMemorySession(startPos = 22)
+        val start = EditorSelection.cursor(DocPos(22))
+
+        // Down once: line 2 ("shrt", len 4) clamps the cursor to its end (col 4).
+        val down1 = moveVertically(session, start, forward = true)
+        assertEquals(2, session.state.doc.lineAt(down1.head).number.value)
+        assertEquals(
+            4,
+            down1.head.value - session.state.doc.lineAt(down1.head).from.value,
+            "short line clamps cursor to its end column"
+        )
+        assertEquals(22, down1.goalColumn, "goal column is captured and preserved")
+
+        // Down again: line 3 ("another long line here", len 22) must spring back
+        // to the GOAL column (22), NOT stay at the short-line column (4).
+        val down2 = moveVertically(session, down1, forward = true)
+        assertEquals(3, session.state.doc.lineAt(down2.head).number.value)
+        assertEquals(
+            22,
+            down2.head.value - session.state.doc.lineAt(down2.head).from.value,
+            "cursor returns to the remembered goal column on the longer line"
+        )
+        assertEquals(22, down2.goalColumn, "goal column survives the round trip")
+    }
+
+    @Test
+    fun goalColumnPreservedOnDownThenUpRoundTrip() {
+        // Start at the end of line 1 (col 22), move down to the short line, then
+        // back up. The cursor must return to the original column on line 1.
+        val session = columnMemorySession(startPos = 22)
+        val start = EditorSelection.cursor(DocPos(22))
+
+        val down = moveVertically(session, start, forward = true)
+        // Clamped to the short line's end.
+        assertEquals(2, session.state.doc.lineAt(down.head).number.value)
+
+        val up = moveVertically(session, down, forward = false)
+        assertEquals(1, session.state.doc.lineAt(up.head).number.value)
+        assertEquals(
+            22,
+            up.head.value - session.state.doc.lineAt(up.head).from.value,
+            "down-then-up round trip preserves the original column"
+        )
     }
 
     @Test


### PR DESCRIPTION
## Root cause (regression from #78)

#78 (vim gj/gk visual-row motion) rewrote `moveVertically` in
`view/.../CursorMotion.kt`. The old code projected the **remembered goal column**
onto the target line (`targetCol = goalCol.coerceAtMost(targetLine.text.length)`),
giving CM6-style column memory. #78 replaced that with the wrap-aware
`posAtCoords(coords.centerX, targetY)` result used **directly** — and `coords.centerX`
is the x of the *current head*, not the x of the remembered goal column.

So after `End` (cursor at line-1 end, goal column captured on the first vertical
move) → `Down` clamps onto a short line, and the *next* `Down` uses the short
line's current x rather than the goal — losing column memory. Repro
(Ctrl+Home → End → Down → Down) gave the short-line column instead of the goal.

## The fix

In `moveVertically`:
- Derive the horizontal target x from the **goal column** resolved on the current
  line (`coordsAtPos(goalPos)`), not from the current head's `centerX`.
- After `posAtCoords` lands on a visual row, if that row is a **different logical
  line**, re-project the remembered goal column onto it (clamped to its length).
  This is what springs the cursor back out to the goal on a longer line after a
  short intermediate line. `posAtCoords` can only resolve the goal x as far as the
  current (possibly short) line extends, so the x alone under-reports the goal —
  clamping the stored goal column fixes it.
- Within the **same** wrapped logical line, the `posAtCoords` (visual-row) result
  is honored unchanged, so #78's gj/gk and default arrow visual-row motion on
  wrapped lines is fully preserved.
- The goal column is carried forward unchanged on every vertical move (never
  overwritten), and horizontal moves/edits reset it as before.

Goal column is a horizontal concept and visual-row motion is vertical; the fix
moves to the next visual row *at the remembered goal x*, exactly CM6's behavior.

## Tests (CI-gated guard — gap-analysis Playwright is not in CI)

Added two `commonTest` cases to `CursorMotionTest` using a deterministic
fake-geometry `EditorSession` (1px/char, 10px/row, three non-wrapping lines:
`"a long first line here"` / `"shrt"` / `"another long line here"`):
- `goalColumnPreservedAcrossShortIntermediateLine`: End-of-line-1 → Down (clamps
  to short line col 4, goal 22 preserved) → Down (springs back to col 22 on
  line 3). Asserts real column values.
- `goalColumnPreservedOnDownThenUpRoundTrip`: down to the short line then back up
  returns to col 22.

Both **FAIL pre-fix** (verified by stashing the fix: got short-line col 4 instead
of goal 22) and **PASS post-fix**. The existing `moveVertically` visual-row tests,
`HorizontalScrollIntoViewTest`, and the `:vim` `VimDisplayLineMotionTest` (gj/gk)
all still pass.

## Verification (local)

- `:view:jvmTest` — green (incl. new tests + existing motion/scroll tests)
- `:vim:jvmTest` — green (gj/gk not regressed)
- `:view:compileKotlinWasmJs` — green
- `:view:compileDebugKotlinAndroid` — green
- `:view:apiCheck` — green (no public API change)
- `:view:spotlessApply` — clean

No `:state` change; `moveVertically`'s signature is unchanged.

Fixes #87