### PR TITLE
Fix LSP completion on wasmJs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `CompletionConfig.asyncOverride`: suspend completion sources that the autocomplete framework launches on the editor's coroutine scope and dispatches when they resolve. This is the wasmJs-safe way to drive an async source (e.g. a language server) — the previous `asyncCompletionSource` blocking bridge throws on wasmJs (#109).
+
+### Fixed
+- **LSP completion now works on wasmJs (#109).** Several issues stacked: (a) the completion source was registered via `asyncCompletionSource`, whose wasmJs actual throws, so the popup never opened — `serverCompletion` now registers via the new `asyncOverride` path; (b) two `autocompletion()` extensions (e.g. `basicSetup` + `languageServerSupport`) no longer shadow each other — the `completionConfig` facet now merges completion sources across all configs instead of taking only the last; (c) the completion popup is rendered with a plain `Column` + bounded width and a `weight`-sized label so it lays out and paints on Compose-wasmJs (a `LazyColumn`/width-less `BasicText` collapsed to nothing); (d) completion labels display (and insert) correctly for servers that use lazy completion — `insertionText()` now treats an empty `textEdit.newText`/`insertText` as absent and falls back to the item label, and `mapCompletionItem` sets `displayLabel` to the item label. (Bold prefix-match highlighting is temporarily dropped on this path — #111; `completionItem/resolve` for auto-imports is tracked in #112.)
+- Completion trigger characters (e.g. `.`) are no longer inserted twice on wasmJs: the hidden text field's input-echo suppression is now reset per keydown and survives the extra `onValueChange` that a completion-popup recomposition can fire (#109).
+
 ### Changed
-- Bumped the lsp dependency to 1.2.0 (was 1.0.1). 1.2.0 tightens several `LanguageServer`/`LanguageClient` return types to be nullable, matching the LSP spec's optional results (`textDocument/hover`, `textDocument/formatting`, `textDocument/references`, `textDocument/rename`, `workspace/workspaceFolders`). The client now treats a null result as "no result" (no-op / empty), preserving prior behaviour. No public API change.
+- Bumped the lsp dependency to 1.2.0 (was 1.0.1) (#108). 1.2.0 tightens several `LanguageServer`/`LanguageClient` return types to be nullable, matching the LSP spec's optional results (`textDocument/hover`, `textDocument/formatting`, `textDocument/references`, `textDocument/rename`, `workspace/workspaceFolders`). The client now treats a null result as "no result" (no-op / empty), preserving prior behaviour.
+- Release artifacts are signed only for non-SNAPSHOT versions, so a local `publishToMavenLocal` of a `-SNAPSHOT` build no longer requires a GPG key.
 
 ## [0.3.3] - 2026-06-04
 

--- a/autocomplete/api/android/autocomplete.api
+++ b/autocomplete/api/android/autocomplete.api
@@ -91,8 +91,8 @@ public final class com/monkopedia/kodemirror/autocomplete/CompletionApplyContext
 public final class com/monkopedia/kodemirror/autocomplete/CompletionConfig {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (ZZZIZZLjava/util/List;)V
-	public synthetic fun <init> (ZZZIZZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZIZZLjava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (ZZZIZZLjava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
@@ -100,10 +100,12 @@ public final class com/monkopedia/kodemirror/autocomplete/CompletionConfig {
 	public final fun component5 ()Z
 	public final fun component6 ()Z
 	public final fun component7 ()Ljava/util/List;
-	public final fun copy (ZZZIZZLjava/util/List;)Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;
-	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;ZZZIZZLjava/util/List;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (ZZZIZZLjava/util/List;Ljava/util/List;)Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;ZZZIZZLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActivateOnTyping ()Z
+	public final fun getAsyncOverride ()Ljava/util/List;
 	public final fun getCloseOnBlur ()Z
 	public final fun getDefaultKeymap ()Z
 	public final fun getIcons ()Z

--- a/autocomplete/api/jvm/autocomplete.api
+++ b/autocomplete/api/jvm/autocomplete.api
@@ -91,8 +91,8 @@ public final class com/monkopedia/kodemirror/autocomplete/CompletionApplyContext
 public final class com/monkopedia/kodemirror/autocomplete/CompletionConfig {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (ZZZIZZLjava/util/List;)V
-	public synthetic fun <init> (ZZZIZZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZIZZLjava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (ZZZIZZLjava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
@@ -100,10 +100,12 @@ public final class com/monkopedia/kodemirror/autocomplete/CompletionConfig {
 	public final fun component5 ()Z
 	public final fun component6 ()Z
 	public final fun component7 ()Ljava/util/List;
-	public final fun copy (ZZZIZZLjava/util/List;)Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;
-	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;ZZZIZZLjava/util/List;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (ZZZIZZLjava/util/List;Ljava/util/List;)Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;ZZZIZZLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/autocomplete/CompletionConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActivateOnTyping ()Z
+	public final fun getAsyncOverride ()Ljava/util/List;
 	public final fun getCloseOnBlur ()Z
 	public final fun getDefaultKeymap ()Z
 	public final fun getIcons ()Z

--- a/autocomplete/src/commonMain/kotlin/com/monkopedia/kodemirror/autocomplete/Config.kt
+++ b/autocomplete/src/commonMain/kotlin/com/monkopedia/kodemirror/autocomplete/Config.kt
@@ -29,6 +29,11 @@ import com.monkopedia.kodemirror.state.Facet
  * @param maxRenderedOptions Maximum number of options to render at once.
  * @param icons Whether to show type icons next to completions.
  * @param override Optional override completion sources that replace the defaults.
+ * @param asyncOverride Optional suspend completion sources. Unlike [override]
+ *   (which must return synchronously), these are launched on the editor's
+ *   coroutine scope and their result dispatched when it resolves — the only way
+ *   to drive an async source (e.g. a language server) on wasmJs, where a
+ *   blocking bridge is impossible. Tried after [override] yields nothing.
  */
 data class CompletionConfig(
     val activateOnTyping: Boolean = true,
@@ -37,10 +42,30 @@ data class CompletionConfig(
     val maxRenderedOptions: Int = 100,
     val icons: Boolean = true,
     val defaultKeymap: Boolean = true,
-    val override: List<CompletionSource>? = null
+    val override: List<CompletionSource>? = null,
+    val asyncOverride: List<SuspendCompletionSource>? = null
 )
 
-/** Facet for completion configuration. */
+/**
+ * Facet for completion configuration.
+ *
+ * Scalar settings (activateOnTyping, etc.) are taken from the highest-precedence
+ * config, but completion SOURCES ([CompletionConfig.override] /
+ * [CompletionConfig.asyncOverride]) from EVERY contributing config are merged.
+ * This lets independently-registered `autocompletion()` extensions coexist —
+ * e.g. `basicSetup`'s bundled `autocompletion()` and `languageServerSupport`'s
+ * `serverCompletion()` — instead of the last one silently shadowing the others'
+ * sources, which left LSP completion with zero sources (#109).
+ */
 val completionConfig: Facet<CompletionConfig, CompletionConfig> = Facet.define(
-    combine = { values -> values.lastOrNull() ?: CompletionConfig() }
+    combine = { values ->
+        if (values.isEmpty()) {
+            CompletionConfig()
+        } else {
+            values.last().copy(
+                override = values.flatMap { it.override.orEmpty() }.ifEmpty { null },
+                asyncOverride = values.flatMap { it.asyncOverride.orEmpty() }.ifEmpty { null }
+            )
+        }
+    }
 )

--- a/autocomplete/src/commonMain/kotlin/com/monkopedia/kodemirror/autocomplete/View.kt
+++ b/autocomplete/src/commonMain/kotlin/com/monkopedia/kodemirror/autocomplete/View.kt
@@ -22,19 +22,19 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.monkopedia.kodemirror.state.ChangeSpec
 import com.monkopedia.kodemirror.state.DocPos
@@ -53,6 +53,7 @@ import com.monkopedia.kodemirror.view.ThemeKey
 import com.monkopedia.kodemirror.view.Tooltip
 import com.monkopedia.kodemirror.view.ViewPlugin
 import com.monkopedia.kodemirror.view.ViewUpdate
+import kotlinx.coroutines.launch
 import com.monkopedia.kodemirror.view.keymap
 import com.monkopedia.kodemirror.view.showTooltip
 
@@ -146,6 +147,7 @@ private fun triggerCompletion(view: EditorSession, explicit: Boolean) {
     val pos = state.selection.main.head
     val ctx = CompletionContext(state, pos, explicit)
     val sources = config.override ?: emptyList()
+    val asyncSources = config.asyncOverride ?: emptyList()
     for (source in sources) {
         val result = source(ctx)
         if (result != null && result.options.isNotEmpty()) {
@@ -156,6 +158,30 @@ private fun triggerCompletion(view: EditorSession, explicit: Boolean) {
             )
             return
         }
+    }
+    // Async (suspend) sources — e.g. a language server. Launched on the editor's
+    // coroutine scope; the result is dispatched when it resolves. This is the
+    // wasmJs-safe path (no blocking bridge). See CompletionConfig.asyncOverride.
+    if (asyncSources.isNotEmpty()) {
+        view.coroutineScope.launch {
+            for (source in asyncSources) {
+                val result = source(ctx)
+                if (result != null && result.options.isNotEmpty()) {
+                    view.dispatch(
+                        TransactionSpec(
+                            effects = listOf(startCompletionEffect.of(result))
+                        )
+                    )
+                    return@launch
+                }
+            }
+            if (explicit) {
+                view.dispatch(
+                    TransactionSpec(effects = listOf(closeCompletionEffect.of(Unit)))
+                )
+            }
+        }
+        return
     }
     // No results, close if open
     if (explicit) {
@@ -236,69 +262,68 @@ private fun CompletionList(
     val result = completionState.result ?: return
     val theme = LocalEditorTheme.current
 
+    // A plain Column (not LazyColumn) so the popup wraps-content to the WIDEST
+    // row: a LazyColumn does not wrap-content on the cross axis, so under this
+    // wrap-content parent it collapsed to the min width and clipped every label
+    // to ~0 (only the fixed-width type icon showed) (#109). It also avoids the
+    // unbounded-height LazyColumn collapse (cf. #33). The list is capped at
+    // config.maxRenderedOptions, so a non-lazy column + verticalScroll is fine.
     Column(
-        modifier = Modifier.background(theme[completionBackground]).padding(2.dp)
+        modifier = Modifier
+            .background(theme[completionBackground])
+            // Bounded width (not pure wrap-content): on Compose-wasmJs a BasicText
+            // with no width modifier measures to ~0 intrinsic width, so the label
+            // needs a CONCRETE width to paint (the fixed-width icon survives, a
+            // width-less label collapses to blank). A bounded Column lets the row's
+            // fillMaxWidth + the label's weight(1f) resolve to a real width (#109).
+            .widthIn(min = 200.dp, max = 360.dp)
+            .heightIn(max = 240.dp)
+            .verticalScroll(rememberScrollState())
+            .padding(2.dp)
     ) {
-        LazyColumn {
-            itemsIndexed(items) { index, item ->
-                val isSelected = index == completionState.selected
-                Row(
-                    modifier = Modifier
-                        .background(
-                            if (isSelected) {
-                                theme[completionSelectedBackground]
-                            } else {
-                                Color.Transparent
-                            }
-                        )
-                        .clickable { applyCompletion(view, item.completion, result) }
-                        .padding(horizontal = 4.dp, vertical = 2.dp)
-                ) {
-                    val textColor = theme[completionTextColor]
-                    if (config.icons && item.completion.type != null) {
-                        BasicText(
-                            text = typeIcon(item.completion.type),
-                            style = TextStyle(color = theme[completionIconColor]),
-                            modifier = Modifier.width(20.dp)
-                        )
-                    }
-                    BasicText(
-                        text = buildHighlightedLabel(
-                            item.completion.displayLabel ?: item.completion.label,
-                            item.highlighted
-                        ),
-                        style = TextStyle(color = textColor)
+        items.forEachIndexed { index, item ->
+            val isSelected = index == completionState.selected
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        if (isSelected) {
+                            theme[completionSelectedBackground]
+                        } else {
+                            Color.Transparent
+                        }
                     )
-                    if (item.completion.detail != null) {
-                        BasicText(
-                            text = " ${item.completion.detail}",
-                            style = TextStyle(color = theme[completionDetailColor]),
-                            modifier = Modifier.padding(start = 4.dp)
-                        )
-                    }
+                    .clickable { applyCompletion(view, item.completion, result) }
+                    .padding(horizontal = 4.dp, vertical = 2.dp)
+            ) {
+                val textColor = theme[completionTextColor]
+                if (config.icons && item.completion.type != null) {
+                    BasicText(
+                        text = typeIcon(item.completion.type),
+                        style = TextStyle(color = theme[completionIconColor]),
+                        modifier = Modifier.width(20.dp)
+                    )
                 }
+                // weight(1f) gives the label text a concrete width within the bounded
+                // row so it paints — a width-less BasicText collapses to ~0 on wasmJs.
+                // Detail (if any) is folded into the same text rather than a separate
+                // width-less BasicText (which would likewise collapse). Plain String,
+                // not AnnotatedString — BasicText(AnnotatedString) also failed to paint
+                // here, so prefix-match bold highlighting is dropped for now (#111).
+                val label = item.completion.displayLabel ?: item.completion.label
+                val text = item.completion.detail?.let { "$label  $it" } ?: label
+                BasicText(
+                    text = text,
+                    style = TextStyle(color = textColor),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
             }
         }
     }
 }
 
-@Composable
-private fun buildHighlightedLabel(label: String, highlights: List<IntRange>) =
-    buildAnnotatedString {
-        var pos = 0
-        for (range in highlights) {
-            if (pos < range.first) {
-                append(label.substring(pos, range.first))
-            }
-            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                append(label.substring(range.first, range.last + 1))
-            }
-            pos = range.last + 1
-        }
-        if (pos < label.length) {
-            append(label.substring(pos))
-        }
-    }
 
 private fun typeIcon(type: String): String = when (type) {
     "function", "method" -> "f"

--- a/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
@@ -133,19 +133,28 @@ mavenPublishing {
     // automaticRelease = true publishes straight to the Central Portal on a successful
     // deploy, skipping the manual "Publish" click in the Sonatype Central Portal UI.
     publishToMavenCentral(automaticRelease = true)
-    signAllPublications()
+    // Sign released artifacts only. SNAPSHOT builds (e.g. local `publishToMavenLocal`
+    // iteration) skip signing: the Central Portal does not require signatures for
+    // snapshots, and skipping avoids needing a GPG key for fast local loops.
+    if (!version.toString().endsWith("SNAPSHOT")) {
+        signAllPublications()
+    }
 }
 
-signing {
-    useGpgCmd()
-    sign(extensions.getByType<PublishingExtension>().publications)
-}
+// Sign released artifacts only. SNAPSHOT builds (local `publishToMavenLocal`
+// iteration) skip signing entirely — no GPG key needed for the fast local loop.
+if (!version.toString().endsWith("SNAPSHOT")) {
+    signing {
+        useGpgCmd()
+        sign(extensions.getByType<PublishingExtension>().publications)
+    }
 
-afterEvaluate {
-    tasks.withType<Sign> {
-        val signingTask = this
-        tasks.withType<AbstractPublishToMaven> {
-            dependsOn(signingTask)
+    afterEvaluate {
+        tasks.withType<Sign> {
+            val signingTask = this
+            tasks.withType<AbstractPublishToMaven> {
+                dependsOn(signingTask)
+            }
         }
     }
 }

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -107,10 +107,17 @@ mavenPublishing {
     // self-sufficient and avoids the 0.3.2 "Skipping deployment validation!" bug
     // where the BOM's isolated deployment never released.
     publishToMavenCentral(automaticRelease = true)
-    signAllPublications()
+    // Sign released artifacts only; SNAPSHOT builds (local mavenLocal iteration)
+    // skip signing. See the matching guard in the kodemirror.library convention plugin.
+    if (!version.toString().endsWith("SNAPSHOT")) {
+        signAllPublications()
+    }
 }
 
-signing {
-    useGpgCmd()
-    sign(extensions.getByType<PublishingExtension>().publications)
+// Sign released artifacts only; SNAPSHOT builds skip signing (local mavenLocal loop).
+if (!version.toString().endsWith("SNAPSHOT")) {
+    signing {
+        useGpgCmd()
+        sign(extensions.getByType<PublishingExtension>().publications)
+    }
 }

--- a/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletion.kt
+++ b/lsp-client/src/commonMain/kotlin/com/monkopedia/kodemirror/lsp/ServerCompletion.kt
@@ -23,9 +23,7 @@ import com.monkopedia.kodemirror.autocomplete.CompletionApplyContext
 import com.monkopedia.kodemirror.autocomplete.CompletionConfig
 import com.monkopedia.kodemirror.autocomplete.CompletionContext
 import com.monkopedia.kodemirror.autocomplete.CompletionResult
-import com.monkopedia.kodemirror.autocomplete.CompletionSource
 import com.monkopedia.kodemirror.autocomplete.SuspendCompletionSource
-import com.monkopedia.kodemirror.autocomplete.asyncCompletionSource
 import com.monkopedia.kodemirror.autocomplete.autocompletion
 import com.monkopedia.kodemirror.autocomplete.snippet
 import com.monkopedia.kodemirror.autocomplete.snippets
@@ -194,7 +192,15 @@ internal fun CompletionItemTextEdit.newText(): String = when (this) {
  * `label`.
  */
 internal fun CompletionItem.insertionText(): String =
-    textEdit?.newText() ?: textEditText ?: insertText ?: label
+    // Treat an EMPTY newText/insertText as absent and fall through to `label`.
+    // Servers that use lazy completion (e.g. kotlin-lsp) send items with an
+    // empty `textEdit.newText` and resolve the real insertion via
+    // `completionItem/resolve`; the empty string would otherwise short-circuit
+    // this chain and leave both the displayed and inserted text blank (#109).
+    textEdit?.newText()?.ifEmpty { null }
+        ?: textEditText?.ifEmpty { null }
+        ?: insertText?.ifEmpty { null }
+        ?: label
 
 /**
  * Map a single LSP [CompletionItem] to an `:autocomplete` [Completion].
@@ -246,6 +252,7 @@ internal fun mapCompletionItem(item: CompletionItem, doc: Text): Completion {
         }
         return Completion(
             label = item.label,
+            displayLabel = item.label,
             detail = item.detail,
             info = info,
             type = type,
@@ -264,7 +271,11 @@ internal fun mapCompletionItem(item: CompletionItem, doc: Text): Completion {
         }
     }
     return Completion(
+        // label is the insertion/filter text; displayLabel is what the popup
+        // SHOWS — the human-readable item.label (e.g. "transform"), which can
+        // differ from the inserted text and must not be left to default to it (#109).
         label = text,
+        displayLabel = item.label,
         detail = item.detail,
         info = info,
         type = type,
@@ -489,12 +500,15 @@ fun serverCompletion(
     uri: String,
     config: ServerCompletionConfig = ServerCompletionConfig()
 ): Extension {
-    val source: CompletionSource = asyncCompletionSource(
-        serverCompletionSource(client, uri, config)
-    )
+    // Register the LSP source as an ASYNC override. The framework launches it on
+    // the editor's coroutine scope and dispatches the result when it resolves —
+    // the previous `asyncCompletionSource` (blocking) bridge is unsupported on
+    // wasmJs (it throws), so completion never opened on web (#109). The suspend
+    // source works uniformly on jvm/wasmJs/native this way.
+    val source: SuspendCompletionSource = serverCompletionSource(client, uri, config)
     return ExtensionList(
         listOf(
-            autocompletion(CompletionConfig(override = listOf(source))),
+            autocompletion(CompletionConfig(asyncOverride = listOf(source))),
             snippets()
         )
     )

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
@@ -245,6 +245,14 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
     // should skip to avoid double-handling.
     val keyProcessedByCallback = remember { booleanArrayOf(false) }
 
+    // Suppresses the hidden text field's onValueChange echo for a key already
+    // handled by the key-event paths (document-level handler / onPreviewKeyEvent).
+    // Declared here (rather than inside EditorContent) so the document-level key
+    // handler below can RESET it at the start of each keydown. It then stays
+    // armed across the — possibly multiple — onValueChange echoes a single
+    // keystroke can produce on wasmJs when a completion popup recomposes (#109).
+    val suppressInput = remember { booleanArrayOf(false) }
+
     // Register a platform-level key handler that receives ALL keydown events.
     // This is the primary input path on wasmJs because Playwright (and some
     // headless environments) dispatch key events to BODY rather than the
@@ -253,12 +261,24 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
     // onPreviewKeyEvent fire — the flag prevents double-handling.
     DisposableEffect(session) {
         val token = platformRegisterKeyHandler handler@{ key, ctrl, alt, meta, shift ->
-            // Clear the flag at the start of each key event.
-            // It will be set to true only if we handle this key.
+            // Clear the flags at the start of each key event.
+            // keyProcessedByCallback is set true only if we handle this key.
+            // suppressInput is reset so this keystroke can re-arm echo
+            // suppression from scratch; it then stays armed across the
+            // (possibly multiple) onValueChange echoes one keystroke can
+            // produce on wasmJs when a completion popup recomposes (#109).
             keyProcessedByCallback[0] = false
+            suppressInput[0] = false
             val handled = handleRawKeyEvent(session, key, ctrl, alt, meta, shift)
             if (handled) {
                 keyProcessedByCallback[0] = true
+                // A plain printable char inserted here still triggers an
+                // onValueChange echo on the hidden field even when onPreviewKeyEvent
+                // does NOT fire on the live wasmJs build — so arm echo suppression
+                // directly rather than relying on onPreviewKeyEvent to bridge it (#109).
+                if (key.length == 1 && !ctrl && !alt && !meta && !key[0].isISOControl()) {
+                    suppressInput[0] = true
+                }
             }
             handled
         }
@@ -597,7 +617,8 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
                     pendingLineLayouts = pendingLineLayouts,
                     editorCoordinates = editorCoordinates,
                     textLayoutResults = textLayoutResults,
-                    keyProcessedByCallback = keyProcessedByCallback
+                    keyProcessedByCallback = keyProcessedByCallback,
+                    suppressInput = suppressInput
                 )
                 // Visible horizontal scrollbar for no-wrap mode (#65). Only
                 // shown when there is actual horizontal overflow and line
@@ -641,7 +662,8 @@ private fun EditorContent(
     pendingLineLayouts: MutableMap<Int, PendingLineLayout>,
     editorCoordinates: LayoutCoordinates?,
     textLayoutResults: MutableMap<Int, TextLayoutResult>,
-    keyProcessedByCallback: BooleanArray
+    keyProcessedByCallback: BooleanArray,
+    suppressInput: BooleanArray
 ) {
     val session = LocalEditorSession.current
     val impl = session as EditorSessionImpl
@@ -668,17 +690,25 @@ private fun EditorContent(
     var hiddenTextValue by remember {
         mutableStateOf(TextFieldValue(""))
     }
-    // Flag to suppress onValueChange when onPreviewKeyEvent consumed the key.
-    // On wasmJs, returning true from onPreviewKeyEvent does NOT call
-    // preventDefault() on the DOM event, so the browser still generates an
-    // input event that triggers onValueChange. This flag bridges the gap.
-    val suppressInput = remember { booleanArrayOf(false) }
+    // suppressInput (hoisted to the caller) suppresses the hidden text field's
+    // onValueChange echo when onPreviewKeyEvent / the document-level handler
+    // already consumed the key. On wasmJs, returning true from onPreviewKeyEvent
+    // does NOT call preventDefault() on the DOM event, so the browser still
+    // generates an input event that triggers onValueChange. This flag bridges
+    // the gap. It is RESET per keydown (by the document-level handler), not by
+    // onValueChange, so it survives more than one echo per keystroke (#109).
     BasicTextField(
         value = hiddenTextValue,
         cursorBrush = SolidColor(Color.Transparent),
         onValueChange = { newValue ->
             if (suppressInput[0]) {
-                suppressInput[0] = false
+                // Sticky: do NOT clear suppressInput here. A single keystroke can
+                // produce more than one onValueChange echo on wasmJs — the browser
+                // input event, plus a re-fire when a completion popup recomposes —
+                // and both must be dropped, otherwise the trigger character is
+                // re-inserted (doubled) and the spurious doc-change closes the
+                // just-opened completion popup (#109). The flag is reset per
+                // keydown by the document-level key handler.
                 hiddenTextValue = TextFieldValue("")
                 return@BasicTextField
             }


### PR DESCRIPTION
Makes language-server completion work on the **wasmJs** target (the popup never opened / rendered there). Verified end-to-end against a live kotlin-lsp engine via the konstructor consumer's Playwright canvas-screenshot harness (popup opens on `.`, renders icon + real labels, inserts correctly).

Fixes #109.

> **No version bump / release.** Version stays `0.3.3`; the CHANGELOG entries land under `[Unreleased]`. More LSP work is planned before the next version is cut, so this PR is just the fix — a 0.3.x release is a separate, later PR.

## The stack of bugs (all #109)
1. **Popup never opened on wasmJs.** `serverCompletion` registered its source via `asyncCompletionSource`, whose wasmJs `actual` throws. Added **`CompletionConfig.asyncOverride`** — suspend sources the framework launches on the editor's `coroutineScope` and dispatches when they resolve (no blocking bridge); `serverCompletion` now uses it. Drives both typed-trigger and Ctrl+Space.
2. **Two `autocompletion()` extensions shadowed each other.** `basicSetup` bundles `autocompletion()`, and `languageServerSupport` adds another; the `completionConfig` facet combine was `values.lastOrNull()`, so one config won wholesale and the LSP source vanished (0 sources). The combine now **merges** `override`/`asyncOverride` across all configs.
3. **Popup rendered as a blank/thin strip.** `CompletionList` used a `LazyColumn` (no cross-axis wrap-content) and width-less `BasicText` labels, which collapse to ~0 on Compose-wasmJs. Now a plain `Column` + bounded width, `fillMaxWidth` rows, and a `weight(1f)` + single-line-ellipsis label so the label gets a concrete width and paints.
4. **Labels (and insertion) blank for lazy-completion servers.** kotlin-lsp sends items with an **empty `textEdit.newText`** (real edits arrive via `completionItem/resolve`). `insertionText()` returned `""`, so the displayed *and* inserted text were empty. It now treats empty `newText`/`insertText`/`textEditText` as absent and falls back to `item.label`; `mapCompletionItem` sets `displayLabel = item.label`.
5. **Trigger char inserted twice on wasmJs.** The hidden text field's input-echo suppression was a one-shot flag; a completion-popup recomposition fires an extra `onValueChange` that slipped past it. The flag is now reset per keydown (document-level handler) and stays armed across multiple echoes.

## Also
- `apiDump`: `CompletionConfig` gains the public `asyncOverride` field (the only API change).
- Skip artifact **signing for `-SNAPSHOT`** versions, so local `publishToMavenLocal` works without a GPG key (this enabled the local-snapshot verification loop used to land #109).

## Deferred (filed)
- **#111** — restore prefix-match **bold** highlighting (was an `AnnotatedString`; dropped for now).
- **#112** — proper lazy completion via `completionItem/resolve` (auto-imports / `additionalTextEdits` won't apply until then; the label fallback handles the common case).

## Verification (local, Kotlin 2.4.0)
`:autocomplete:jvmTest`, `:lsp-client:jvmTest`, `:view:jvmTest` ✅ · wasmJs compile (autocomplete/lsp-client/view) ✅ · `apiCheck` ✅ · `spotlessCheck` ✅. End-to-end completion behavior screenshot-verified on the live engine by the konstructor consumer.