### PR TITLE
changelog.d hardening: guard CHANGELOG.md in check, refuse a duplicate released heading in assemble

### DIFF
--- a/.github/scripts/changelog.py
+++ b/.github/scripts/changelog.py
@@ -8,11 +8,12 @@ version-bump PR described in `CLAUDE.md` -> "Release process".
 
 Commands
 --------
-  check      Validate every fragment's name and body. Run in CI.
+  check      Validate every fragment's name and body, and assert that
+             CHANGELOG.md itself was not hand-edited. Run in CI.
   preview    Print the section assembly would produce; writes nothing.
   assemble   Insert that section into CHANGELOG.md and delete the fragments.
 
-Deliberate properties, each earned from a real failure recorded on #281:
+Deliberate properties, each earned from a real failure recorded on #281/#297:
 
 * **No parsing of entry text.** A fragment body is copied verbatim. An entry is
   not reliably "one bullet carrying one `(#N)`" -- a previous auto-resolver
@@ -29,6 +30,21 @@ Deliberate properties, each earned from a real failure recorded on #281:
   new section back out and requires the remainder to reproduce the previous file
   byte for byte, with positive controls on both sides so that an empty-vs-empty
   comparison cannot pass as success.
+* **A version is released once.** `assemble` refuses a version whose `## [X.Y.Z]`
+  heading is already in the file. The `-SNAPSHOT` guard was the only defence and
+  it is inert in this repo's steady state: the post-release SNAPSHOT bump has
+  been performed after three of eight releases, so `main` normally sits on an
+  already-released version. `_verify_additive` does not cover it -- a *heading*
+  collision leaves the rendered section absent from the old file (#297).
+* **`check` also guards CHANGELOG.md, not just the fragments.** Validating only
+  the fragments that are present answers "are these well-formed?", never "did
+  this change do the right thing with the changelog". Since #295 removed
+  `## [Unreleased]`, an edit written against the old instructions no longer
+  conflicts -- git lands the hunk at the nearest surviving context, which is
+  *inside an already-published section*, and the merge is clean. So `check`
+  refuses a reintroduced `## [Unreleased]` heading outright, and, given
+  `--base-ref`, refuses any change to CHANGELOG.md that is not a release
+  assembly (#297).
 """
 
 from __future__ import annotations
@@ -36,6 +52,7 @@ from __future__ import annotations
 import argparse
 import datetime
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -68,6 +85,10 @@ VERSION_RE = re.compile(r'(?m)^\s*version\s*=\s*"([^"]+)"')
 
 # First released section in CHANGELOG.md; the new section is inserted above it.
 SECTION_START_RE = re.compile(r"(?m)^## \[")
+
+# The block #295 deleted. Its reappearance means someone is writing entries by
+# the pre-fragment instructions, and those entries will never be assembled.
+UNRELEASED_RE = re.compile(r"(?m)^## \[Unreleased\]")
 
 
 class Failure(Exception):
@@ -202,8 +223,15 @@ def _verify_additive(old: str, new: str, section: str, fragments) -> None:
             raise Failure(f"internal check: fragment {path.name} did not reach the section")
 
 
-def assemble(changelog: Path, section: str, fragments) -> str:
+def assemble(changelog: Path, version: str, section: str, fragments) -> str:
     old = changelog.read_text(encoding="utf-8")
+    if re.search(rf"(?m)^## \[{re.escape(version)}\]", old):
+        raise Failure(
+            f"CHANGELOG.md already has a [{version}] section. Bump the version in "
+            f"{VERSION_FILE} before assembling, or pass --version. (The -SNAPSHOT "
+            "guard does not catch this: the post-release SNAPSHOT bump is usually "
+            "skipped, so `main` normally sits on an already-released version.)"
+        )
     match = SECTION_START_RE.search(old)
     cut = match.start() if match else len(old)
     new = old[:cut] + section + "\n" + old[cut:]
@@ -211,11 +239,101 @@ def assemble(changelog: Path, section: str, fragments) -> str:
     return new
 
 
+def verify_no_unreleased_section(text: str) -> None:
+    """Refuse a `## [Unreleased]` heading in CHANGELOG.md.
+
+    Anchored to a heading rather than to the word, so prose that happens to say
+    "unreleased" is not an error -- a guard that fires on the good case too gets
+    weakened by the next person who trips over it.
+    """
+    if UNRELEASED_RE.search(text):
+        raise Failure(
+            "CHANGELOG.md has a `## [Unreleased]` heading. #295 removed it: entries "
+            "live as one file per change under changelog.d/ and are assembled at the "
+            "release cut. An entry written under that heading is never assembled."
+        )
+
+
+def _leading_section_insertion(old: str, new: str) -> str | None:
+    """Return the text `new` inserts above `old`'s first released section.
+
+    `None` unless `new` is exactly `old` with one new `## [` section spliced in
+    at the point `assemble` splices -- i.e. every other byte of the file, before
+    and after, is untouched.
+    """
+    match = SECTION_START_RE.search(old)
+    cut = match.start() if match else len(old)
+    tail = old[cut:]
+    if new[:cut] != old[:cut]:
+        return None
+    if tail and not new.endswith(tail):
+        return None
+    inserted = new[cut : len(new) - len(tail)]
+    if not inserted.startswith("## ["):
+        return None
+    if len(SECTION_START_RE.findall(inserted)) != 1:
+        return None
+    return inserted
+
+
+def verify_changelog_matches_base(root: Path, old: str, new: str) -> None:
+    """Assert this change either leaves CHANGELOG.md alone or assembles a release.
+
+    `check` otherwise never reads CHANGELOG.md, so a hunk landing inside a
+    published section passes CI with a green tick and a clean merge (#297).
+    """
+    if new == old:
+        return
+    inserted = _leading_section_insertion(old, new)
+    if inserted is None:
+        raise Failure(
+            "CHANGELOG.md was modified. Entries go in changelog.d/ as one file per "
+            "change; CHANGELOG.md is written only by `changelog.py assemble` at the "
+            "release cut, and published sections are history. Since #295 removed "
+            "`## [Unreleased]`, an edit written for the old layout merges cleanly "
+            "into an already-published section instead of conflicting."
+        )
+    version = derive_version(root)
+    if not inserted.startswith(f"## [{version}] "):
+        raise Failure(
+            f"CHANGELOG.md gained a section that is not this build's release: "
+            f"expected `## [{version}] - <date>`, got {inserted.splitlines()[0]!r}."
+        )
+
+
+def _git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise Failure(
+            f"`git {' '.join(args)}` failed: {result.stderr.strip() or 'no output'}"
+        )
+    return result.stdout
+
+
+def base_changelog(root: Path, base_ref: str) -> str:
+    """CHANGELOG.md as of the merge base with `base_ref`.
+
+    Fails loudly if the ref cannot be resolved: a lookup that degrades to an
+    empty string would make every comparison below read as "unchanged".
+    """
+    merge_base = _git(root, "merge-base", "HEAD", base_ref).strip()
+    if not merge_base:
+        raise Failure(f"cannot resolve a merge base with {base_ref}")
+    return _git(root, "show", f"{merge_base}:CHANGELOG.md")
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     parser.add_argument("command", choices=["check", "preview", "assemble"])
     parser.add_argument("--version", help="release version (default: read from the build)")
     parser.add_argument("--date", help="release date, YYYY-MM-DD (default: today)")
+    parser.add_argument(
+        "--base-ref",
+        help="check only: git ref this change is based on. CHANGELOG.md is compared "
+        "against it and must be either identical or a release assembly.",
+    )
     parser.add_argument(
         "--keep-fragments",
         action="store_true",
@@ -230,6 +348,16 @@ def main(argv: list[str]) -> int:
         print(f"changelog.d: {len(fragments)} fragment(s) valid")
         for issue, section, _body, path in fragments:
             print(f"  #{issue:<5} {section:<14} {path.name}")
+        current = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+        verify_no_unreleased_section(current)
+        # Printed either way, so a log reader can see whether the comparison
+        # actually happened -- a silently skipped guard is the failure mode this
+        # whole check exists to close.
+        if args.base_ref:
+            verify_changelog_matches_base(root, base_changelog(root, args.base_ref), current)
+            print(f"CHANGELOG.md: checked against {args.base_ref}")
+        else:
+            print("CHANGELOG.md: no --base-ref; compared against nothing")
         return 0
 
     version = args.version or derive_version(root)
@@ -243,7 +371,9 @@ def main(argv: list[str]) -> int:
         return 0
 
     changelog = root / "CHANGELOG.md"
-    changelog.write_text(assemble(changelog, section, fragments), encoding="utf-8")
+    changelog.write_text(
+        assemble(changelog, version, section, fragments), encoding="utf-8"
+    )
     print(f"CHANGELOG.md: added [{version}] - {date} from {len(fragments)} fragment(s)")
     if not args.keep_fragments:
         for _issue, _section, _body, path in fragments:

--- a/.github/scripts/test-changelog.py
+++ b/.github/scripts/test-changelog.py
@@ -9,6 +9,7 @@ with a **negative control** that must fail, because a guard that cannot be shown
 to fire is indistinguishable from no guard at all.
 """
 
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -98,7 +99,7 @@ class Assembly(unittest.TestCase):
         self.section = changelog.render_section("2.0.0", "2020-02-02", self.fragments)
 
     def test_inserts_above_the_newest_released_section(self):
-        result = changelog.assemble(self.changelog, self.section, self.fragments)
+        result = changelog.assemble(self.changelog, "2.0.0", self.section, self.fragments)
         self.assertTrue(result.startswith("# Changelog\n\n## [2.0.0] - 2020-02-02\n"))
         self.assertIn("## [1.0.0] - 2020-01-01", result)
         # Purely additive: strip the new section, get the original back exactly.
@@ -122,6 +123,184 @@ class Assembly(unittest.TestCase):
         # empty-vs-empty is the silent twin of empty-vs-value: it reads as a pass.
         with self.assertRaises(changelog.Failure):
             changelog._verify_additive("", "", "", [])
+
+
+class DuplicateReleasedHeading(unittest.TestCase):
+    """`assemble` must refuse a version that is already in CHANGELOG.md.
+
+    The `-SNAPSHOT` guard is the intended defence and is inert here: the
+    post-release SNAPSHOT bump is usually skipped, so `main` normally reads an
+    already-released version. `_verify_additive` does not cover it either -- on a
+    heading collision the rendered section is still absent from the old file.
+    """
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        self.changelog = self.dir / "CHANGELOG.md"
+        self.changelog.write_text(BASE, encoding="utf-8")
+        self.fragments = [(9, "fixed", "- Fix nine (#9).\n", self.dir / "9.fixed.md")]
+
+    def section(self, version):
+        return changelog.render_section(version, "2020-02-02", self.fragments)
+
+    def test_refuses_a_version_already_released(self):
+        with self.assertRaises(changelog.Failure):
+            changelog.assemble(self.changelog, "1.0.0", self.section("1.0.0"),
+                               self.fragments)
+
+    def test_refuses_it_even_when_the_date_differs(self):
+        # The measured failure: same version, new date, so the rendered section is
+        # not a substring of the old file and `_verify_additive` stays silent.
+        section = self.section("1.0.0").replace("2020-02-02", "2020-03-03")
+        self.assertNotIn(section, BASE)
+        with self.assertRaises(changelog.Failure):
+            changelog.assemble(self.changelog, "1.0.0", section, self.fragments)
+
+    def test_accepts_a_version_not_yet_released(self):
+        result = changelog.assemble(self.changelog, "2.0.0", self.section("2.0.0"),
+                                    self.fragments)
+        self.assertIn("## [2.0.0] - 2020-02-02", result)
+
+    def test_a_version_that_is_a_prefix_of_a_released_one_is_accepted(self):
+        # Over-strictness control: `1.0` must not match `## [1.0.0]`. A guard that
+        # reddens the good case reads as strictness and gets removed later.
+        result = changelog.assemble(self.changelog, "1.0", self.section("1.0"),
+                                    self.fragments)
+        self.assertIn("## [1.0] - 2020-02-02", result)
+
+
+class UnreleasedHeading(unittest.TestCase):
+    def test_accepts_a_changelog_of_released_sections(self):
+        changelog.verify_no_unreleased_section(BASE)
+
+    def test_rejects_a_reintroduced_unreleased_heading(self):
+        with self.assertRaises(changelog.Failure):
+            changelog.verify_no_unreleased_section(
+                "# Changelog\n\n## [Unreleased]\n\n### Fixed\n- An entry (#2).\n" + BASE
+            )
+
+    def test_does_not_fire_on_the_word_in_an_entry(self):
+        # Over-strictness control: the guard is about a heading, not a word.
+        changelog.verify_no_unreleased_section(
+            BASE + "- Documented the unreleased [Unreleased] convention (#3).\n"
+        )
+
+
+class ChangelogAgainstBase(unittest.TestCase):
+    """`check`'s CHANGELOG.md guard: a PR may not touch published history.
+
+    The live victim is a branch opened before #295: it still carries a
+    `## [Unreleased]` hunk, that heading no longer exists, and git lands the hunk
+    inside the newest *published* section. `mergeable: MERGEABLE` is accurate.
+    """
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        version_file = self.root / changelog.VERSION_FILE
+        version_file.parent.mkdir(parents=True)
+        version_file.write_text('version = "2.0.0"\n', encoding="utf-8")
+
+    def assembled(self, version="2.0.0"):
+        return BASE.replace(
+            "## [1.0.0]",
+            f"## [{version}] - 2020-02-02\n\n### Fixed\n- Fix nine (#9).\n\n## [1.0.0]",
+            1,
+        )
+
+    def test_an_untouched_changelog_passes(self):
+        changelog.verify_changelog_matches_base(self.root, BASE, BASE)
+
+    def test_a_release_assembly_passes(self):
+        # The good case that must stay green: the version-bump PR does edit this
+        # file, and its own CI has to pass.
+        changelog.verify_changelog_matches_base(self.root, BASE, self.assembled())
+
+    def test_an_edit_inside_a_published_section_fails(self):
+        landed = BASE.replace("- An old entry (#1).",
+                              "- An old entry (#1).\n- A bullet from a pre-#295 branch (#268).")
+        self.assertNotEqual(landed, BASE)
+        with self.assertRaises(changelog.Failure):
+            changelog.verify_changelog_matches_base(self.root, BASE, landed)
+
+    def test_a_reworded_published_line_fails(self):
+        with self.assertRaises(changelog.Failure):
+            changelog.verify_changelog_matches_base(
+                self.root, BASE, BASE.replace("An old entry", "An OLD entry"))
+
+    def test_an_appended_bullet_fails(self):
+        with self.assertRaises(changelog.Failure):
+            changelog.verify_changelog_matches_base(self.root, BASE, BASE + "- Extra (#4).\n")
+
+    def test_a_section_for_some_other_version_fails(self):
+        # A hand-written section is not an assembly of the version being built.
+        with self.assertRaises(changelog.Failure):
+            changelog.verify_changelog_matches_base(self.root, BASE, self.assembled("9.9.9"))
+
+    def test_an_assembly_that_also_edits_the_preamble_fails(self):
+        # A release PR is the one PR allowed to touch this file, so it is also the
+        # one place another edit could ride along. Same *length* as the original,
+        # so the inserted slice is still exactly the new section and only comparing
+        # the preamble byte for byte catches it.
+        edited = self.assembled().replace("# Changelog", "# CHANGELOG", 1)
+        self.assertEqual(len(edited), len(self.assembled()))
+        with self.assertRaises(changelog.Failure):
+            changelog.verify_changelog_matches_base(self.root, BASE, edited)
+
+    def test_an_assembly_that_also_rewords_a_published_line_fails(self):
+        # The same trick below the insertion point: only comparing the tail byte
+        # for byte catches it.
+        reworded = self.assembled().replace("An old entry", "An OLD entry", 1)
+        self.assertEqual(len(reworded), len(self.assembled()))
+        with self.assertRaises(changelog.Failure):
+            changelog.verify_changelog_matches_base(self.root, BASE, reworded)
+
+    def test_two_sections_at_once_fails(self):
+        doubled = self.assembled()
+        doubled = doubled.replace("## [1.0.0]", "## [1.5.0] - 2020-01-15\n\n## [1.0.0]", 1)
+        with self.assertRaises(changelog.Failure):
+            changelog.verify_changelog_matches_base(self.root, BASE, doubled)
+
+
+class BaseLookup(unittest.TestCase):
+    """`base_changelog` must read a real commit, and fail loudly if it cannot.
+
+    A lookup that degrades to an empty string would make every comparison above
+    read as "unchanged" -- the inert-guard shape this issue is about.
+    """
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.git("init", "-q")
+        (self.root / "CHANGELOG.md").write_text(BASE, encoding="utf-8")
+        self.git("add", "CHANGELOG.md")
+        self.git("-c", "user.email=t@t", "-c", "user.name=t",
+                 "-c", "commit.gpgsign=false", "commit", "-qm", "base")
+
+    def git(self, *args):
+        subprocess.run(["git", "-C", str(self.root), *args], check=True,
+                       capture_output=True, text=True)
+
+    def test_reads_the_committed_file_not_the_working_tree(self):
+        (self.root / "CHANGELOG.md").write_text(BASE + "- Local edit (#5).\n",
+                                                encoding="utf-8")
+        self.assertEqual(changelog.base_changelog(self.root, "HEAD"), BASE)
+
+    def test_a_file_absent_at_the_base_is_loud_not_empty(self):
+        # `git show` failing while `merge-base` succeeds: the one path where a
+        # swallowed git error would return "" and read as "the base was empty".
+        (self.root / "other").write_text("x", encoding="utf-8")
+        self.git("add", "other")
+        self.git("-c", "user.email=t@t", "-c", "user.name=t",
+                 "-c", "commit.gpgsign=false", "commit", "-qm", "second")
+        self.git("rm", "-q", "CHANGELOG.md")
+        self.git("-c", "user.email=t@t", "-c", "user.name=t",
+                 "-c", "commit.gpgsign=false", "commit", "-qm", "drop the changelog")
+        with self.assertRaises(changelog.Failure):
+            changelog.base_changelog(self.root, "HEAD")
+
+    def test_an_unresolvable_ref_is_loud_not_empty(self):
+        with self.assertRaises(changelog.Failure):
+            changelog.base_changelog(self.root, "no-such-ref")
 
 
 class VersionDerivation(unittest.TestCase):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # `--base-ref` below needs the base commit, which a depth-1 checkout does not have:
+          # on a pull_request the checked-out ref is the merge commit and its parents are absent.
+          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -20,10 +24,23 @@ jobs:
       # Validates every `changelog.d/` fragment name and body (#281). A malformed fragment would
       # otherwise surface only at the release cut, in the version-bump PR, which is the worst
       # place to discover it. Seconds, and it fails inside a branch-protection-required job.
+      #
+      # `--base-ref` additionally compares CHANGELOG.md against the merge base and refuses any
+      # change to it that is not a release assembly (#297). Without it `check` reads only the
+      # fragments, so a PR editing CHANGELOG.md directly passes — and since #295 removed
+      # `## [Unreleased]`, such an edit no longer conflicts either: git lands the hunk inside an
+      # already-published section and the merge is clean. The flag is omitted on `push` (no PR to
+      # compare against); the script prints which branch it took, so an inert guard is visible in
+      # the log rather than silent.
+      # `github.event.pull_request.base.sha` rather than `origin/<base_ref>`: actions/checkout
+      # fetches only the ref it checks out, so there is no `refs/remotes/origin/main` to name --
+      # but the base commit is an ancestor of the merge commit and so is present at depth 0.
       - name: Validate changelog fragments
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           python3 .github/scripts/test-changelog.py
-          python3 .github/scripts/changelog.py check
+          python3 .github/scripts/changelog.py check ${BASE_SHA:+--base-ref "$BASE_SHA"}
       # `:kodemirror-bom:verifyBomCoverage` checks the generated BOM POM against the set of
       # modules that publish, failing on drift in either direction (#244). It is named here
       # because this job does not run `check`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,16 @@ committing or pushing directly to `main`. An independent reviewer pass produces 
    - tests green: `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :<module>:jvmTest`
    - style: `spotlessApply` / `ktlintFormat`
    - API: `apiCheck` (run `apiDump` only for an *intended* public-API change)
-   - changelog: add **a new file** `changelog.d/<issue>.<section>.md` holding the entry, and
-     **do not edit `CHANGELOG.md`** — it is assembled at release time. Entries still carry the
-     issue/PR number. One file per change is the whole point: two PRs never touch the same file,
-     so merging one no longer conflicts every other open PR and invalidates its approval (#281).
-     `changelog.d/README.md` has the format; `python3 .github/scripts/changelog.py check` validates it.
+   - changelog: when the change is one a **user of the library reads about** — behaviour, public
+     API, build/release process, or user-facing docs — add **a new file**
+     `changelog.d/<issue>.<section>.md` holding the entry. A change with no user-visible effect
+     (pure internal refactor, test-only, CI plumbing) legitimately gets none; `check` does not
+     require one. Either way **do not edit `CHANGELOG.md`** — it is assembled at release time,
+     and `check --base-ref origin/main` refuses any other change to it (#297). Entries still
+     carry the issue/PR number. One file per change is the whole point: two PRs never touch the
+     same file, so merging one no longer conflicts every other open PR and invalidates its
+     approval (#281). `changelog.d/README.md` has the format and the when-to-write-one criterion;
+     `python3 .github/scripts/changelog.py check` validates it.
 2. **Open a PR via the coderbot wrapper** (`/home/jmonk/git/urithiru/coder-bot/coderbot`),
    authored by `monkopedia-coder`, requesting the reviewer on creation:
    - `coderbot git push -u origin <branch>`
@@ -130,10 +135,12 @@ cut the next patch.
    default or a wrong test count is most visible — two such defects were caught that way and
    both were in changelog diffs a reviewer had been trained to skim. `assemble` refuses to run
    on an empty `changelog.d/`, refuses a `-SNAPSHOT` or underivable version rather than
-   producing an empty one, and verifies its own output is **purely additive**: it strips the new
-   section back out and requires the remainder to match the previous file byte for byte, so a
-   published section cannot be silently reworded. It aborts and writes nothing if any of that
-   fails.
+   producing an empty one, refuses a version whose `## [X.Y.Z]` heading is already in the file
+   (the `-SNAPSHOT` guard does not cover that — the post-release bump is usually skipped, so
+   `main` normally reads an already-released version, #297), and verifies its own output is
+   **purely additive**: it strips the new section back out and requires the remainder to match
+   the previous file byte for byte, so a published section cannot be silently reworded. It aborts
+   and writes nothing if any of that fails.
 2. **Tag** `vX.Y.Z` on the merged release commit and push the tag.
 3. **Dispatch `deploy.yml`** (`gh workflow run deploy.yml`). A single macOS runner publishes all
    targets (incl. the BOM) to Maven Central in one Gradle invocation — one atomic Central Portal

--- a/README.md
+++ b/README.md
@@ -117,13 +117,15 @@ See [all open issues](https://github.com/Monkopedia/kodemirror/issues) for the f
 
 Contributions are welcome! Please [open an issue](https://github.com/Monkopedia/kodemirror/issues/new) to discuss before submitting large changes.
 
-**Changelog entries go in `changelog.d/`, not in `CHANGELOG.md`.** Add a new file named
+**Changelog entries go in `changelog.d/`, not in `CHANGELOG.md`.** When your change is one a user
+reads about — behaviour, public API, the build, or user-facing docs — add a new file named
 `<issue>.<section>.md` — for example `changelog.d/281.fixed.md` — containing the markdown bullet(s)
-your change should appear as. `CHANGELOG.md` is assembled from those files at release time and has
-no `[Unreleased]` section to edit. One file per pull request means two pull requests never touch
-the same file, so they never conflict on the changelog. See
-[`changelog.d/README.md`](changelog.d/README.md) for the sections and the format, and run
-`python3 .github/scripts/changelog.py check` to validate.
+your change should appear as. A change with no user-visible effect needs none. `CHANGELOG.md` is
+assembled from those files at release time and has no `[Unreleased]` section to edit; editing it
+directly is refused by CI. One file per change means two pull requests never touch the same file,
+so they never conflict on the changelog. See
+[`changelog.d/README.md`](changelog.d/README.md) for the sections, the format and when an entry is
+expected, and run `python3 .github/scripts/changelog.py check` to validate.
 
 ## License
 

--- a/changelog.d/297.build.md
+++ b/changelog.d/297.build.md
@@ -1,0 +1,12 @@
+- Hardened the `changelog.d/` tooling so `check` answers "did this change do the right thing with
+  the changelog", not just "are the fragments present well-formed" (#297).
+  - `check` refuses a `## [Unreleased]` heading in `CHANGELOG.md`, and — given `--base-ref`, as CI
+    now runs it — refuses any change to `CHANGELOG.md` that is not a release assembly. Previously
+    `check` never read the file at all, so a branch written before #295 removed `[Unreleased]`
+    passed CI while git landed its hunk *inside an already-published section*, with a clean merge.
+  - `assemble` refuses a version whose `## [X.Y.Z]` heading is already in `CHANGELOG.md`. The
+    `-SNAPSHOT` guard does not cover it: the post-release SNAPSHOT bump has been performed after
+    three of eight releases, so `main` normally sits on an already-released version, and assembly
+    there produced a second identical heading with exit 0 and the fragments deleted.
+  - `changelog.d/README.md` now states when a fragment is expected and when it is legitimately
+    omitted; a fragment remains optional rather than required.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -3,6 +3,27 @@
 **Do not edit `CHANGELOG.md`.** Add a file here instead. `CHANGELOG.md` is assembled from these
 files at release time and has no `[Unreleased]` section.
 
+## When an entry is expected
+
+**Not every pull request needs a fragment, and none is required.**
+`python3 .github/scripts/changelog.py check` validates the fragments that are *present*; a PR
+adding none passes, deliberately. Write one when the change is something a **user of the library
+reads about**:
+
+- user-visible behaviour, a bug fix, or a performance change
+- public API — anything that moves `api/*.api`
+- the build, packaging, or release process, and supported platforms or versions
+- documentation a user reads (`README.md`, `docs-site/`)
+
+Legitimately omit one for a change with no user-visible effect: a pure internal refactor, a
+test-only change, CI plumbing, or repository-internal notes. A blanket requirement would only
+produce a permanent stream of `N.internal.md` files reading "internal refactor", which makes the
+released section *harder* to read, and whether a change is user-visible is a judgement no script
+can make — asking for it every time turns that judgement into a rubber stamp.
+
+When in doubt, write one: an unnecessary entry is deleted in review, a missing one is noticed
+after the release.
+
 ## Adding an entry
 
 Create `changelog.d/<issue>.<section>.md` containing the markdown bullet(s) your change should
@@ -31,6 +52,26 @@ Rules, all of them checked by `python3 .github/scripts/changelog.py check`:
   indented sub-bullets are fine — an entry is not required to be a single bullet.
 - One issue needing two fragments in the same section (two PRs, one issue) adds a discriminator:
   `281.fixed.followup.md`.
+
+## What `check` refuses
+
+Beyond the fragment rules above, `check` reads `CHANGELOG.md` itself:
+
+- a `## [Unreleased]` heading — #295 removed it, so its reappearance means an entry is being
+  written where nothing will ever assemble it;
+- any other change to `CHANGELOG.md`, when given a base to compare against — as CI does,
+  passing the pull request's base commit. The only accepted change is a release assembly: one
+  new `## [X.Y.Z]` section at the top, matching the version in the build files, with every
+  other byte untouched.
+
+That second check exists because removing `[Unreleased]` also removed the conflict that used to
+force a human to look. A branch written for the old layout now merges **cleanly** — git places
+the hunk at the nearest surviving context, which is inside an already-published section — so
+nothing else in the pipeline would notice (#297). Locally, name the branch you are based on:
+
+```bash
+python3 .github/scripts/changelog.py check --base-ref origin/main
+```
 
 ## Why files instead of one shared block
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -88,9 +88,16 @@ wrong `MapMode` default and a fabricated test count both reached review and were
 someone reading the entry.
 
 `assemble` refuses an empty `changelog.d/`, refuses a `-SNAPSHOT` or underivable version instead
-of writing an empty one, and checks its own result is purely additive — the new section stripped
-back out must reproduce the previous `CHANGELOG.md` byte for byte, so published sections cannot be
-reworded by accident. Any of those failing aborts with a non-zero exit and writes nothing.
+of writing an empty one, refuses a version whose `## [X.Y.Z]` heading is already in the file, and
+checks its own result is purely additive — the new section stripped back out must reproduce the
+previous `CHANGELOG.md` byte for byte, so published sections cannot be reworded by accident. Any
+of those failing aborts with a non-zero exit and writes nothing.
+
+The already-released refusal covers the case the `-SNAPSHOT` guard cannot: because step 8's
+post-release SNAPSHOT bump is usually skipped, `main` normally sits on an already-released
+version, and running `assemble` before step 2 would otherwise write a **second** `## [X.Y.Z]`
+heading with exit 0 and delete the fragments. `deploy.yml`'s extractor re-arms on the second
+matching heading, so the release notes would carry both sections (#297).
 
 The result must be a dated `[X.Y.Z] - YYYY-MM-DD` section; `deploy.yml` extracts the release notes
 from it by that exact heading.


### PR DESCRIPTION
Fixes #297 — all three parts, each measured in both directions.

## 3. `check` could not see a direct `CHANGELOG.md` edit (the newest part, and the one with a live victim)

`check` read the fragments and nothing else, so a PR editing `CHANGELOG.md` — including into an
already-published section — passed the required job with `changelog.d: N fragment(s) valid`.
Since #295 removed `## [Unreleased]`, such an edit no longer conflicts either: git lands the hunk
at the nearest surviving context and `mergeable: MERGEABLE` is accurate.

Two guards, both in `check`:

- **`## [Unreleased]` is refused outright**, always, with no CI wiring needed — so this half can
  never go inert.
- **`--base-ref <ref>` refuses any change to `CHANGELOG.md` that is not a release assembly**: one
  new `## [X.Y.Z]` section spliced in at the top, its version matching the build files, every
  other byte of the file identical. `ci.yml` passes the PR's base sha and adds `fetch-depth: 0`
  (a depth-1 checkout has the merge commit but not its parents, so there is no base commit to
  read). The script prints `CHANGELOG.md: checked against <ref>` or `no --base-ref; compared
  against nothing`, so a guard that stops running is visible in the log rather than silent.

Measured on this branch, against `origin/main` (7163b0e6):

| case | result |
| --- | --- |
| this PR: fragments only, `CHANGELOG.md` untouched | **exit 0** |
| a bullet inserted at line 74, inside the published `## [0.3.6]` (the #268 shape) | **exit 1** |
| `## [Unreleased]` reintroduced (with *and* without `--base-ref`) | **exit 1** |
| a hand-written `## [9.9.9]` section at the top | **exit 1** |
| a real release cut: bump to 0.3.7 + `assemble`, then `check --base-ref origin/main` | **exit 0** |

That last row is the one that matters for the strictness direction — the version-bump PR is the
one PR allowed to touch this file, and its own CI has to stay green.

## 2. `assemble` produced a duplicate released heading

`assemble` now refuses a version whose `## [X.Y.Z]` heading is already in the file. Measured on a
copy of `main` with no edits: before, `assemble` printed
`CHANGELOG.md: added [0.3.6] - 2026-09-02 from 6 fragment(s)`, exit 0, two `## [0.3.6]` headings,
fragments deleted. After: exit 1, one heading, all six fragments still on disk. Assembling onto a
fresh 0.3.7 still exits 0.

The `-SNAPSHOT` guard is the intended defence and is inert here — the post-release bump has
happened after three of eight releases, so `main` normally sits on an already-released version.
`_verify_additive` cannot catch it either: on a *heading* collision the rendered section (new
date) is still absent from the old file.

## 1. When a fragment is expected

**Stated, not required** — I did not add a requirement, and I think that is right. Three reasons,
in the order they moved me:

1. Whether a change is user-visible is a judgement no script can make. A mandatory fragment
   converts that judgement into a rubber stamp, which is worse than the current silence: today a
   missing entry is an omission, under a requirement it would be a satisfied gate.
2. The published section is the artifact being protected, and a permanent stream of
   `N.internal.md` files reading "internal refactor" makes it harder to read, not easier.
3. The permissiveness is not an accident of the implementation — `check`'s whole design is to
   validate fragment *shape* and never parse entry text.

`changelog.d/README.md` gains a "When an entry is expected" section with the criterion (behaviour,
public API, build/release process, user-facing docs get one; internal refactors, test-only changes
and CI plumbing need not) and a "When in doubt, write one" default. `CLAUDE.md` step 1, `README.md`
§ Contributing and `docs/release-checklist.md` are aligned with it: all three previously read as
unconditional, which is the contradiction the issue flagged, and #292/#293 established `CLAUDE.md`
is authoritative while the checklist may add detail but not contradict — so the criterion is stated
in `CLAUDE.md` and detailed in the README rather than the other way round.

## Tests: 15 -> 34, mutation-checked

Every new guard line was mutated in turn and the failing tests recorded. **Two lines initially
survived mutation** — `_leading_section_insertion`'s prefix and tail comparisons — and got tests
written for them (a preamble edit and a published-line rewording that ride along with an otherwise
valid assembly, both length-preserving so the inserted slice still looks right). That is the
defect this whole issue is about, caught on my own change.

| mutation (the exact line neutered) | failing tests |
| --- | --- |
| `_verify_additive` body → `return` | **3** (unchanged: the existing property survives) |
| `assemble`: `if re.search(rf"(?m)^## \[{re.escape(version)}\]", old):` | 2 |
| `verify_no_unreleased_section`: `if UNRELEASED_RE.search(text):` | 1 |
| `verify_changelog_matches_base`: `if inserted is None:` | 6 |
| `verify_changelog_matches_base`: `if not inserted.startswith(f"## [{version}] "):` | 1 |
| `_leading_section_insertion`: `if len(SECTION_START_RE.findall(inserted)) != 1:` | 1 |
| `_leading_section_insertion`: `if new[:cut] != old[:cut]:` | 1 |
| `_leading_section_insertion`: `if tail and not new.endswith(tail):` | 1 |
| `_git`: `raise Failure(...)` → `return ""` | 1 |

No guard survives its own mutation. Neutering `_verify_additive` still fails exactly the same
three tests it did before.

Both directions are represented in the suite deliberately: `test_accepts_a_version_not_yet_released`,
`test_a_version_that_is_a_prefix_of_a_released_one_is_accepted` (`1.0` must not match
`## [1.0.0]`), `test_does_not_fire_on_the_word_in_an_entry`, `test_an_untouched_changelog_passes`
and `test_a_release_assembly_passes` are all there so a guard that reddens on the good case fails
the suite rather than reading as strictness.

## Notes

- No Kotlin changed; Python and markdown only.
- My own changelog entry is `changelog.d/297.build.md`, not a `CHANGELOG.md` edit — which makes
  this PR a live test of the guard it adds. The `check` job here runs
  `changelog.py check --base-ref <base sha>` from this branch's own script.
- `.github/workflows/ci.yml` is outside the file list in the issue, but the base-ref comparison
  has no effect unless CI passes the ref; without that wiring the guard would ship inert.
- #268 will go red once this merges. That is the intent — it currently carries five bullets
  landed inside the published `## [0.3.6]` section.
