### PR TITLE
Bump lsp dependency to 1.2.0; null-handle tightened result types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Bumped the lsp dependency to 1.2.0 (was 1.0.1). 1.2.0 tightens several `LanguageServer`/`LanguageClient` return types to be nullable, matching the LSP spec's optional results (`textDocument/hover`, `textDocument/formatting`, `textDocument/references`, `textDocument/rename`, `workspace/workspaceFolders`). The client now treats a null result as "no result" (no-op / empty), preserving prior behaviour. No public API change.
+
 ## [0.3.3] - 2026-06-04
 
 ### Changed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ kover = "0.9.8"
 dokka = "2.2.0"
 bcv = "0.18.1"
 vanniktech = "0.36.0"
-lsp = "1.0.1"
+lsp = "1.2.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerFormat.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerFormat.kt
@@ -132,7 +132,7 @@ fun formatDocument(session: EditorSession): Boolean {
             )
         } catch (e: CancellationException) {
             throw e
-        }
+        } ?: return@launch
         val spec = textEditsToChangeSpec(edits, targetSession.state.doc, mapping = null)
             ?: return@launch
         targetSession.dispatch(TransactionSpec(changes = spec, userEvent = "format"))

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerHover.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerHover.kt
@@ -370,7 +370,7 @@ fun serverHover(
             client.server.textDocumentHover(params)
         } catch (e: CancellationException) {
             throw e
-        }
+        } ?: return@hover null
         val blocks = parseHoverContents(hover.contents)
         if (blocks.isEmpty()) return@hover null
         val anchor = hoverTooltipPos(hover, pos, prevDoc, mapping)

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerReferences.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerReferences.kt
@@ -248,7 +248,7 @@ fun findReferences(session: EditorSession): Boolean {
             )
         } catch (e: CancellationException) {
             throw e
-        }
+        } ?: return@launch
         val locations = toReferenceLocations(response)
         if (locations.isEmpty()) return@launch
         session.dispatch(

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerRename.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerRename.kt
@@ -303,7 +303,7 @@ private fun doRename(
             } catch (e: CancellationException) {
                 throw e
             }
-            applyWorkspaceEdit(client, binding.uri, response, mapping)
+            if (response != null) applyWorkspaceEdit(client, binding.uri, response, mapping)
         } finally {
             if (mapping != null) client.workspace.releaseMapping(mapping)
         }

--- a/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/LSPClientTest.kt
+++ b/lsp-client/src/jvmTest/kotlin/com/monkopedia/kodemirror/lsp/LSPClientTest.kt
@@ -227,7 +227,7 @@ class LSPClientTest {
                 )
             ).applied
         )
-        assertTrue(lc.workspaceWorkspaceFolders().isEmpty())
+        assertTrue(lc.workspaceWorkspaceFolders().isNullOrEmpty())
     }
 
     @Test


### PR DESCRIPTION
Bumps the `lsp` dependency `1.0.1` → `1.2.0` and adapts to its source-breaking change. Validated as an **independent second consumer** of lsp 1.2.0 (per request, coordinating with lsp-kotlin).

## What 1.2.0 changes
lsp 1.2.0 tightens several `LanguageServer`/`LanguageClient` method return types to be **nullable**, matching the LSP spec's optional results. Wire format is unchanged; this is purely a Kotlin source-level nullability fix.

## Changes in this PR (minimal, behaviour-preserving)
Four **caller** sites in `:lsp-client` commonMain now treat a null result as "no result" — exactly the prior behaviour (no-op / empty):
- `ServerHover` — `textDocument/hover` → `Hover?`: null ⇒ no tooltip (`?: return@hover null`)
- `ServerFormat` — `textDocument/formatting` → `List<TextEdit>?`: null ⇒ no edits dispatched (`?: return@launch`)
- `ServerReferences` — `textDocument/references` → `List<Location>?`: null ⇒ no reference panel (`?: return@launch`)
- `ServerRename` — `textDocument/rename` → `WorkspaceEdit?`: null ⇒ no edits applied (guarded, mapping still released in `finally`)

One **test** call site (`LSPClientTest`) reads `workspaceWorkspaceFolders()` through the now-nullable `LanguageClient` interface type → `isEmpty()` ⇒ `isNullOrEmpty()`.

## Notes from the validation
- **No public API change** (`apiCheck` clean) — all edits are internal function bodies + one test.
- **No implementor churn**: the showcase `StubLanguageServer` and the jvmTest `TestLanguageServer` needed **zero** edits. Kotlin permits an override to *narrow* a nullable base return to non-null (covariant return types), so `override fun textDocumentHover(...): Hover` remains a valid override of a base now returning `Hover?`.
- Already-tolerant paths: `textDocument/definition`, `/declaration`, `/completion`, `/signatureHelp` needed no changes — the client's `parse*Result` helpers and the signature-help return type were already null-tolerant.
- No "beyond-mechanical" latent bugs surfaced: every tightened result already mapped to an existing empty/no-op branch.

## Local verification (Kotlin 2.4.0)
- `:lsp-client:jvmTest` ✅
- `:lsp-client` wasmJs + iosArm64 compile ✅ (1.2.0's Kotlin-2.4.0 klibs link cleanly)
- `:lsp-client:apiCheck` ✅
- `:samples:showcase` desktop + wasmJs compile ✅
- `spotlessCheck` ✅