### PR TITLE
Port insertNewlineKeepIndent + bracket-explosion tests (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Arrow-navigating a completion list longer than the popup now scrolls the selected row into view; the `verticalScroll` column previously did not follow the selection, so the highlight could move out of sight below the fold (#115).
 - Editing no longer crashes (`IllegalArgumentException: Invalid position …`) when a coordinate query (tooltip positioning, caret reveal) holds a document position that briefly outlives a shrinking edit. `coordsAtPos`/`blockAtPos` now return null for a position outside the current document instead of throwing `lineAt` mid-render — on a delete that removes the last character a stale position is exactly `length + 1` (#127).
 
+### Tests
+- Ported upstream `:commands` coverage for `insertNewlineKeepIndent` and the bracket-explosion behaviour of `insertNewlineAndIndent` (both were ported but untested) (#116).
+
 ### Changed
 - Bumped the lsp dependency to 1.2.0 (was 1.0.1) (#108). 1.2.0 tightens several `LanguageServer`/`LanguageClient` return types to be nullable, matching the LSP spec's optional results (`textDocument/hover`, `textDocument/formatting`, `textDocument/references`, `textDocument/rename`, `workspace/workspaceFolders`). The client now treats a null result as "no result" (no-op / empty), preserving prior behaviour.
 - Release artifacts are signed only for non-SNAPSHOT versions, so a local `publishToMavenLocal` of a `-SNAPSHOT` build no longer requires a GPG key.

--- a/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/NewlineCommandsTest.kt
+++ b/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/NewlineCommandsTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.commands
+
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.asDoc
+import com.monkopedia.kodemirror.view.EditorSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Ported from upstream `@codemirror/commands` `test/test-commands.ts`
+ * (`insertNewlineKeepIndent` and the bracket-explosion behaviour of
+ * `insertNewlineAndIndent`). Part of #116 — both commands were ported but
+ * untested.
+ *
+ * These cases use a plain [EditorState] with no language extension, so the
+ * indentation comes from the leading-whitespace fallback (no indent service).
+ * The amount-of-indent cases that need a language indent service
+ * (`getIndentation`) are tracked separately. A single `|` marks the cursor;
+ * `<…>` an anchored selection range.
+ */
+class NewlineCommandsTest {
+
+    private fun view(docWithCursor: String): EditorSession {
+        // Supports a single `|` cursor, or `<` … `|` for a selection whose
+        // anchor is at `<` and head at `|`.
+        val anchorMark = docWithCursor.indexOf('<')
+        val headMark = docWithCursor.indexOf('|')
+        require(headMark >= 0) { "cursor mark `|` required" }
+        val doc = docWithCursor.replace("<", "").replace("|", "")
+        val selection = if (anchorMark >= 0) {
+            // Strip-order: `<` precedes `|` in the raw string; once `<` is
+            // removed the head index shifts left by one.
+            val anchor = anchorMark
+            val head = headMark - 1
+            SelectionSpec.CursorSpec(DocPos(anchor), DocPos(head))
+        } else {
+            SelectionSpec.CursorSpec(DocPos(headMark))
+        }
+        return EditorSession(
+            EditorState.create(
+                EditorStateConfig(doc = doc.asDoc(), selection = selection)
+            )
+        )
+    }
+
+    private fun assertDoc(v: EditorSession, expected: String) {
+        assertEquals(expected, v.state.doc.toString())
+    }
+
+    // ── insertNewlineKeepIndent ──
+
+    @Test
+    fun keepIndentCopiesLeadingWhitespace() {
+        val v = view("    foo|")
+        insertNewlineKeepIndent(v)
+        assertDoc(v, "    foo\n    ")
+    }
+
+    @Test
+    fun keepIndentWithZeroIndent() {
+        val v = view("foo|")
+        insertNewlineKeepIndent(v)
+        assertDoc(v, "foo\n")
+    }
+
+    @Test
+    fun keepIndentReplacesSelection() {
+        val v = view("  <ab|")
+        insertNewlineKeepIndent(v)
+        assertDoc(v, "  \n  ")
+    }
+
+    // ── insertNewlineAndIndent bracket explosion ──
+
+    @Test
+    fun explodesEmptyBrackets() {
+        val v = view("{|}")
+        insertNewlineAndIndent(v)
+        assertDoc(v, "{\n\n}")
+    }
+
+    @Test
+    fun explodesBracketsPreservingOuterIndent() {
+        val v = view("  {|}")
+        insertNewlineAndIndent(v)
+        assertDoc(v, "  {\n  \n  }")
+    }
+
+    @Test
+    fun doesNotExplodeWhenNotBetweenBrackets() {
+        val v = view("{x|}")
+        insertNewlineAndIndent(v)
+        assertDoc(v, "{x\n}")
+    }
+
+    @Test
+    fun parenAndSquareBracketsAlsoExplode() {
+        val vp = view("(|)")
+        insertNewlineAndIndent(vp)
+        assertDoc(vp, "(\n\n)")
+        val vs = view("[|]")
+        insertNewlineAndIndent(vs)
+        assertDoc(vs, "[\n\n]")
+    }
+}


### PR DESCRIPTION
Part of #116 (upstream `:commands` test port). Ports the remaining newline-command cases that are portable without a language indent service.

## What's covered
**`insertNewlineKeepIndent`** (was ported, zero tests):
- copies the line's leading whitespace onto the new line
- zero-indent line
- replaces a non-empty selection with newline+indent

**`insertNewlineAndIndent` bracket explosion** (`{|}` → `{\n\n}`):
- empty brackets explode the closing bracket onto its own line, cursor on the middle line
- outer indentation preserved (`  {|}` → `  {\n  \n  }`)
- no explosion when the cursor is not between a matching pair (`{x|}`)
- `()`, `[]`, `{}` all explode

`isBetweenBrackets` works on raw text and the indent fallback is leading-whitespace, so these need no language — verified by running them (all green on first run).

## Scope notes (not in this PR)
- **Indent-*amount* cases** (upstream's 2/4-space, tab, tab+alignment explode variants) and **`indentSelection`** need a language indent service (`getIndentation`) wired into `:commands` test scope — tracked under #116, assessing the cleanest way to provide that without an awkward test-only module dependency.
- **`moveLine` multi-range** is intentionally NOT ported: kodemirror's `moveLines` operates only on `state.selection.main`, so the upstream multi-range/merge cases describe an unimplemented feature (single-range only) rather than a missing test. Filing that separately as a feature gap.

Test-only; no production change, no version bump (stays 0.3.3). `:commands:jvmTest` + spotless green.