### PR TITLE
Port :commands deleteGroup + deleteTrailingWhitespace tests from upstream (#116)

### DIFF
--- a/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/DeleteGroupTest.kt
+++ b/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/DeleteGroupTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.commands
+
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.asDoc
+import com.monkopedia.kodemirror.view.EditorSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Ported from upstream `@codemirror/commands` `test/test-commands.ts`
+ * (deleteGroupForward / deleteGroupBackward). Part of #116 — `deleteByGroup`
+ * had no direct coverage. A single `|` marks the cursor.
+ */
+class DeleteGroupTest {
+
+    private fun view(docWithCursor: String): EditorSession {
+        val pos = docWithCursor.indexOf('|')
+        require(pos >= 0)
+        val doc = docWithCursor.replace("|", "")
+        return EditorSession(
+            EditorState.create(
+                EditorStateConfig(
+                    doc = doc.asDoc(),
+                    selection = SelectionSpec.CursorSpec(DocPos(pos))
+                )
+            )
+        )
+    }
+
+    private fun assertResult(v: EditorSession, expectedWithCursor: String) {
+        val expectedPos = expectedWithCursor.indexOf('|')
+        val expectedDoc = expectedWithCursor.replace("|", "")
+        assertEquals(expectedDoc, v.state.doc.toString(), "document text")
+        assertEquals(expectedPos, v.state.selection.main.head.value, "cursor position")
+    }
+
+    private fun fwd(from: String, to: String) {
+        val v = view(from)
+        deleteGroupForward(v)
+        assertResult(v, to)
+    }
+
+    private fun back(from: String, to: String) {
+        val v = view(from)
+        deleteGroupBackward(v)
+        assertResult(v, to)
+    }
+
+    // ── deleteGroupForward ──
+
+    @Test fun fwdDeletesWord() = fwd("one |two three", "one | three")
+
+    @Test fun fwdDeletesWordWithLeadingSpace() = fwd("one| two three", "one| three")
+
+    @Test fun fwdDeletesPunctuation() = fwd("one|...two", "one|two")
+
+    @Test fun fwdDeletesSpaceGroup() = fwd("one|  \ttwo", "one|two")
+
+    @Test fun fwdDeletesNewline() = fwd("one|\ntwo", "one|two")
+
+    @Test fun fwdStopsAtNewline() = fwd("one| \n two", "one|\n two")
+
+    @Test fun fwdStopsAfterNewline() = fwd("one|\n two", "one| two")
+
+    @Test fun fwdDeletesToEndOfDoc() = fwd("one|two", "one|")
+
+    @Test fun fwdDoesNothingAtEndOfDoc() = fwd("one|", "one|")
+
+    // ── deleteGroupBackward ──
+
+    @Test fun backDeletesWord() = back("one two| three", "one | three")
+
+    @Test fun backDeletesWordWithTrailingSpace() = back("one two |three", "one |three")
+
+    @Test fun backDeletesPunctuation() = back("one...|two", "one|two")
+
+    @Test fun backDeletesSpaceGroup() = back("one \t |two", "one|two")
+
+    @Test fun backDeletesNewline() = back("one\n|two", "one|two")
+
+    @Test fun backStopsAtNewline() = back("one \n |two", "one \n|two")
+
+    @Test fun backStopsAfterNewline() = back("one \n|two", "one |two")
+
+    @Test fun backDeletesToStartOfDoc() = back("one|two", "|two")
+}

--- a/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/DeleteTrailingWhitespaceTest.kt
+++ b/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/DeleteTrailingWhitespaceTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.commands
+
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.asDoc
+import com.monkopedia.kodemirror.view.EditorSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Ported from upstream `@codemirror/commands` `test/test-commands.ts`
+ * (`deleteTrailingWhitespace`). Part of #116 — previously uncovered.
+ */
+class DeleteTrailingWhitespaceTest {
+
+    private fun run(input: String): String {
+        val v = EditorSession(
+            EditorState.create(
+                EditorStateConfig(
+                    doc = input.asDoc(),
+                    selection = SelectionSpec.CursorSpec(DocPos(0))
+                )
+            )
+        )
+        deleteTrailingWhitespace(v)
+        return v.state.doc.toString()
+    }
+
+    @Test fun deletesTrailingWhitespace() = assertEquals("foo", run("foo   "))
+
+    @Test fun checksMultipleLines() =
+        assertEquals("one\ntwo\nthree\n", run("one\ntwo \nthree   \n   "))
+
+    @Test fun handlesEmptyLines() = assertEquals("one\n\ntwo", run("one  \n\ntwo "))
+}


### PR DESCRIPTION
Continues the #116 test-coverage port (after #120 ported the comment tests + fixed #119). Adds the previously-uncovered upstream `@codemirror/commands` cases for:

- **`deleteGroupForward` / `deleteGroupBackward`** — 17 cases (word; leading/trailing space; punctuation group; space group; newline boundaries — stop at / stop after; doc start/end edges).
- **`deleteTrailingWhitespace`** — 3 cases (single line, multiple lines, empty lines).

**All pass against the current implementation** — coverage only, no behavior change. (Unlike the comment tests, which surfaced #119, these areas were already correct — a useful signal that the gap was localized.)

`:commands:jvmTest` now 71 tests (was 51), 0 failures. Test-only; no source/API change.

Part of #116. Remaining for a follow-up: bracket-explode, multi-range `moveLine`, and (needs-decision) `indentSelection`.