### PR TITLE
Ignore __pycache__ written by the changelog test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ package-lock.json
 playwright-report/
 test-results/
 gap-analysis/screenshots/
+
+# `.github/scripts/test-changelog.py` imports `changelog.py`, so running it writes bytecode here.
+__pycache__/


### PR DESCRIPTION
Follow-up to #295, which merged before this one-line commit reached the PR (the branch was pushed at 03:43:26 and #295 had merged at 03:43:06).

`.github/scripts/test-changelog.py` **imports** `changelog.py` rather than shelling out to it — unlike `test-report-android-test-count.py`, which invokes its subject as a subprocess and so never generates bytecode. So running the changelog test leaves `.github/scripts/__pycache__/` untracked in the working tree, where a `git add -A` can pick it up. `.gitignore` had no `__pycache__` rule because nothing in the repo had ever written one.

Control: after running the test on this branch, `.github/scripts/__pycache__` exists on disk and `git status --short` lists only `.gitignore` — so the rule is matching rather than the directory merely being absent.

Part of #281.