### PR TITLE
Add indentSelection command (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Minimal Android sample app (`samples/android`) that embeds and builds a `KodeMirror` editor with `basicSetup` plus a Markdown language extension, unblocking the "running on Android" prerequisite (#29).
+- `indentSelection` command (`:commands`): re-indents every line touched by the selection to the indentation computed by the language indent service / tree strategy (`getIndentation`), mirroring upstream `@codemirror/commands`. Skips lines where `getIndentation` returns null, applies all line changes in one transaction, and moves the cursor ahead of the indentation when it sat within the old indent. Bound in `defaultKeymap` to `Ctrl-Alt-\` (`Meta-Alt-\` on macOS) (#135).
 - `CompletionConfig.asyncOverride`: suspend completion sources that the autocomplete framework launches on the editor's coroutine scope and dispatches when they resolve. This is the wasmJs-safe way to drive an async source (e.g. a language server) — the previous `asyncCompletionSource` blocking bridge throws on wasmJs (#109).
 
 ### Fixed

--- a/commands/api/android/commands.api
+++ b/commands/api/android/commands.api
@@ -126,6 +126,7 @@ public final class com/monkopedia/kodemirror/commands/HistoryKt {
 public final class com/monkopedia/kodemirror/commands/IndentCommandsKt {
 	public static final fun getIndentLess ()Lkotlin/jvm/functions/Function1;
 	public static final fun getIndentMore ()Lkotlin/jvm/functions/Function1;
+	public static final fun getIndentSelection ()Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/monkopedia/kodemirror/commands/KeymapsKt {

--- a/commands/api/jvm/commands.api
+++ b/commands/api/jvm/commands.api
@@ -126,6 +126,7 @@ public final class com/monkopedia/kodemirror/commands/HistoryKt {
 public final class com/monkopedia/kodemirror/commands/IndentCommandsKt {
 	public static final fun getIndentLess ()Lkotlin/jvm/functions/Function1;
 	public static final fun getIndentMore ()Lkotlin/jvm/functions/Function1;
+	public static final fun getIndentSelection ()Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/monkopedia/kodemirror/commands/KeymapsKt {

--- a/commands/src/commonMain/kotlin/com/monkopedia/kodemirror/commands/IndentCommands.kt
+++ b/commands/src/commonMain/kotlin/com/monkopedia/kodemirror/commands/IndentCommands.kt
@@ -19,12 +19,17 @@
 package com.monkopedia.kodemirror.commands
 
 import com.monkopedia.kodemirror.language.getIndentUnit
+import com.monkopedia.kodemirror.language.getIndentation
 import com.monkopedia.kodemirror.language.indentString
+import com.monkopedia.kodemirror.state.ChangeByRangeResult
 import com.monkopedia.kodemirror.state.ChangeSpec
 import com.monkopedia.kodemirror.state.DocPos
 import com.monkopedia.kodemirror.state.EditorSelection
+import com.monkopedia.kodemirror.state.EditorState
 import com.monkopedia.kodemirror.state.InsertContent
+import com.monkopedia.kodemirror.state.Line
 import com.monkopedia.kodemirror.state.LineNumber
+import com.monkopedia.kodemirror.state.SelectionRange
 import com.monkopedia.kodemirror.state.SelectionSpec
 import com.monkopedia.kodemirror.state.Transaction
 import com.monkopedia.kodemirror.state.TransactionSpec
@@ -43,6 +48,80 @@ val indentMore: (EditorSession) -> Boolean = { view ->
  */
 val indentLess: (EditorSession) -> Boolean = { view ->
     changeIndent(view, add = false)
+}
+
+/**
+ * Auto-indent the lines touched by the selection, replacing each line's
+ * existing leading whitespace with the indentation computed by the
+ * language's [getIndentation] (indent service / tree strategy).
+ *
+ * Lines for which `getIndentation` returns `null` (no opinion) are left
+ * untouched. When the cursor sits within a line's old indentation, it is
+ * moved to the end of the new indentation, matching upstream
+ * `@codemirror/commands` `indentSelection`.
+ *
+ * Note: unlike upstream, kodemirror's [getIndentation] does not yet support
+ * the `overrideIndentation` option, so tree-based strategies see the
+ * pre-change indentation of earlier lines when re-indenting a block. The
+ * end result is applied in a single transaction with the selection remapped.
+ */
+val indentSelection: (EditorSession) -> Boolean = { view ->
+    val state = view.state
+    if (state.readOnly) {
+        false
+    } else {
+        var atLine = -1
+        val spec = state.changeByRange { range ->
+            val changes = mutableListOf<ChangeSpec>()
+            var pos = range.from
+            while (pos <= range.to) {
+                val line = state.doc.lineAt(pos)
+                if (
+                    line.number.value > atLine &&
+                    (range.empty || range.to > line.from)
+                ) {
+                    indentLine(state, line, range, changes)
+                    atLine = line.number.value
+                }
+                pos = line.to + 1
+            }
+            val changeSet = state.changes(ChangeSpec.Multi(changes))
+            ChangeByRangeResult(
+                range = EditorSelection.range(
+                    changeSet.mapPos(range.anchor, 1),
+                    changeSet.mapPos(range.head, 1)
+                ),
+                changes = ChangeSpec.Multi(changes)
+            )
+        }
+        view.dispatch(spec.copy(userEvent = "indent"))
+        true
+    }
+}
+
+/**
+ * Compute and append the re-indentation change for [line], mirroring the
+ * per-line body of upstream's `indentSelection`.
+ */
+private fun indentLine(
+    state: EditorState,
+    line: Line,
+    range: SelectionRange,
+    changes: MutableList<ChangeSpec>
+) {
+    var indent = getIndentation(state, line.from) ?: return
+    if (line.text.none { !it.isWhitespace() }) indent = 0
+    val cur = line.text.takeWhile { it == ' ' || it == '\t' }
+    val norm = indentString(state, indent)
+    if (cur != norm || range.from < line.from + cur.length) {
+        changes.add(
+            ChangeSpec.Single(
+                line.from,
+                line.from + cur.length,
+                InsertContent.StringContent(norm)
+            )
+        )
+    }
 }
 
 private fun changeIndent(view: EditorSession, add: Boolean): Boolean {

--- a/commands/src/commonMain/kotlin/com/monkopedia/kodemirror/commands/Keymaps.kt
+++ b/commands/src/commonMain/kotlin/com/monkopedia/kodemirror/commands/Keymaps.kt
@@ -108,6 +108,7 @@ val defaultKeymap: List<KeyBinding> = standardKeymap + commentKeymap + listOf(
     // Indent
     KeyBinding(key = "Ctrl-]", run = indentMore),
     KeyBinding(key = "Ctrl-[", run = indentLess),
+    KeyBinding(key = "Ctrl-Alt-\\", mac = "Meta-Alt-\\", run = indentSelection),
 
     // Delete line
     KeyBinding(key = "Ctrl-Shift-k", run = deleteLine),

--- a/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/IndentSelectionTest.kt
+++ b/commands/src/jvmTest/kotlin/com/monkopedia/kodemirror/commands/IndentSelectionTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.commands
+
+import com.monkopedia.kodemirror.language.IndentContext
+import com.monkopedia.kodemirror.language.indentService
+import com.monkopedia.kodemirror.state.DocPos
+import com.monkopedia.kodemirror.state.EditorSelection
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.ExtensionList
+import com.monkopedia.kodemirror.state.SelectionSpec
+import com.monkopedia.kodemirror.state.asDoc
+import com.monkopedia.kodemirror.state.asSpec
+import com.monkopedia.kodemirror.view.EditorSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Ports upstream `@codemirror/commands` `indentSelection` tests, adapted to a
+ * fixed indent service instead of a real language module (the same pattern as
+ * [IndentServiceNewlineTest], see #135). Upstream drives these with
+ * `javascriptLanguage` (2-space indentation); here a minimal [indentService]
+ * supplies the desired column count, so the test needs no language module.
+ */
+class IndentSelectionTest {
+
+    /**
+     * Build a session whose indent service answers with the given column
+     * count for any position (or null to express "no opinion"). [selection]
+     * defaults to a single cursor at [cursor].
+     */
+    private fun viewWithIndent(
+        doc: String,
+        selection: SelectionSpec,
+        indent: (IndentContext, DocPos) -> Int?
+    ): EditorSession {
+        val state = EditorState.create(
+            EditorStateConfig(
+                doc = doc.asDoc(),
+                selection = selection,
+                extensions = ExtensionList(
+                    listOf(indentService.of(indent))
+                )
+            )
+        )
+        return EditorSession(state)
+    }
+
+    private fun cursor(at: Int) = SelectionSpec.CursorSpec(DocPos(at))
+
+    @Test
+    fun autoIndentsCurrentLine() {
+        // "if (0)\nfoo()" with the cursor at the end. The service asks for 2
+        // columns; "foo()" gains a 2-space indent. (Upstream: same shape.)
+        val doc = "if (0)\nfoo()"
+        val v = viewWithIndent(doc, cursor(doc.length)) { _, _ -> 2 }
+        indentSelection(v)
+        assertEquals("if (0)\n  foo()", v.state.doc.toString())
+        // Cursor stays at the (now shifted) end of "foo()".
+        assertEquals("if (0)\n  foo()".length, v.state.selection.main.head.value)
+    }
+
+    @Test
+    fun movesCursorAheadOfIndentation() {
+        // "if (0)\n foo()" with the cursor inside the old single-space indent.
+        // Re-indenting to 2 spaces moves the cursor to just after the indent.
+        val doc = "if (0)\n foo()"
+        // Cursor between the leading space and "foo" → offset 8.
+        val v = viewWithIndent(doc, cursor(8)) { _, _ -> 2 }
+        indentSelection(v)
+        assertEquals("if (0)\n  foo()", v.state.doc.toString())
+        // After "if (0)\n" (7) + "  " (2) → cursor at offset 9, before "foo".
+        assertEquals(9, v.state.selection.main.head.value)
+    }
+
+    @Test
+    fun indentsBlocksOfLines() {
+        // Three lines selected; each is re-indented to the service's 2 columns.
+        val doc = "if (0) {\none\ntwo\nthree\n}"
+        // Select from start of "one" to end of "three".
+        val from = "if (0) {\n".length
+        val to = "if (0) {\none\ntwo\nthree".length
+        val v = viewWithIndent(
+            doc,
+            EditorSelection.single(DocPos(from), DocPos(to)).asSpec()
+        ) { _, _ -> 2 }
+        indentSelection(v)
+        assertEquals("if (0) {\n  one\n  two\n  three\n}", v.state.doc.toString())
+    }
+
+    @Test
+    fun relativeIndentationAndNullOpinion() {
+        // Relative case: the service answers with the line's number * 2 columns
+        // so successive selected lines get increasing indentation, except line
+        // 3 for which it returns null (no opinion) and is therefore untouched.
+        // (Upstream feeds prior changes back via overrideIndentation; kodemirror
+        // skips null-opinion lines, so we additionally assert the skip here.)
+        val doc = "a\nb\nc\nd"
+        val v = viewWithIndent(
+            doc,
+            EditorSelection.single(DocPos(0), DocPos(doc.length)).asSpec()
+        ) { ctx, pos ->
+            val number = ctx.state.doc.lineAt(pos).number.value
+            if (number == 3) null else (number - 1) * 2
+        }
+        indentSelection(v)
+        // line 1 → 0, line 2 → 2, line 3 → null (unchanged), line 4 → 6.
+        assertEquals("a\n  b\nc\n      d", v.state.doc.toString())
+    }
+}


### PR DESCRIPTION
Adds the upstream `@codemirror/commands` `indentSelection` command, which kodemirror was missing (it only had manual `indentMore`/`indentLess`). Surfaced by the #116 test port.

## What

- Export `val indentSelection: (EditorSession) -> Boolean` in `:commands` (IndentCommands.kt).
- For every line touched by any selection range, compute the desired indentation via `getIndentation(state, line.from)` and replace the line's existing leading whitespace with `indentString(state, cols)`. Lines where `getIndentation` returns null (no opinion) are skipped.
- All line changes are applied in a single transaction, remapping the selection; the cursor is moved to after the indentation when it sat within the old indent (matches upstream).
- Mirrors upstream's `changeBySelectedLine` line-iteration via kodemirror's `changeByRange`.
- Bound in `defaultKeymap` to `Ctrl-Alt-\` (`Meta-Alt-\` on macOS), matching upstream's `Mod-Alt-\`.

## Tests

New `IndentSelectionTest.kt` (`commands/src/jvmTest`) registers a minimal in-test `indentService` (the `IndentServiceNewlineTest` pattern) and ports upstream's 4 cases adapted to a fixed/relative service: auto-indent current line, move cursor ahead of indentation, indent a block of lines, and relative/null-opinion indentation.

## Notes

- kodemirror's `getIndentation` does not yet support upstream's `overrideIndentation` option, so tree-based strategies see earlier lines' pre-change indentation when re-indenting a block (documented in the KDoc). With the indent service / fixed strategies the tests exercise, the result is identical.
- New public symbol `indentSelection` is intended; ran `apiDump` and included the updated `commands/api/{jvm,android}/commands.api`.

Verified locally: `:commands:jvmTest`, `:commands:apiCheck`, `:commands:spotlessApply` all green.

Fixes #135