### PR TITLE
Dispatch updateListener facet on every transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- updateListener facet (and the onChange/onSelection extensions built on it) now fire on every transaction; previously they were registered but never dispatched (#103)
+
 ## [0.3.2] - 2026-06-02
 
 ### Fixed

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/EditorSessionImpl.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/EditorSessionImpl.kt
@@ -131,6 +131,11 @@ internal class EditorSessionImpl(
         )
         pluginHost?.update(update)
         pluginHost?.syncToState(tr.state, oldState)
+        // Notify registered update listeners after the view/plugins have updated,
+        // matching CM6 where updateListeners fire after the view updates. Reading
+        // an unset facet yields an empty list, so this is a no-op when no listeners
+        // are registered. Drives the onChange/onSelection extensions (#103).
+        tr.state.facet(EditorSession.updateListener).forEach { it(update) }
         // Honor scrollIntoView: queue a request for the composable to reveal
         // the primary selection head. This drives caret-reveal on cursor moves
         // (#33) and the search/jump reveal in vim `n`/`N` (#58).

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/UpdateListenerTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/UpdateListenerTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view
+
+import com.monkopedia.kodemirror.state.ChangeSpec
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.EditorSelection
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.InsertContent
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.TransactionSpec
+import com.monkopedia.kodemirror.state.asDoc
+import com.monkopedia.kodemirror.state.extensionListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for #103: the [EditorSession.updateListener] facet (and the
+ * [onChange]/[onSelection] extensions built on it) must fire on every
+ * dispatched transaction. Previously [EditorSessionImpl.dispatchTransaction]
+ * never read the facet, so all three were silently dead.
+ */
+class UpdateListenerTest {
+
+    @Test
+    fun updateListenerFiresOnDocChange() {
+        val rawUpdates = mutableListOf<ViewUpdate>()
+        val changedTexts = mutableListOf<String>()
+
+        val state = EditorState.create(
+            EditorStateConfig(
+                doc = "hello".asDoc(),
+                extensions = extensionListOf(
+                    EditorSession.updateListener.of { update -> rawUpdates.add(update) },
+                    onChange { text -> changedTexts.add(text) }
+                )
+            )
+        )
+        val session = EditorSession(state)
+
+        session.dispatch(
+            TransactionSpec(
+                changes = ChangeSpec.Single(
+                    DocPos(5),
+                    DocPos(5),
+                    InsertContent.StringContent(" world")
+                )
+            )
+        )
+
+        // The raw facet listener fired with a doc-changed update.
+        assertEquals(1, rawUpdates.size)
+        assertTrue(rawUpdates.single().docChanged)
+        // onChange fired with the new document text.
+        assertEquals(listOf("hello world"), changedTexts)
+    }
+
+    @Test
+    fun onSelectionFiresOnSelectionOnlyChangeButOnChangeDoesNot() {
+        val rawUpdates = mutableListOf<ViewUpdate>()
+        val changedTexts = mutableListOf<String>()
+        val selections = mutableListOf<EditorSelection>()
+
+        val state = EditorState.create(
+            EditorStateConfig(
+                doc = "hello".asDoc(),
+                extensions = extensionListOf(
+                    EditorSession.updateListener.of { update -> rawUpdates.add(update) },
+                    onChange { text -> changedTexts.add(text) },
+                    onSelection { selection -> selections.add(selection) }
+                )
+            )
+        )
+        val session = EditorSession(state)
+
+        // Selection-only transaction: move the cursor, no document change.
+        session.dispatch(
+            TransactionSpec(
+                selection = SelectionSpec.CursorSpec(DocPos(2))
+            )
+        )
+
+        // The raw facet listener fired.
+        assertEquals(1, rawUpdates.size)
+        assertTrue(rawUpdates.single().selectionSet)
+        assertTrue(!rawUpdates.single().docChanged)
+        // onSelection fired with the moved selection; onChange did NOT.
+        assertEquals(1, selections.size)
+        assertEquals(DocPos(2), selections.single().main.head)
+        assertEquals(emptyList(), changedTexts)
+    }
+
+    @Test
+    fun noListenersRegisteredIsNoOp() {
+        // Reading the unset facet must yield an empty list (no throw).
+        val state = EditorState.create(EditorStateConfig(doc = "hi".asDoc()))
+        val session = EditorSession(state)
+        session.dispatch(
+            TransactionSpec(
+                changes = ChangeSpec.Single(
+                    DocPos(2),
+                    DocPos(2),
+                    InsertContent.StringContent("!")
+                )
+            )
+        )
+        assertEquals("hi!", session.state.doc.toString())
+    }
+}


### PR DESCRIPTION
## Root cause

`EditorSession.updateListener` is a documented facet ("called after every transaction"), and the public `onChange(callback)` / `onSelection(callback)` extensions are built on it via `EditorSession.updateListener.of { ... }`. But `EditorSessionImpl.dispatchTransaction(tr)` never read that facet — it only invoked the constructor `onUpdate(tr)` callback. As a result the facet, `onChange {}`, and `onSelection {}` were all registered but never dispatched: they silently never fired.

## Fix

In `dispatchTransaction`, after `pluginHost?.update(update)` / `pluginHost?.syncToState(...)` (so listeners observe post-update state, matching CM6 where updateListeners fire after the view updates) and before the existing `onUpdate(tr)` call, invoke the registered listeners:

```kotlin
tr.state.facet(EditorSession.updateListener).forEach { it(update) }
```

Reading an unset facet yields an empty list, so this is a safe no-op when no listeners are registered. The constructor `onUpdate(tr)` callback is unchanged and still fires (after the listeners). Minimal change; no public API change (the facet/extensions already exist), so `apiCheck` stays green with no `apiDump`.

## Regression test

New `view/src/commonTest/.../UpdateListenerTest.kt` (plain non-Compose — constructs an `EditorSession` and drives `dispatch(...)` directly, no `KodeMirror` mount needed):
- Registers a raw `EditorSession.updateListener.of {}`, plus `onChange {}` and `onSelection {}`.
- Doc-change transaction: asserts the raw listener fired with `docChanged == true` and `onChange` fired with the new doc text.
- Selection-only transaction (cursor move): asserts `onSelection` fired with the moved selection, the raw listener saw `selectionSet && !docChanged`, and `onChange` did NOT fire — confirming the docChanged/selectionSet gating.
- A no-listeners-registered case confirms reading the unset facet is a no-op (no throw).

**Pre-fix:** with the `dispatchTransaction` change stashed, the two listener-firing tests FAIL (AssertionError — callbacks never fire). **Post-fix:** all `:view:jvmTest` pass.

## Verification (JDK 21)

- `:view:jvmTest` — green (incl. the new test)
- `:view:compileKotlinWasmJs` — green
- `:view:compileDebugKotlinAndroid` — green
- `:view:apiCheck` — green (no apiDump; no public API change)
- `:view:spotlessApply` — clean

Fixes #103