### PR TITLE
Bump version to 0.3.2 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-02
+
+### Fixed
+- Editor no longer crashes on mount ("EditorSession is not attached") when a hover-tooltip or lint extension is used; the session coroutine scope is now attached before plugins are constructed (#92). (First complete release of this fix — 0.3.1 contained it but failed to publish completely to Maven Central.)
+
 ## [0.3.1] - 2026-06-01
 
 ### Fixed

--- a/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.1"
+version = "0.3.2"
 
 android {
     namespace = "com.monkopedia.kodemirror.${project.name.replace("-", ".")}"

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.1"
+version = "0.3.2"
 
 dependencies {
     constraints {


### PR DESCRIPTION
Patch release: version 0.3.1->0.3.2 in both build files; CHANGELOG adds [0.3.2] dated 2026-06-02. 0.3.2 re-releases the #92 editor-mount-crash fix on the fixed publish toolchain (Gradle 9 + vanniktech 0.36.0) — 0.3.1 failed to publish completely to Maven Central (timeout dropped the BOM) and is a burned version. No code changes. Publish is a separate step (now auto-creates the GitHub Release).