### PR TITLE
Pin wasm npm tooling Node to 22.11.0 so showcase webpack build stops using Node 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Build
+- Pinned the wasm npm *tooling* Node.js to 22.11.0 so the showcase production webpack build (`wasmJsBrowserProductionWebpack`) stops failing on the Kotlin 2.4.10 default Node v25. The 0.3.5 `WasmNodeJsEnvSpec` pin only covers the target-node users (`:kotlinWasmNpmInstall` / yarn); the webpack tooling node is resolved from the legacy `WasmNodeJsRootExtension.version`, which the EnvSpec doesn't update, so webpack kept launching v25 (green `:check`, red `build-showcase`). The `WasmNodeJsRootExtension.version` setter is now also pinned (deprecation suppressed under `-Werror`).
+
 ### Fixed
 - A click could occasionally teleport the caret to the start of the line instead of landing under the pointer (#171). `posFromVisibleItems` clamped the resolved character offset to the `ColumnItem`'s `[from, to)` span, but that `columnItems` snapshot can lag the `TextLayoutResult` by a frame after a content change: `BasicText` recomposes and writes its new layout (via `onTextLayout`) before the snapshot catches up, so `item.to - item.from` is momentarily stale — e.g. `0` on a just-populated line — while the layout (and thus the resolved offset) is already correct. Clamping a correct offset to that stale span collapsed every hit in that window to `item.from`, i.e. the line start. The offset is now clamped to the layout's own text length — the domain the offset was resolved against — so a hit during the stale frame lands correctly; when the snapshot is fresh the two lengths agree and behaviour is unchanged.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,15 +20,31 @@ dependencies {
     }
 }
 
-// Kotlin 2.4.10 defaults the managed Node.js to v25, which breaks
-// :kotlinWasmNpmInstall / :kotlinNpmInstall. Pin the JS and wasm Node
-// toolchains to a known-good LTS. Must use the EnvSpec API + version.set()
-// — the deprecated NodeJsRootExtension.version= setter fails under -Werror.
+// Kotlin 2.4.10 defaults the managed Node.js to v25, which fails to start on
+// the CI runners. Pin the JS and wasm Node toolchains to a known-good LTS.
+//
+// This needs BOTH APIs. The modern EnvSpec.version drives the target-node users
+// (`:kotlinWasmNpmInstall` / yarn), but the wasm *npm tooling* node — the one
+// `wasmJsBrowser*Webpack` launches to run webpack — is resolved from the legacy
+// `WasmNodeJsRootExtension.version` instead, which the EnvSpec does not update.
+// Setting only the EnvSpec leaves webpack on the default v25, so the showcase
+// production build fails while `:check` (which never runs webpack) passes.
+// The RootExtension setter is a scheduled-for-removal deprecation and this build
+// compiles with -Werror, hence the suppression; drop it once the tooling node
+// honours the EnvSpec.
 plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin> {
     the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsEnvSpec>().version.set("22.11.0")
 }
 plugins.withType<org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsPlugin> {
     the<org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsEnvSpec>().version.set("22.11.0")
+}
+plugins.withType<org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootPlugin> {
+    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
+    fun pinWasmToolingNode() {
+        the<org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootExtension>().version =
+            "22.11.0"
+    }
+    pinWasmToolingNode()
 }
 
 // Add Dokka aggregation only for subprojects that apply the Dokka plugin


### PR DESCRIPTION
## Problem

Main has been red on the `Docs` / `build-showcase` CI job: `:samples:showcase:wasmJsBrowserProductionWebpack` fails with

```
> A problem occurred starting process 'command '/home/runner/.gradle/nodejs/node-v25.0.0-linux-x64/bin/node''
```

The required `check` job stays green because it never runs webpack, so this slipped in (build-showcase is not a required check). Pre-existing — failed on `5203bf66` before #185/#186 too.

## Root cause

The 0.3.5 Node pin sets `WasmNodeJsEnvSpec.version` (+ the JS `NodeJsEnvSpec`) to `22.11.0`. That correctly pins the **target-node** users — `:kotlinWasmNpmInstall` / yarn run on `node-v22.11.0`. But the wasm **npm tooling** node — the one `wasmJsBrowser*Webpack` launches to run `webpack.js` — is resolved from the *legacy* `WasmNodeJsRootExtension.version`, which the EnvSpec does **not** update. So webpack kept launching the Kotlin 2.4.10 default `node-v25.0.0`.

Confirmed by reproducing locally with `--info` (same run, two different nodes):
- yarn: `.../nodejs/node-v22.11.0-linux-x64/bin/node ... yarn.js` ✓ (EnvSpec pin)
- webpack: `.../nodejs/node-v25.0.0-linux-x64/bin/node ... webpack.js` ✗ (RootExtension default)

## Fix

Also pin `WasmNodeJsRootExtension.version` to `22.11.0` inside `withType<WasmNodeJsRootPlugin>`. The setter is a scheduled-for-removal deprecation and the build compiles with `-Werror`, so it's wrapped in a `@Suppress("DEPRECATION", "DEPRECATION_ERROR")` local function (documented; drop once the tooling node honours the EnvSpec).

## Verification

Locally, `:samples:showcase:wasmJsBrowserProductionWebpack` now launches `node-v22.11.0` and is **BUILD SUCCESSFUL** (was node-25 → start-process failure). The `build-showcase` job on this PR is the remote proof.

## Scope
Build config only (`build.gradle.kts`) + CHANGELOG. No source/API change.