### PR TITLE
Remove unused kotlinx-datetime dependency (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 - **Dropped the `iosX64` and `macosX64` (Apple-Intel) publication targets.** Compose-Multiplatform 1.11.x no longer publishes those two targets (`runtime-macosx64:1.11.x` is absent from Maven Central), so the library follows suit. Apple Silicon (`macosArm64`, `iosArm64`, `iosSimulatorArm64`), JVM, wasmJs, and Android are unaffected. This is a breaking change only for consumers building for Apple-Intel (#182).
+- Removed the unused `kotlinx-datetime` dependency from `:state`, `:lint`, and `:merge` (#180). Those modules use stdlib `kotlin.time.Clock` for timestamps and never imported `kotlinx.datetime`, so the dependency was dead weight; dropping it also removes the `samples/showcase` `kotlinx-datetime:0.6.2` wasm resolution force-pin that only existed to resolve the transitive artifact.
 
 ## [0.3.5] - 2026-07-15
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ compose-plugin = "1.11.1"
 atomicfu = "0.33.0"
 kotlinx-serialization = "1.11.0"
 kotlinx-coroutines = "1.11.0"
-kotlinx-datetime = "0.7.1"
 ktlint = "12.1.2"
 spotless = "8.8.0"
 roborazzi = "1.68.0"
@@ -20,7 +19,6 @@ androidx-activity = "1.13.0"
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 roborazzi-compose-desktop = { module = "io.github.takahirom.roborazzi:roborazzi-compose-desktop", version.ref = "roborazzi" }
 lsp = { module = "com.monkopedia.lsp:lsp", version.ref = "lsp" }
 lsp-ksrpc = { module = "com.monkopedia.lsp:lsp-ksrpc", version.ref = "lsp" }

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -6,8 +6,3 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
-
-format-util@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
-  integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==

--- a/lint/build.gradle.kts
+++ b/lint/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
             implementation(compose.foundation)
             implementation(compose.runtime)
             implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.datetime)
         }
         commonTest.dependencies {
             implementation(project(":state"))

--- a/merge/build.gradle.kts
+++ b/merge/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.foundation)
             implementation(compose.runtime)
-            implementation(libs.kotlinx.datetime)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/samples/showcase/build.gradle.kts
+++ b/samples/showcase/build.gradle.kts
@@ -77,13 +77,6 @@ kotlin {
     }
 }
 
-configurations.configureEach {
-    resolutionStrategy {
-        force("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
-        force("org.jetbrains.kotlinx:kotlinx-datetime-wasm-js:0.6.2")
-    }
-}
-
 tasks.configureEach {
     if (name.startsWith("wasmJsTest") || name == "wasmJsNodeTest") enabled = false
 }

--- a/state/build.gradle.kts
+++ b/state/build.gradle.kts
@@ -7,7 +7,6 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.kotlinx.serialization.json)
-            implementation(libs.kotlinx.datetime)
         }
     }
 }


### PR DESCRIPTION
## Remove unused kotlinx-datetime dependency (resolves #180)

#180 asked to bump kotlinx-datetime 0.7.1 → 0.8.0, flagging its pre-1.0 ABI/wasm-compat surface. Investigating turned up that **the dependency is dead**: `:state`, `:lint`, and `:merge` declare `implementation(libs.kotlinx.datetime)` but never import it — their `currentTimeMillis()` helpers use **stdlib `kotlin.time.Clock.System.now()`**. There are **zero `import kotlinx.datetime`** sites anywhere (main or test).

So instead of bumping a dependency nothing uses (and inheriting the 0.8.0 compat surface), this **removes** it:
- Drop `implementation(libs.kotlinx.datetime)` from `:state` / `:lint` / `:merge`
- Remove the version + library alias from `gradle/libs.versions.toml`
- Remove the `samples/showcase` `kotlinx-datetime:0.6.2` / `-wasm-js:0.6.2` resolution force-pin — it only existed to pin the transitive artifact for wasm, and there's no transitive artifact anymore

### Verification (local)
- `apiCheck` — **0 `.api` changes** (removing an `implementation` dep doesn't touch the API; ABI stable)
- `:lint:jvmTest` / `:merge:jvmTest` / `:state:jvmTest` — green **without** the dependency (proves it was unused)
- `:samples:showcase:compileKotlinWasmJs` — green **without** the force-pin (proves the wasm workaround is no longer needed)

Net: −1 dependency, −1 wasm build workaround, and #180's ABI/compat concern is moot. Fixes #180.
