### PR TITLE
Add selectNextOccurrence subword test (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Tests
 - Ported upstream `:commands` coverage for `insertNewlineKeepIndent` and the bracket-explosion behaviour of `insertNewlineAndIndent` (both were ported but untested) (#116).
 - Added `:autocomplete` pipeline coverage for unfiltered (`filter = false`) results, accept replacing a range that extends past the cursor, first-non-empty source selection, and `completeFromList` word-match/explicit gating (#117).
+- Added the upstream `selectNextOccurrence` subword case — selecting a subword (`one` inside `onetwo`) also matches it inside another word (`onethree`) (#118).
 
 ### Changed
 - Bumped the lsp dependency to 1.2.0 (was 1.0.1) (#108). 1.2.0 tightens several `LanguageServer`/`LanguageClient` return types to be nullable, matching the LSP spec's optional results (`textDocument/hover`, `textDocument/formatting`, `textDocument/references`, `textDocument/rename`, `workspace/workspaceFolders`). The client now treats a null result as "no result" (no-op / empty), preserving prior behaviour.

--- a/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/SelectNextOccurrenceTest.kt
+++ b/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/SelectNextOccurrenceTest.kt
@@ -153,6 +153,24 @@ class SelectNextOccurrenceTest {
     }
 
     @Test
+    fun matchesSubwordWhenASubwordIsSelected() {
+        // Ported from upstream `@codemirror/search` `test-selection-match.ts`
+        // ("matches subwords if a subword is selected"). Selecting "one" inside
+        // the word "onetwo" also selects the "one" inside "onethree".
+        //
+        // kodemirror's selectNextOccurrence does a plain substring search (no
+        // whole-word boundary restriction), so a subword selection naturally
+        // matches occurrences embedded in other words. "onetwo onethree":
+        // o0 n1 e2 t3 w4 o5 ' '6 o7 n8 e9 t10 h11 r12 e13 e14.
+        val view = createViewWithSelection("onetwo onethree", 0, 3)
+        assertTrue(selectNextOccurrence(view))
+        val ranges = view.state.selection.ranges
+        assertEquals(2, ranges.size)
+        assertEquals(DocPos(7), ranges[1].from)
+        assertEquals(DocPos(10), ranges[1].to)
+    }
+
+    @Test
     fun multipleInvocationsAddAll() {
         val doc = "aa bb aa cc aa"
         val view = createView(doc, cursor = 0)


### PR DESCRIPTION
The one `:search`-area item the audit (#118) folded in rather than giving its own ticket.

Adds `matchesSubwordWhenASubwordIsSelected` to `SelectNextOccurrenceTest`: selecting `one` inside the word `onetwo` and invoking `selectNextOccurrence` also selects the `one` inside `onethree`. kodemirror's `selectNextOccurrence` does a plain substring search (no whole-word boundary restriction), so a subword selection naturally matches occurrences embedded in other words — this pins that behaviour (upstream `@codemirror/search` `test-selection-match.ts` "matches subwords if a subword is selected").

(`selectNextOccurrence` lives in `:commands`, not `:search` — the audit's module note was slightly off; the test joins the existing `SelectNextOccurrenceTest` there.)

Test-only; no production change, no version bump (stays 0.3.3). `:commands:jvmTest` + spotless green.