### PR TITLE
Bump to Kotlin 2.4.0 and lsp 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Built on Kotlin 2.4.0 (was 2.3.20). Consumers of the wasmJs/native klibs must be on Kotlin 2.4.0+ (klib ABI is forward-incompatible). Also bumped the lsp dependency to 1.0.1 (the Kotlin-2.4.0 build; identical public API) (#105).
+
 ### Fixed
 - updateListener facet (and the onChange/onSelection extensions built on it) now fire on every transaction; previously they were registered but never dispatched (#103)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ tasks.register("stripStableFromApiDumps") {
 subprojects {
     pluginManager.withPlugin("org.jetbrains.kotlin.plugin.compose") {
         extensions.configure<org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension> {
-            stabilityConfigurationFile.set(
+            stabilityConfigurationFiles.add(
                 rootProject.layout.projectDirectory.file("compose-stability.conf")
             )
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.2"
-kotlin = "2.3.20"
+kotlin = "2.4.0"
 compose-plugin = "1.10.3"
 atomicfu = "0.32.1"
 kotlinx-serialization = "1.10.0"
@@ -13,7 +13,7 @@ kover = "0.9.8"
 dokka = "2.2.0"
 bcv = "0.18.1"
 vanniktech = "0.36.0"
-lsp = "1.0.0"
+lsp = "1.0.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/vim/api/android/vim.api
+++ b/vim/api/android/vim.api
@@ -70,8 +70,8 @@ public final class com/monkopedia/kodemirror/vim/ActionArgs {
 public final class com/monkopedia/kodemirror/vim/ComposableSingletons$VimPanelKt {
 	public static final field INSTANCE Lcom/monkopedia/kodemirror/vim/ComposableSingletons$VimPanelKt;
 	public fun <init> ()V
-	public final fun getLambda$749234107$vim_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$929911605$vim_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$749234107$com_monkopedia_kodemirror_vim_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$929911605$com_monkopedia_kodemirror_vim_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/monkopedia/kodemirror/vim/ExParams {

--- a/vim/api/jvm/vim.api
+++ b/vim/api/jvm/vim.api
@@ -70,8 +70,8 @@ public final class com/monkopedia/kodemirror/vim/ActionArgs {
 public final class com/monkopedia/kodemirror/vim/ComposableSingletons$VimPanelKt {
 	public static final field INSTANCE Lcom/monkopedia/kodemirror/vim/ComposableSingletons$VimPanelKt;
 	public fun <init> ()V
-	public final fun getLambda$749234107$vim ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$929911605$vim ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$749234107$com_monkopedia_kodemirror_vim ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$929911605$com_monkopedia_kodemirror_vim ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/monkopedia/kodemirror/vim/ExParams {


### PR DESCRIPTION
Toolchain bump for the klib-ABI gate required by konstructor's Kotlin 2.4.0 migration (konstructor #5). konstructor consumes kodemirror's wasm-js/native klibs; the klib ABI is forward-incompatible, so a 2.4.0 consumer needs kodemirror built on 2.4.0.

## Changes
1. `gradle/libs.versions.toml`: `kotlin = "2.3.20"` → `"2.4.0"`. The Compose-compiler and serialization Gradle plugins ride the Kotlin version ref, so they move with it.
2. `gradle/libs.versions.toml`: `lsp = "1.0.0"` → `"1.0.1"`. lsp 1.0.1 is the Kotlin-2.4.0 build of the same library with a byte-identical public API; consumable now that we're on 2.4.0. (Not 1.1.0.)
3. `build.gradle.kts`: migrate the Compose-compiler stability config from the singular `stabilityConfigurationFile.set(...)` to the plural `stabilityConfigurationFiles.add(...)` (a `ListProperty`). The singular property is deprecated in 2.4.0 and removed in 2.5.0; on 2.4.0 it fails build-script compilation. This is the only first-party code change needed.

## No Compose bump needed
Compose MP **1.10.3** supports Kotlin 2.4.0 with no version change. No KSP in the project. No kotlinx library (coroutines 1.10.2, atomicfu 0.32.1, kover 0.9.8, bcv 0.18.1, serialization 1.10.0) needed bumping — none surfaced as incompatible during the full local matrix, so nothing was bumped speculatively.

## apiCheck — one benign Compose-compiler synthetic rename
apiCheck initially flagged a diff in `:vim` only: the Kotlin 2.4.0 Compose compiler changed the synthetic suffix on its generated `ComposableSingletons$VimPanelKt` lambda accessors from the short module-name suffix to the fully-qualified package suffix:
- jvm: `getLambda$<id>$vim` → `getLambda$<id>$com_monkopedia_kodemirror_vim`
- android: `getLambda$<id>$vim_release` → `getLambda$<id>$com_monkopedia_kodemirror_vim_release`

These are compiler-synthesized `ComposableSingletons` lambda-holder accessors (the numeric lambda IDs are unchanged), not hand-authored API — the same class of synthetic Compose churn the build already strips for `$stable`. No real declared symbol was added, removed, or changed. Regenerated the `:vim` dump (`:vim:apiDump`) so the committed `.api` matches; `vim/api/vim.api` (which has no module suffix) was untouched. Full `apiCheck` is green after the regen. No other module's public API changed.

## Local verification (Gradle 9.0, JDK 21) — all green
- `./gradlew help` — configures on Kotlin 2.4.0 (BUILD SUCCESSFUL)
- `./gradlew jvmTest testDebugUnitTest` — full JVM + Android unit tests across modules (BUILD SUCCESSFUL)
- `./gradlew :state:wasmJsTest :collab:wasmJsTest :lezer-common:wasmJsTest :lezer-highlight:wasmJsTest :lezer-lr:wasmJsTest` — test-development executables compile; the `wasmJsTest` tasks themselves are SKIPPED via the centralized convention-plugin disable, as expected (BUILD SUCCESSFUL)
- `./gradlew :view:compileKotlinWasmJs :view:compileKotlinIosSimulatorArm64 :view:compileDebugKotlinAndroid` — all three targets compile (BUILD SUCCESSFUL)
- `./gradlew :samples:showcase:compileKotlinWasmJs :samples:showcase:compileKotlinDesktop` — the showcase `StubLanguageServer` (implements the full `com.monkopedia.lsp.LanguageServer`) compiled **unchanged** against lsp 1.0.1, confirming the API is identical (BUILD SUCCESSFUL)
- `./gradlew apiCheck` — green (after the `:vim` synthetic-accessor regen above)
- `./gradlew spotlessApply` — clean

Native macOS/iOS test *execution* can't run on Linux; CI's `check-macos`/`check-ios` cover it. The `iosSimulatorArm64` compile above confirms native compiles.

## Not in scope
Project `version` stays **0.3.2** — the 0.3.3 version bump + publish is a separate gated release step. No deploy dispatched.

Fixes #105