### PR TITLE
Fix caret-teleport to line start on hit-test during content-change frame lag (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- A click could occasionally teleport the caret to the start of the line instead of landing under the pointer (#171). `posFromVisibleItems` clamped the resolved character offset to the `ColumnItem`'s `[from, to)` span, but that `columnItems` snapshot can lag the `TextLayoutResult` by a frame after a content change: `BasicText` recomposes and writes its new layout (via `onTextLayout`) before the snapshot catches up, so `item.to - item.from` is momentarily stale — e.g. `0` on a just-populated line — while the layout (and thus the resolved offset) is already correct. Clamping a correct offset to that stale span collapsed every hit in that window to `item.from`, i.e. the line start. The offset is now clamped to the layout's own text length — the domain the offset was resolved against — so a hit during the stale frame lands correctly; when the snapshot is fresh the two lengths agree and behaviour is unchanged.
+
 ### Changed
 - Bumped Compose-Multiplatform 1.10.3 → 1.11.1 (Skia M138 → M144) and migrated `Key.Home` → `Key.MoveHome` (1.11 removed the `Key.Home` alias).
 

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
@@ -1452,6 +1452,18 @@ private fun posFromVisibleItems(
         .coerceAtLeast(0f)
     val expandedOffset = layout.getOffsetForPosition(Offset(localX, localY))
     val charOffset = unmapTabOffset(expandedOffset, item.tabOffsetMap)
-    return item.from.value +
-        charOffset.coerceIn(0, item.to.value - item.from.value)
+    // Clamp to the LAYOUT's char length, not the ColumnItem's [from, to) span.
+    // `charOffset` was resolved against `layout`, so the layout's own text
+    // length is its natural domain. The `columnItems` snapshot can lag the
+    // TextLayoutResult by a frame after a content change: BasicText recomposes
+    // and writes its new layout (via onTextLayout) before this snapshot catches
+    // up, leaving item.to-item.from stale — e.g. 0 on a just-populated line
+    // while the layout already holds the full text. Clamping a correctly
+    // resolved offset to that stale span collapses every hit to item.from,
+    // teleporting the caret to the line start (#171). The layout, being the
+    // source `charOffset` came from, is the consistent bound. When the snapshot
+    // is fresh the two lengths agree, so this only changes behaviour in the
+    // stale window.
+    val layoutCharLen = unmapTabOffset(layout.layoutInput.text.length, item.tabOffsetMap)
+    return item.from.value + charOffset.coerceIn(0, layoutCharLen)
 }


### PR DESCRIPTION
## Summary

`posFromVisibleItems` clamped the resolved character offset to the `ColumnItem`'s `[from, to)` span:

```kotlin
return item.from.value + charOffset.coerceIn(0, item.to.value - item.from.value)
```

That `columnItems` snapshot can lag the `TextLayoutResult` by a frame after a content change: `BasicText` recomposes and writes its new layout (via `onTextLayout`) before this snapshot catches up, so `item.to - item.from` is momentarily stale — e.g. `0` on a just-populated line — while the layout (and thus the resolved `charOffset`) is already correct. Clamping a correct offset to that stale span collapsed **every** hit in that window to `item.from`, teleporting the caret to the line start.

The fix clamps to the layout's own text length instead — the domain `charOffset` was resolved against:

```kotlin
val layoutCharLen = unmapTabOffset(layout.layoutInput.text.length, item.tabOffsetMap)
return item.from.value + charOffset.coerceIn(0, layoutCharLen)
```

When the snapshot is fresh the two lengths agree, so this only changes behaviour in the stale frame.

## Root-cause evidence

Confirmed on real hardware (GNOME fractional-scale 1.5) via an extended `[KM-HITDEBUG]` capture carrying `itemLen`/`lineLen`/`mismatch`. Warm samples showed the hit-test math resolving perfectly (`gop` tracks `localX` exactly, correct nearest-boundary, wrap-aware on a 105-char line) yet the caret sitting at `0,0` — because the returned offset was coerced into `[0, item.to - item.from == 0]`. The `println` emitted the pre-coerce value, which is why the log "looked right" while the caret jumped.

## Scope

- Addresses the **flaky caret-teleport-to-0,0** axis of #171 (the more egregious symptom). Does **not** close #171: a separate, constant ~½-char horizontal drift between the painted glyph and the caret persists on real wasm/CanvasKit and needs a screenshot glyph-ink-vs-caret measurement (the click log can't capture it, since hit-test and caret-draw math agree with each other). That axis stays open.

## Testing

- `:view:jvmTest` `ClickTargetingTest`, `HitTestVerticalAnchorTest`, `DragSelectionTest` green (they exercise the fresh path — the idle-synced Compose harness settles recomposition before each click, so it can't reproduce the single-frame stale race itself; they guard against regression of normal clicks).
- Real-hardware re-verification is the validation path for the race: konstructor will redeploy this build to the debug host and re-run the `[KM-HITDEBUG]` capture.
- spotlessApply + ktlintFormat clean; no API change.

Part of #171.