### PR TITLE
Test insertNewlineAndIndent uses the language indent service (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Editing no longer crashes (`IllegalArgumentException: Invalid position …`) when a coordinate query (tooltip positioning, caret reveal) holds a document position that briefly outlives a shrinking edit. `coordsAtPos`/`blockAtPos` now return null for a position outside the current document instead of throwing `lineAt` mid-render — on a delete that removes the last character a stale position is exactly `length + 1` (#127).
 
 ### Tests
-- Ported upstream `:commands` coverage for `insertNewlineKeepIndent` and the bracket-explosion behaviour of `insertNewlineAndIndent` (both were ported but untested) (#116).
+- Ported upstream `:commands` coverage for `insertNewlineKeepIndent` and the bracket-explosion behaviour of `insertNewlineAndIndent` (both were ported but untested), including its use of a registered `indentService` for language-aware indentation (#116).
 - Added `:autocomplete` pipeline coverage for unfiltered (`filter = false`) results, accept replacing a range that extends past the cursor, first-non-empty source selection, and `completeFromList` word-match/explicit gating (#117).
 
 ### Changed

--- a/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/IndentServiceNewlineTest.kt
+++ b/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/IndentServiceNewlineTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.commands
+
+import com.monkopedia.kodemirror.language.indentService
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.ExtensionList
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.asDoc
+import com.monkopedia.kodemirror.view.EditorSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * `insertNewlineAndIndent` consults the language indent service (via
+ * `getIndentation`) when one is registered, instead of the leading-whitespace
+ * fallback exercised by [NewlineCommandsTest]. This is the language-aware
+ * branch upstream's tests drive with `javascriptLanguage`; here we register a
+ * minimal [indentService] that always asks for a fixed column count, so the
+ * test needs no real language module (#116).
+ */
+class IndentServiceNewlineTest {
+
+    /** A view whose indent service always requests [columns] of indentation. */
+    private fun viewWithFixedIndent(
+        doc: String,
+        cursor: Int,
+        columns: Int
+    ): EditorSession {
+        val state = EditorState.create(
+            EditorStateConfig(
+                doc = doc.asDoc(),
+                selection = SelectionSpec.CursorSpec(DocPos(cursor)),
+                extensions = ExtensionList(
+                    listOf(indentService.of { _, _ -> columns })
+                )
+            )
+        )
+        return EditorSession(state)
+    }
+
+    @Test
+    fun plainNewlineUsesIndentService() {
+        // The service asks for 4 columns; the new line is indented to 4 spaces
+        // rather than copying the (empty) leading whitespace of "foo".
+        val v = viewWithFixedIndent("foo", cursor = 3, columns = 4)
+        insertNewlineAndIndent(v)
+        assertEquals("foo\n    ", v.state.doc.toString())
+    }
+
+    @Test
+    fun explosionMiddleLineUsesIndentService() {
+        // Between brackets: the closing bracket keeps the line's (empty) leading
+        // whitespace, but the middle line is indented by the service's 4 columns.
+        val v = viewWithFixedIndent("{}", cursor = 1, columns = 4)
+        insertNewlineAndIndent(v)
+        assertEquals("{\n    \n}", v.state.doc.toString())
+    }
+
+    @Test
+    fun cursorLandsOnIndentedMiddleLine() {
+        val v = viewWithFixedIndent("{}", cursor = 1, columns = 4)
+        insertNewlineAndIndent(v)
+        // After "{" + "\n" (1) + "    " (4) → cursor at column offset 6.
+        assertEquals(6, v.state.selection.main.head.value)
+    }
+}


### PR DESCRIPTION
Part of #116. Complements the #129 no-language newline tests by exercising the **language-aware** indent branch of `insertNewlineAndIndent`.

`insertNewlineAndIndent` calls `getIndentation`, which consults the `indentService` facet before falling back to copying leading whitespace. The #129 tests covered the fallback (no language); this registers a minimal in-test `indentService` (always requesting a fixed column count) and asserts:
- a plain newline indents the new line to the service's columns (`foo|` + service→4 ⇒ `foo\n    `)
- bracket explosion indents the **middle** line from the service while the closing bracket keeps the line's leading whitespace (`{|}` ⇒ `{\n    \n}`)
- the cursor lands on the indented middle line

`:commands` already depends on `:language`, so no real language module is needed — just `indentService.of { _, _ -> columns }`. All 3 pass on first run.

## Scope note
`indentSelection` (upstream's auto-indent-whole-selection command) is **not implemented** in kodemirror — it has manual `indentMore`/`indentLess` (already tested in `IndentCommandsTest`) but no `indentSelection`. So that upstream test group describes an unimplemented feature, not a missing test; noting it on #116 as a feature gap rather than porting red tests.

Test-only; no production change, no version bump (stays 0.3.3). `:commands:jvmTest` + spotless green.