### PR TITLE
Fix editor mount crash when hover-tooltip/lint extension is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Editor no longer crashes on mount ("EditorSession is not attached") when a hover-tooltip or lint extension is used; the session coroutine scope is now attached before plugins are constructed (#92)
+
 ## [0.3.0] - 2026-05-29
 
 ### Tests

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
@@ -141,6 +141,14 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
     val impl = session as EditorSessionImpl
     val state by session::state
 
+    // Attach the coroutine scope to the session BEFORE constructing the plugin
+    // host. syncToState() builds the view plugins, and some plugins (e.g.
+    // HoverTooltipPlugin) read session.coroutineScope eagerly in their
+    // initializer; if the scope isn't attached yet that read throws
+    // "EditorSession is not attached to a KodeMirror composable" (#92).
+    val compositionScope = rememberCoroutineScope()
+    impl.backingCoroutineScope = compositionScope
+
     val pluginHost = remember(session) {
         ViewPluginHost(session).also { it.syncToState(state, null) }
     }
@@ -157,7 +165,6 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
         mutableMapOf<Int, TextLayoutResult>()
     }
 
-    val compositionScope = rememberCoroutineScope()
     val clipboardManager = LocalClipboardManager.current
 
     // Wire up session internals eagerly (during composition, not in a side
@@ -167,7 +174,6 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
     // harmless because remember() always returns the same instances.
     impl.pluginHost = pluginHost
     impl.lineLayoutCache = lineLayoutCache
-    impl.backingCoroutineScope = compositionScope
     impl.clipboardManager = clipboardManager
 
     DisposableEffect(session) {

--- a/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/HoverTooltipMountTest.kt
+++ b/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/HoverTooltipMountTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view.input
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import com.monkopedia.kodemirror.view.hoverTooltip
+import kotlin.test.Test
+
+/**
+ * Regression test for #92: mounting an editor that uses a hover tooltip (e.g.
+ * via the `linter(...)` extension, which installs a [hoverTooltip] under the
+ * hood) must not crash during composition.
+ *
+ * [HoverTooltipPlugin][com.monkopedia.kodemirror.view] reads
+ * `session.coroutineScope` eagerly in its initializer. The plugin host is built
+ * (and thus the plugin constructed) before the session's coroutine scope was
+ * attached, so the eager read threw
+ * `IllegalStateException: EditorSession is not attached to a KodeMirror
+ * composable`. The fix attaches the scope before plugin construction.
+ *
+ * If composition throws, [runEditorTest] never reaches [block] and the test
+ * fails. Reaching the assertion at all confirms the editor mounted cleanly.
+ */
+class HoverTooltipMountTest {
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun editorWithHoverTooltipMountsWithoutCrashing() {
+        runEditorTest(
+            doc = "hello world",
+            // Minimal hover source that never produces a tooltip; the trigger
+            // for #92 is merely having the plugin installed, not showing it.
+            extensions = hoverTooltip { _, _ -> null }
+        ) { holder ->
+            // Reaching this block means composition did not throw. Confirm the
+            // editor actually mounted with the expected document.
+            holder.assertDoc("hello world")
+        }
+    }
+}


### PR DESCRIPTION
## Problem (#92)

Mounting a `KodeMirror` editor that installs a hover tooltip (e.g. via the `linter(...)` extension, or directly via `hoverTooltip { ... }`) crashed during composition:

```
kotlin.IllegalStateException: EditorSession is not attached to a KodeMirror composable
  at EditorSessionImpl.kt:68 (the coroutineScope getter's null guard)
```

## Root cause

`HoverTooltipPlugin` reads `session.coroutineScope` eagerly in a `val` initializer (`Tooltip.kt`). In `KodeMirror.kt` the plugin host was constructed (`ViewPluginHost(session).also { it.syncToState(...) }`, which builds the plugins) *before* `impl.backingCoroutineScope = compositionScope` was assigned. So the eager read hit the null guard and threw. This is an init-order hazard for any plugin that needs the scope at construction time.

## Fix

Attach the session coroutine scope **before** the plugin host is constructed. The wiring assignments are plain composition-body statements (not in a side effect), so this is a safe reorder:

- Moved `val compositionScope = rememberCoroutineScope()` and `impl.backingCoroutineScope = compositionScope` above the `pluginHost = remember(session) { ... }` block.
- Removed the now-duplicate assignment from its old spot (assigned exactly once, before plugin construction).
- Other eager assignments (`pluginHost`, `lineLayoutCache`, `clipboardManager`) and the `DisposableEffect` cleanup are unchanged.

No public API change (internal reorder).

## Regression test

Added `view/src/jvmTest/.../input/HoverTooltipMountTest.kt`: mounts an editor with a `hoverTooltip { _, _ -> null }` extension via the `runEditorTest` harness and asserts the document mounted. If composition throws, the harness never reaches the assertion and the test fails.

- **Pre-fix (fix stashed):** test FAILS with `java.lang.IllegalStateException at EditorSessionImpl.kt:68` — the exact regression.
- **Post-fix:** test PASSES, full `:view:jvmTest` suite green.

## Verification (all green)

- `:view:jvmTest` (incl. new test)
- `:view:compileKotlinWasmJs`
- `:view:compileDebugKotlinAndroid`
- `:view:apiCheck` (no apiDump needed)
- `:view:spotlessApply`

Fixes #92