### PR TITLE
Remove redundant LinePos.copy() extension that shadowed data-class copy (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Bumped Compose-Multiplatform 1.10.3 → 1.11.1 (Skia M138 → M144) and migrated `Key.Home` → `Key.MoveHome` (1.11 removed the `Key.Home` alias).
 
 ### Removed
+- Removed the redundant public `fun LinePos.copy(line, ch)` extension in `:vim` (#186). It shadowed the `LinePos` data class's generated `copy()` and silently dropped the `sticky` field — a latent data-loss footgun the moment `sticky` gets wired up (its CM5 sticky-column logic is not yet ported). The extension had zero call sites, so removing it is behaviour-preserving today and leaves the full-fidelity generated `copy()` as the only one.
 - **Dropped the `iosX64` and `macosX64` (Apple-Intel) publication targets.** Compose-Multiplatform 1.11.x no longer publishes those two targets (`runtime-macosx64:1.11.x` is absent from Maven Central), so the library follows suit. Apple Silicon (`macosArm64`, `iosArm64`, `iosSimulatorArm64`), JVM, wasmJs, and Android are unaffected. This is a breaking change only for consumers building for Apple-Intel (#182).
 - Removed the unused `kotlinx-datetime` dependency from `:state`, `:lint`, and `:merge` (#180). Those modules use stdlib `kotlin.time.Clock` for timestamps and never imported `kotlinx.datetime`, so the dependency was dead weight; dropping it also removes the `samples/showcase` `kotlinx-datetime:0.6.2` wasm resolution force-pin that only existed to resolve the transitive artifact.
 

--- a/vim/api/android/vim.api
+++ b/vim/api/android/vim.api
@@ -173,11 +173,6 @@ public final class com/monkopedia/kodemirror/vim/LinePos : java/lang/Comparable 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/monkopedia/kodemirror/vim/LinePosKt {
-	public static final fun copy (Lcom/monkopedia/kodemirror/vim/LinePos;II)Lcom/monkopedia/kodemirror/vim/LinePos;
-	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/vim/LinePos;IIILjava/lang/Object;)Lcom/monkopedia/kodemirror/vim/LinePos;
-}
-
 public final class com/monkopedia/kodemirror/vim/LinePosRange {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/kodemirror/vim/LinePos;Lcom/monkopedia/kodemirror/vim/LinePos;)V

--- a/vim/api/jvm/vim.api
+++ b/vim/api/jvm/vim.api
@@ -173,11 +173,6 @@ public final class com/monkopedia/kodemirror/vim/LinePos : java/lang/Comparable 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/monkopedia/kodemirror/vim/LinePosKt {
-	public static final fun copy (Lcom/monkopedia/kodemirror/vim/LinePos;II)Lcom/monkopedia/kodemirror/vim/LinePos;
-	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/vim/LinePos;IIILjava/lang/Object;)Lcom/monkopedia/kodemirror/vim/LinePos;
-}
-
 public final class com/monkopedia/kodemirror/vim/LinePosRange {
 	public static final field $stable I
 	public fun <init> (Lcom/monkopedia/kodemirror/vim/LinePos;Lcom/monkopedia/kodemirror/vim/LinePos;)V

--- a/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/LinePos.kt
+++ b/vim/src/commonMain/kotlin/com/monkopedia/kodemirror/vim/LinePos.kt
@@ -53,9 +53,6 @@ internal fun cursorMin(a: LinePos, b: LinePos): LinePos = if (cursorIsBefore(a, 
 /** Returns the later of two positions. */
 internal fun cursorMax(a: LinePos, b: LinePos): LinePos = if (cursorIsBefore(a, b)) b else a
 
-/** Copy a LinePos, optionally overriding line or ch. */
-fun LinePos.copy(line: Int = this.line, ch: Int = this.ch): LinePos = LinePos(line, ch)
-
 // ---------------------------------------------------------------------------
 // Position conversion helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`LinePos` is a data class with three fields:

```kotlin
// vim/.../LinePos.kt:31
data class LinePos(val line: Int, val ch: Int, val sticky: String? = null) : Comparable<LinePos>
```

…but a top-level extension shadowed the generated `copy()`:

```kotlin
// vim/.../LinePos.kt:57 (removed)
fun LinePos.copy(line: Int = this.line, ch: Int = this.ch): LinePos = LinePos(line, ch)
```

At any call site `pos.copy(ch = x)` resolved to this extension and built `LinePos(line, ch)` — **silently dropping `sticky`**. The two `copy()`s are indistinguishable at the call site but behave differently.

## Why it's safe (and why "silent data loss" is latent, not active, today)

- The extension has **zero call sites** repo-wide (`git grep '\.copy(ch' / '\.copy(line'` finds only the definition).
- `sticky` is currently vestigial: never written with a non-null value, and its CM5 sticky-column logic is explicitly **not yet ported** (`VimMotions.kt:507-508` — "We don't have sticky in the Kotlin LinePos, so we return as-is").

So removing the extension is behaviour-preserving for every current call site, and it eliminates the footgun before `sticky` gets wired up — at which point the shadow *would* have caused real data loss.

## Change
- Delete the `LinePos.copy` extension; the generated data-class `copy()` (which carries `sticky`) becomes the only `copy`.
- Regenerated the vim API dump (jvm + android): drops the synthetic `LinePosKt { copy, copy$default }`. The data-class `copy(II Ljava/lang/String)` is unchanged.

## Testing
- `:vim:jvmTest` green; `:vim:apiDump` regenerated; spotlessApply + ktlintFormat clean.

Fixes #186.

Provenance: surfaced during the Graphify tooling A/B evaluation (call-graph flagged the duplicate `copy`), verified by hand against `origin/main`.