### PR TITLE
Fix Maven Central publish reliability (single atomic deployment)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,36 +8,31 @@ permissions:
 jobs:
   build:
     uses: ./.github/workflows/ci.yml
+
+  # Publish EVERYTHING in a single Gradle invocation on one runner.
+  #
+  # The vanniktech maven-publish plugin uses a build-scoped shared service
+  # (MavenCentralBuildService, maxParallelUsages=1) that collects every module's
+  # artifacts registered during the build and, at the end of the build, uploads
+  # them as ONE Central Portal deployment. Because all modules share the
+  # group+version (com.monkopedia.kodemirror:<version>), that single deployment
+  # bundles all targets (jvm, android, wasmJs, macos*, ios*) AND the BOM, and is
+  # validated + auto-released atomically (automaticRelease = true in the
+  # convention plugin adds the Publish/Validate end-of-build actions).
+  #
+  # This replaces the previous 10-way matrix, where each entry ran in a SEPARATE
+  # Gradle invocation and therefore created a SEPARATE deployment. That caused the
+  # validation timeout / partial publishes, and on 0.3.2 left the BOM deployment
+  # un-released ("Skipping deployment validation!") because the BOM module is the
+  # only one without automaticRelease, so its isolated invocation never added a
+  # Validate action.
+  #
+  # Runs on macOS because the apple-native targets (macos*/ios*) require a macOS
+  # toolchain; jvm/android/wasmJs build on any platform and macos-latest ships the
+  # Android SDK, so one runner can build and publish every target this project has.
   deploy:
     needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # BOM
-          - target: :kodemirror-bom:publishMavenPublicationToMavenCentralRepository
-            os: ubuntu-latest
-          # Ubuntu targets
-          - target: publishJvmPublicationToMavenCentralRepository
-            os: ubuntu-latest
-          - target: publishAndroidReleasePublicationToMavenCentralRepository
-            os: ubuntu-latest
-          - target: publishWasmJsPublicationToMavenCentralRepository
-            os: ubuntu-latest
-          - target: publishKotlinMultiplatformPublicationToMavenCentralRepository
-            os: ubuntu-latest
-          # macOS targets (need macOS runner for native compilation)
-          - target: publishIosArm64PublicationToMavenCentralRepository
-            os: macos-latest
-          - target: publishIosSimulatorArm64PublicationToMavenCentralRepository
-            os: macos-latest
-          - target: publishIosX64PublicationToMavenCentralRepository
-            os: macos-latest
-          - target: publishMacosArm64PublicationToMavenCentralRepository
-            os: macos-latest
-          - target: publishMacosX64PublicationToMavenCentralRepository
-            os: macos-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
     - name: Import GPG key
@@ -50,15 +45,15 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
     - uses: gradle/actions/setup-gradle@v4
-    - name: Gradle publish
+    - name: Gradle publish (single atomic Central Portal deployment)
       run: >-
-        ./gradlew ${{ matrix.target }}
+        ./gradlew publishToMavenCentral
         -Psigning.gnupg.passphrase='${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}'
         -Psigning.gnupg.keyName='${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}'
         -PmavenCentralUsername='${{ secrets.OSSRH_USERNAME }}'
         -PmavenCentralPassword='${{ secrets.OSSRH_TOKEN }}'
 
-  # After ALL Maven Central matrix publishes succeed, cut a matching GitHub Release.
+  # After the Maven Central publish succeeds, cut a matching GitHub Release.
   release:
     needs: deploy
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,12 @@ cut the next patch.
    and `kodemirror-bom/build.gradle.kts`, and finalize `CHANGELOG.md` (`## [Unreleased]` →
    `## [X.Y.Z] - <date>`).
 2. **Tag** `vX.Y.Z` on the merged release commit and push the tag.
-3. **Dispatch `deploy.yml`** (`gh workflow run deploy.yml`). It publishes all targets to Maven
-   Central AND, after every matrix publish succeeds, the `release` job auto-creates the matching
-   GitHub Release (`vX.Y.Z`) from the CHANGELOG section. The job skips `-SNAPSHOT`/`-RC` versions
-   and is re-run safe (no-op if the release already exists). `--verify-tag` fails the job if the
-   tag was never pushed.
+3. **Dispatch `deploy.yml`** (`gh workflow run deploy.yml`). A single macOS runner publishes all
+   targets (incl. the BOM) to Maven Central in one Gradle invocation — one atomic Central Portal
+   deployment, validated + auto-released. After it succeeds, the `release` job auto-creates the
+   matching GitHub Release (`vX.Y.Z`) from the CHANGELOG section. The job skips `-SNAPSHOT`/`-RC`
+   versions and is re-run safe (no-op if the release already exists). `--verify-tag` fails the job
+   if the tag was never pushed.
 4. **Verify** the BOM resolves on Maven Central (`repo1.maven.org`); propagation can take 10–35 min.
 5. **Notify** downstream consumers.
 

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -99,7 +99,14 @@ mavenPublishing {
             url.set("https://github.com/Monkopedia/kodemirror/")
         }
     }
-    publishToMavenCentral()
+    // automaticRelease = true matches the library convention plugin so the BOM
+    // module also contributes the Publish/Validate end-of-build actions. In the
+    // single-invocation publish (deploy.yml) the shared MavenCentralBuildService
+    // bundles every module — incl. this BOM — into one deployment that the other
+    // modules already mark for auto-release; setting it here too makes the BOM
+    // self-sufficient and avoids the 0.3.2 "Skipping deployment validation!" bug
+    // where the BOM's isolated deployment never released.
+    publishToMavenCentral(automaticRelease = true)
     signAllPublications()
 }
 


### PR DESCRIPTION
## Root cause (#101)

`deploy.yml` published via a **10-way matrix**, each entry running a separate `./gradlew publishX…ToMavenCentralRepository` on a separate runner. The vanniktech plugin's `MavenCentralBuildService` is a **build-scoped shared service** (`registerIfAbsent`, `maxParallelUsages=1`): every module's publish task registers its artifacts into the service during the build, and at end-of-build (`close()`) the service uploads everything as **one** Central Portal deployment. Because each matrix entry was a *separate Gradle invocation*, each produced a **separate deployment** for the same `com.monkopedia.kodemirror:<version>` — fragile, and the source of the 0.3.1 validation timeout / partial publish.

On 0.3.2 the `kodemirror-bom` deployment went GREEN but never released — its job logged **"Skipping deployment validation!"**. That string is logged in `MavenCentralBuildService.runEndOfBuildActions` when the build has an `Upload` action but no `Validate` action. `Validate`/`Publish` actions are added only by `EnableAutomaticMavenCentralPublishingTask`, which a publish task depends on only when `automaticRelease = true`. The BOM uses bare `publishToMavenCentral()` (no `automaticRelease`), and in the matrix it ran in its own isolated invocation — so no module added a Validate action and the BOM uploaded as `USER_MANAGED` and sat un-released (the user published it manually).

## Investigation of vanniktech 0.36.0 deployment grouping

Confirmed from the 0.36.0 source (`plugin/.../central/MavenCentralBuildService.kt`):

- All modules in **one Gradle invocation** call `registerProject()` on the shared service; `close()` runs once and zips **all** registered projects' artifacts into **one** deployment.
- Deployment naming: 1 coordinate → `group-artifactId-version`; multiple coordinates with the **same group+version** → `group-version` (our case → `com.monkopedia.kodemirror-<version>`); otherwise `group-timestamp`.
- If **any** module added `automaticRelease=true`'s `Publish`+`Validate` actions, the **whole** combined deployment (incl. the BOM's artifacts) is validated + auto-released atomically.

So one aggregate invocation = one atomic deployment for the whole release. This is the clean fix.

## The fix

- Replace the 10-way matrix with a **single `deploy` job on `macos-latest`** running `./gradlew publishToMavenCentral` once. macOS can build every target (apple-native needs macOS; jvm/android/wasmJs build anywhere; `macos-latest` ships the Android SDK) — so one runner publishes all targets + the BOM into one atomic deployment. Same `-Psigning.gnupg.* / -PmavenCentralUsername/Password` flags as before.
- Set `automaticRelease = true` on `kodemirror-bom` too, so the BOM module is self-sufficient (defense in depth) rather than relying on a sibling module to add the Validate action.
- The `release` job (auto `gh release create`) is unchanged except `needs: deploy` (now the single job instead of the matrix). It still runs after the publish succeeds.
- Updated the release-process note in `CLAUDE.md` (no longer a matrix).

## Validation (no real publish triggered)

- `actionlint 1.7.12` on `deploy.yml`: clean.
- `./gradlew publishToMavenCentral --dry-run` (with `ANDROID_HOME` set): **BUILD SUCCESSFUL**, graph resolves with no unresolved references. **58** module `publishToMavenCentral` leaves in the graph, including `:kodemirror-bom:publishMavenPublicationToMavenCentralRepository`. After the BOM change, **every** publishing module — including `:kodemirror-bom` — now has `enableAutomaticMavenCentralPublishing` in the graph (previously the BOM was the only one without it). Published-module set is unchanged from the old matrix.
- `./gradlew help`: configures cleanly on Gradle 9.

The real test is the next release dispatch.

Fixes #101