### PR TITLE
Bump version to 0.3.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-01
+
 ### Fixed
 - Editor no longer crashes on mount ("EditorSession is not attached") when a hover-tooltip or lint extension is used; the session coroutine scope is now attached before plugins are constructed (#92)
 

--- a/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.0"
+version = "0.3.1"
 
 android {
     namespace = "com.monkopedia.kodemirror.${project.name.replace("-", ".")}"

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.0"
+version = "0.3.1"
 
 dependencies {
     constraints {


### PR DESCRIPTION
Patch release: version 0.3.0->0.3.1 in both build files; CHANGELOG [Unreleased]->[0.3.1] dated 2026-06-01. 0.3.1 = the #92 editor-mount-crash fix (regression in 0.3.0 when a hover-tooltip/lint extension is used). No code changes in this PR; publish to Maven Central is a separate step (now auto-release, #91). Fixes nothing directly — release bump.