### PR TITLE
Bump version to 0.3.4 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-07-09
+
 ### Added
 - Minimal Android sample app (`samples/android`) that embeds and builds a `KodeMirror` editor with `basicSetup` plus a Markdown language extension, unblocking the "running on Android" prerequisite (#29).
 - `indentSelection` command (`:commands`): re-indents every line touched by the selection to the indentation computed by the language indent service / tree strategy (`getIndentation`), mirroring upstream `@codemirror/commands`. Skips lines where `getIndentation` returns null, applies all line changes in one transaction, and moves the cursor ahead of the indentation when it sat within the old indent. Bound in `defaultKeymap` to `Ctrl-Alt-\` (`Meta-Alt-\` on macOS) (#135).

--- a/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.4-SNAPSHOT"
+version = "0.3.4"
 
 android {
     namespace = "com.monkopedia.kodemirror.${project.name.replace("-", ".")}"

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.4-SNAPSHOT"
+version = "0.3.4"
 
 dependencies {
     constraints {


### PR DESCRIPTION
## 0.3.4 release prep

Version-bump PR per the release process: drops the `-SNAPSHOT` suffix in the library convention plugin and the BOM, and finalizes `CHANGELOG.md` (`## [Unreleased]` → `## [0.3.4] - 2026-07-09`, with a fresh empty `[Unreleased]`).

### What's in 0.3.4 (since v0.3.3, 2026-06-04)
- **Hit-testing:** clicks land on the glyph after scrolling (#165), and no longer ~¼-line low (#169) — routed through the live layout + `contentTopPadding` accounting.
- **Scroll:** session-swap no longer wedges scrolling (#166); vim `gg`/`G`/offscreen motions reliably reveal the cursor (#158); resilient scroll-into-view collector (#155).
- **Completion:** LSP completion works on wasmJs (#109/#113), multi-cursor apply (#136), merge/dedup across sources (#137), lazy `completionItem/resolve` auto-imports (#112), prefix filtering (#114), `sortText` ordering (#138), explicit-session lifecycle (#139), restored bold prefix highlight (#111), and several stale-popup/crash fixes.
- **Language/indent:** completed `IndentContext` CodeMirror-6 parity — real `textAfterPos` + functional simulated-break `bias` (#161); `indentSelection` command (#135); multi-range `moveLineUp/Down` (#130).
- **Correctness/cleanup:** out-of-range `coordsAtPos` returns null (#127); `getCursorRect` clamp (#152); hover tooltip viewport clamp (#110); dead-code/import house-style cleanups (#162/#163/#164); Roborazzi screenshot CI gate (#89); minimal Android sample (#29).

Full details in `CHANGELOG.md`.