### PR TITLE
Bump version to 0.3.3 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-06-04
+
 ### Changed
 - Built on Kotlin 2.4.0 (was 2.3.20). Consumers of the wasmJs/native klibs must be on Kotlin 2.4.0+ (klib ABI is forward-incompatible). Also bumped the lsp dependency to 1.0.1 (the Kotlin-2.4.0 build; identical public API) (#105).
 

--- a/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.2"
+version = "0.3.3"
 
 android {
     namespace = "com.monkopedia.kodemirror.${project.name.replace("-", ".")}"

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.2"
+version = "0.3.3"
 
 dependencies {
     constraints {


### PR DESCRIPTION
Release 0.3.3: version 0.3.2->0.3.3 in both build files; CHANGELOG [Unreleased]->[0.3.3] dated 2026-06-04. Ships: Kotlin 2.4.0 + lsp 1.0.1 (#105, the klib-ABI gate for konstructor's 2.4.0 migration) and the updateListener/onChange/onSelection dispatch fix (#103, reported by konstructor). No code changes in this PR. Publish to Maven Central is the next step (auto-creates the GitHub Release).