### PR TITLE
Enable automatic release to Maven Central

### DIFF
--- a/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
@@ -130,7 +130,9 @@ mavenPublishing {
             url.set("https://github.com/Monkopedia/kodemirror/")
         }
     }
-    publishToMavenCentral()
+    // automaticRelease = true publishes straight to the Central Portal on a successful
+    // deploy, skipping the manual "Publish" click in the Sonatype Central Portal UI.
+    publishToMavenCentral(automaticRelease = true)
     signAllPublications()
 }
 


### PR DESCRIPTION
## What

Enables automatic release to Maven Central so a successful `deploy.yml` publishes straight to the Sonatype Central Portal with no manual "Publish" click.

`convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts`:
```diff
-    publishToMavenCentral()
+    // automaticRelease = true publishes straight to the Central Portal on a successful
+    // deploy, skipping the manual "Publish" click in the Sonatype Central Portal UI.
+    publishToMavenCentral(automaticRelease = true)
```

## Mechanism chosen and why

**DSL argument: `publishToMavenCentral(automaticRelease = true)`** — not the `mavenCentralAutomaticPublishing` gradle property.

The repo pins vanniktech maven-publish **0.35.0** (`gradle/libs.versions.toml` key `vanniktech`). Verified against the 0.35.0 source: `MavenPublishBaseExtension.publishToMavenCentral` is declared as `@JvmOverloads public fun publishToMavenCentral(automaticRelease: Boolean = false, validateDeployment: Boolean = true)`, so the `automaticRelease = true` argument is the documented, stable API for this version. The `mavenCentralAutomaticPublishing` gradle property is **not** referenced anywhere in the 0.35.0 extension source (it is a later addition), so it would be a no-op on 0.35.0 — the DSL arg is the correct mechanism for the pinned version. The `SonatypeHost` host param was already removed in recent versions, consistent with the single overload found.

## Scope / impact

- Affects **future** releases only; the pending 0.3.0 is unaffected.
- No other publishing/signing config touched. One-line behavioral change plus a comment.
- Build/release infra only — no user-facing API or behavior change, so no CHANGELOG entry (matches repo precedent: CHANGELOG entries are all library changes).

## Verification

- `./gradlew help` (Java 21) succeeds — convention plugin compiles/configures.
- `./gradlew :kodemirror-bom:publishMavenPublicationToMavenCentralRepository --dry-run` configures cleanly (BUILD SUCCESSFUL, tasks SKIPPED), confirming the DSL arg resolves with no unresolved-reference. No publish/upload was executed.

Fixes #90