### PR TITLE
Migrate to Compose-Multiplatform 1.11.1, drop Apple-Intel targets (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Bumped Compose-Multiplatform 1.10.3 → 1.11.1 (Skia M138 → M144) and migrated `Key.Home` → `Key.MoveHome` (1.11 removed the `Key.Home` alias).
+
+### Removed
+- **Dropped the `iosX64` and `macosX64` (Apple-Intel) publication targets.** Compose-Multiplatform 1.11.x no longer publishes those two targets (`runtime-macosx64:1.11.x` is absent from Maven Central), so the library follows suit. Apple Silicon (`macosArm64`, `iosArm64`, `iosSimulatorArm64`), JVM, wasmJs, and Android are unaffected. This is a breaking change only for consumers building for Apple-Intel (#182).
+
 ## [0.3.5] - 2026-07-15
 
 ### Changed

--- a/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.5"
+version = "0.3.6-SNAPSHOT"
 
 android {
     namespace = "com.monkopedia.kodemirror.${project.name.replace("-", ".")}"
@@ -58,10 +58,8 @@ kotlin {
 
     // Native targets — compile but largely untested.
     macosArm64()
-    macosX64()
     iosArm64()
     iosSimulatorArm64()
-    iosX64()
 
     applyDefaultHierarchyTemplate()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 kotlin = "2.4.10"
-compose-plugin = "1.10.3"
+compose-plugin = "1.11.1"
 atomicfu = "0.33.0"
 kotlinx-serialization = "1.11.0"
 kotlinx-coroutines = "1.11.0"

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.monkopedia.kodemirror"
-version = "0.3.5"
+version = "0.3.6-SNAPSHOT"
 
 dependencies {
     constraints {

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/InputHandling.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/InputHandling.kt
@@ -75,7 +75,7 @@ private fun keyName(key: Key): String = when (key) {
     Key.DirectionRight -> "ArrowRight"
     Key.DirectionUp -> "ArrowUp"
     Key.DirectionDown -> "ArrowDown"
-    Key.Home -> "Home"
+    Key.MoveHome -> "Home"
     Key.MoveEnd -> "End"
     Key.PageUp -> "PageUp"
     Key.PageDown -> "PageDown"
@@ -137,7 +137,7 @@ private fun keyName(key: Key): String = when (key) {
 private fun isSpecialKey(key: Key): Boolean = when (key) {
     Key.Enter, Key.Escape, Key.Tab, Key.Spacebar, Key.Backspace, Key.Delete,
     Key.DirectionLeft, Key.DirectionRight, Key.DirectionUp, Key.DirectionDown,
-    Key.Home, Key.MoveEnd, Key.PageUp, Key.PageDown,
+    Key.MoveHome, Key.MoveEnd, Key.PageUp, Key.PageDown,
     Key.F1, Key.F2, Key.F3, Key.F4, Key.F5, Key.F6,
     Key.F7, Key.F8, Key.F9, Key.F10, Key.F11, Key.F12,
     Key.ShiftLeft, Key.ShiftRight,

--- a/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/KeyboardHandlingTest.kt
+++ b/view/src/jvmTest/kotlin/com/monkopedia/kodemirror/view/input/KeyboardHandlingTest.kt
@@ -99,8 +99,8 @@ class KeyboardHandlingTest {
         waitForIdle()
 
         onNodeWithTag("KodeMirror_input").performKeyInput {
-            keyDown(Key.Home)
-            keyUp(Key.Home)
+            keyDown(Key.MoveHome)
+            keyUp(Key.MoveHome)
         }
         waitForIdle()
         holder.assertCursorAt(0)

--- a/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimExtension.kt
+++ b/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/VimExtension.kt
@@ -491,7 +491,7 @@ private fun composeKeyName(event: KeyEvent): String {
         Key.DirectionRight -> "ArrowRight"
         Key.DirectionUp -> "ArrowUp"
         Key.DirectionDown -> "ArrowDown"
-        Key.Home -> "Home"
+        Key.MoveHome -> "Home"
         Key.MoveEnd -> "End"
         Key.PageUp -> "PageUp"
         Key.PageDown -> "PageDown"


### PR DESCRIPTION
## Migrate to Compose-Multiplatform 1.11.1 — drops Apple-Intel targets (Fixes #182)

Jason approved dropping the Apple-Intel targets to match upstream.

**Why:** Compose-Multiplatform 1.11.x no longer publishes the `iosX64`/`macosX64` targets — `org.jetbrains.compose:runtime-macosx64` is **404 across all 1.11.x** on Maven Central (1.11.0, 1.11.1). The library declares both, so bumping compose forces dropping them. Apple Silicon (`macosArm64`/`iosArm64`/`iosSimulatorArm64`), JVM, wasmJs, and Android are unaffected (`runtime-macosarm64:1.11.1` = 200).

### Changes (7 files)
- `compose-plugin` 1.10.3 → **1.11.1** (Skia M138 → M144)
- **Removed `macosX64()` + `iosX64()`** from the convention plugin
- `Key.Home` → `Key.MoveHome` (1.11 removed the `Key.Home` alias) — 3 code files; mirrors the existing `Key.MoveEnd` mapping, logical key-name strings unchanged
- Open next dev cycle: version → **0.3.6-SNAPSHOT** (main had been sitting on the released `0.3.5`)
- CHANGELOG under `[Unreleased]` (Changed + **Removed** with the breaking-change note)

### Breaking change
Dropping the two published Apple-Intel artifacts is breaking **only** for consumers building for `iosX64`/`macosX64`. konstructor (wasm) and all other targets are unaffected. Pre-1.0, owner-approved.

### Verification (local, mirrors CI `check`)
- `apiCheck` ran, **zero `.api` changes** → ABI stable (klib validation is disabled; jvm API unchanged; dropping native targets doesn't touch it)
- `jvmTest`, `:view:verifyRoborazziJvm` (**no baseline re-record needed** — the Skia M138→M144 jump stayed within pixel threshold), `testDebugUnitTest`, wasm compile — all green
- Apple-target compile (the Arm64 targets on 1.11.1) confirmed by CI `check-macos` / `check-ios`

Note: version is `0.3.6-SNAPSHOT` (dev). The eventual release version is a separate cut decision — given the target drop, 0.4.0 is defensible, but pre-1.0 0.3.6 is fine; not deciding here.
