### PR TITLE
Open next dev snapshot: version 0.3.4-SNAPSHOT

### DIFF
--- a/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.3"
+version = "0.3.4-SNAPSHOT"
 
 android {
     namespace = "com.monkopedia.kodemirror.${project.name.replace("-", ".")}"

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.3"
+version = "0.3.4-SNAPSHOT"
 
 dependencies {
     constraints {


### PR DESCRIPTION
Bumps the committed version from `0.3.3` (the released version) to `0.3.4-SNAPSHOT` in both `convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts` and `kodemirror-bom/build.gradle.kts`.

## Why
0.3.3 was released to Maven Central, but the standard post-release step of opening the next development snapshot was skipped. main has since accumulated ~17 merged PRs while pinned at a *release* version. Because the skip-signing guard keys off the `-SNAPSHOT` suffix, a plain local `publishToMavenLocal` at version `0.3.3` tries to GPG-sign and fails with "no default secret key" — which broke the downstream konstructor consumer's local publish (reported on the bus). Bumping to `0.3.4-SNAPSHOT` restores skip-signing for local dev publishes and makes the version reflect the unreleased work.

## Scope / safety
- Pure version-string change; no code, no behavior change.
- **Not a release.** `-SNAPSHOT` is never published to Maven Central; this just sets the dev version. The actual 0.3.4 release (drop `-SNAPSHOT`, finalize CHANGELOG, tag, deploy) remains a separate maintainer-driven step per the release process in CLAUDE.md.
- Approved by the maintainer (Jason) and requested by the konstructor consumer.

No CHANGELOG change (the `[Unreleased]` section stays open until the actual release).