### PR TITLE
Auto-create GitHub Release on publish + document release process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,3 +57,53 @@ jobs:
         -Psigning.gnupg.keyName='${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}'
         -PmavenCentralUsername='${{ secrets.OSSRH_USERNAME }}'
         -PmavenCentralPassword='${{ secrets.OSSRH_TOKEN }}'
+
+  # After ALL Maven Central matrix publishes succeed, cut a matching GitHub Release.
+  release:
+    needs: deploy
+    runs-on: ubuntu-latest
+    # Top-level perms are read-only; this job needs write to create a release.
+    permissions:
+      contents: write
+    env:
+      # gh CLI is preinstalled on ubuntu runners; authenticate via the Actions token.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Create GitHub Release
+      run: |
+        set -euo pipefail
+        # Detect the published version from the build files (never hardcode).
+        VERSION=$(grep -E '^version = ' kodemirror-bom/build.gradle.kts | sed -E 's/.*"([^"]+)".*/\1/')
+        echo "Detected version: $VERSION"
+
+        # Only final releases get a GitHub Release; skip pre-release versions.
+        case "$VERSION" in
+          *-SNAPSHOT|*-RC*)
+            echo "Version $VERSION is a pre-release (SNAPSHOT/RC); skipping GitHub Release."
+            exit 0
+            ;;
+        esac
+
+        TAG="v$VERSION"
+
+        # Idempotent: if a release already exists for this tag, skip (re-run safe).
+        if gh release view "$TAG" --repo Monkopedia/kodemirror >/dev/null 2>&1; then
+          echo "Release $TAG already exists; nothing to do."
+          exit 0
+        fi
+
+        # Extract this version's CHANGELOG section: from the "## [VERSION] - date"
+        # header up to (but not including) the next "## [" header.
+        awk -v v="## [$VERSION]" 'index($0,v)==1{f=1;print;next} /^## \[/{f=0} f' CHANGELOG.md > /tmp/relnotes.md
+
+        if [ -s /tmp/relnotes.md ]; then
+          echo "Using CHANGELOG section for release notes:"
+          cat /tmp/relnotes.md
+          gh release create "$TAG" --repo Monkopedia/kodemirror \
+            --title "$TAG" --notes-file /tmp/relnotes.md --latest --verify-tag
+        else
+          echo "No CHANGELOG section found for $VERSION; falling back to --generate-notes."
+          gh release create "$TAG" --repo Monkopedia/kodemirror \
+            --title "$TAG" --generate-notes --latest --verify-tag
+        fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,25 @@ When the user asks to compare screenshots or fix visual differences, follow the 
 
 Each fix should be a single focused PR via the automated review workflow.
 
+### Release process
+
+Publishing is irreversible and runs only on maintainer go. Git tags and GitHub Releases exist
+**only** for fully-published versions; a partial/failed publish is a burned version — skip it and
+cut the next patch.
+
+1. **Version-bump PR** (normal coderbot → reviewer flow): set `version = "X.Y.Z"` (drop the
+   `-SNAPSHOT` suffix) in both `convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts`
+   and `kodemirror-bom/build.gradle.kts`, and finalize `CHANGELOG.md` (`## [Unreleased]` →
+   `## [X.Y.Z] - <date>`).
+2. **Tag** `vX.Y.Z` on the merged release commit and push the tag.
+3. **Dispatch `deploy.yml`** (`gh workflow run deploy.yml`). It publishes all targets to Maven
+   Central AND, after every matrix publish succeeds, the `release` job auto-creates the matching
+   GitHub Release (`vX.Y.Z`) from the CHANGELOG section. The job skips `-SNAPSHOT`/`-RC` versions
+   and is re-run safe (no-op if the release already exists). `--verify-tag` fails the job if the
+   tag was never pushed.
+4. **Verify** the BOM resolves on Maven Central (`repo1.maven.org`); propagation can take 10–35 min.
+5. **Notify** downstream consumers.
+
 ### General
 
 - When the user says to "always" do something, record that instruction in this file.


### PR DESCRIPTION
## What

Closes the gap where publishing produced a Maven Central artifact + git tag but never a matching GitHub Release.

### deploy.yml — new \`release\` job
A final job appended after the existing build/deploy jobs (those are unchanged except being depended on):
- \`needs: deploy\` — runs only after **all** 10 Maven Central matrix publishes succeed.
- \`runs-on: ubuntu-latest\`, with \`permissions: contents: write\` (top-level is \`contents: read\`) and \`GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}\` (gh CLI is preinstalled on ubuntu runners).
- Steps: \`actions/checkout@v4\` → a single script step that:
  1. **Detects the version** from \`kodemirror-bom/build.gradle.kts\` (\`grep ... | sed ...\`) — never hardcoded; echoes it.
  2. **Skips pre-releases** — \`case\` on \`*-SNAPSHOT|*-RC*\` exits 0 cleanly with a printed reason.
  3. **Idempotent** — \`gh release view\` first; if the release for the tag already exists, skip (re-run safe).
  4. **Extracts the matching CHANGELOG section** via awk (from \`## [VERSION]\` to just before the next \`## [\`) into \`/tmp/relnotes.md\`; falls back to \`--generate-notes\` if empty.
  5. \`gh release create "v\$VERSION" --repo Monkopedia/kodemirror --title "v\$VERSION" --notes-file ... --latest --verify-tag\` — \`--verify-tag\` fails if the tag wasn't pushed.

### CLAUDE.md — Release process section
Added a concise "### Release process" subsection under "## Workflow" documenting: version-bump PR (drop \`-SNAPSHOT\` in the two version files + finalize CHANGELOG) → tag \`vX.Y.Z\` and push → dispatch \`deploy.yml\` (publishes to Central + auto-creates the GitHub Release) → verify BOM on \`repo1.maven.org\` (10–35 min) → notify downstream. Notes that publishing is irreversible and a partial publish is a burned version.

## Validation (no real publish triggered)
- **actionlint 1.7.12**: clean on \`.github/workflows/deploy.yml\` (no errors). YAML also parses via PyYAML; jobs = build/deploy/release with correct \`needs\`/permissions/env.
- **Version detection** against current main (\`0.3.1\`): \`VERSION=[0.3.1]\` ✓.
- **CHANGELOG extraction** verified against real file for both \`0.3.1\` (single section) and \`0.3.0\` (correctly stops at the next \`## [\` header).
- **SNAPSHOT/RC skip**: \`0.3.1 -> RELEASE\`, \`0.3.2-SNAPSHOT -> SKIP\`, \`0.4.0-RC1 -> SKIP\` ✓.
- \`./gradlew help\` still configures.

The next release (0.3.2) will exercise this end-to-end. No CHANGELOG entry (infra/tooling, matches precedent); no version bump.

Fixes #98