### PR TITLE
Raise the soft keyboard on mobile browsers (#303)

### DIFF
--- a/changelog.d/303.fixed.md
+++ b/changelog.d/303.fixed.md
@@ -1,0 +1,10 @@
+- Fixed the soft keyboard not appearing when the editor is tapped in a browser on mobile (#303).
+  The editor's tap gesture did not consume the pointer down, so Compose for Web never called
+  `preventDefault()` on it and the browser's default action moved DOM focus to the Compose
+  `<canvas>`, blurring the backing `<textarea>` a soft keyboard is raised for; and because the
+  hidden field already held Compose focus, `requestFocus()` on tap was a no-op that never asked
+  the platform to show the keyboard. The gesture now consumes the down and calls
+  `SoftwareKeyboardController.show()`, matching what `BasicTextField` does. Verified in a browser
+  by measuring DOM focus and `pointerdown.defaultPrevented` before and after; a real device and an
+  actual on-screen keyboard were not exercised, and iOS Safari and Firefox for Android may have a
+  further obstacle of their own.

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.TextFieldValue
@@ -250,11 +251,17 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
 
     // Focus management
     val focusRequester = remember { FocusRequester() }
+    // Requesting Compose focus is not enough to raise a soft keyboard once the
+    // hidden field already holds focus: with no focus *change* there is no new
+    // startInput, so the platform is never asked to show the IME. Compose's own
+    // BasicTextField calls show() explicitly for that case
+    // (CoreTextField.requestFocusAndShowKeyboardIfNeeded); the editor's tap
+    // handler below does the same (#303).
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     // Auto-focus the hidden text field when the editor first appears
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
-        platformFocusInput()
     }
 
     // Track whether the platform callback already handled this keydown.
@@ -559,10 +566,21 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
                         // separate tap/drag coroutines competed for the DOWN
                         // event and focus could be skipped.
                         awaitEachGesture {
-                            val down = awaitFirstDown()
-                            // Always focus immediately on any pointer down
+                            // Consume the down, as detectTapAndPress does for a
+                            // text field. On wasmJs that is what makes Compose
+                            // call preventDefault() on the browser event;
+                            // without it the default action moves DOM focus to
+                            // the tabindex=0 <canvas> and blurs the backing
+                            // <textarea>, the only element a soft keyboard is
+                            // raised for (#303). Children (line-list scroll,
+                            // gutter clicks) see the Main pass first, so this
+                            // does not take the gesture away from them.
+                            val down = awaitFirstDown().also { it.consume() }
+                            // Focus immediately on any pointer down, and ask for
+                            // the keyboard even when focus does not change —
+                            // otherwise one the user dismissed never comes back.
                             focusRequester.requestFocus()
-                            platformFocusInput()
+                            keyboardController?.show()
 
                             val downPosition = down.position
                             var isDrag = false

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/Platform.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/Platform.kt
@@ -113,17 +113,6 @@ internal expect fun platformRegisterKeyHandler(
 internal expect fun platformUnregisterKeyHandler(token: PlatformKeyHandlerToken)
 
 /**
- * Ensure the editor's backing text input element has platform focus.
- *
- * On wasmJs, Compose's FocusRequester.requestFocus() gives Compose-internal
- * focus but doesn't always move DOM focus to the textarea that Skiko creates.
- * This function explicitly focuses the textarea in the shadow DOM.
- *
- * On JVM/Desktop, this is a no-op since Compose manages focus natively.
- */
-internal expect fun platformFocusInput()
-
-/**
  * Write [text] to the underlying system clipboard.
  *
  * On wasmJs the canvas-rendered editor has no DOM `contenteditable`, so the

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/FocusManagementTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/FocusManagementTest.kt
@@ -32,53 +32,34 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 /**
- * Tests for focus management after canvas/editor clicks.
+ * Tests for focus management after editor clicks.
  *
- * # Issue #2: Canvas click can break keyboard input
+ * # Issue #2: a tap/drag race could skip `requestFocus()`
  *
- * ## Root cause analysis
+ * The editor used to run separate tap and drag gesture coroutines that each
+ * competed for the DOWN event, so focus could be skipped depending on which
+ * won. They are now one `awaitEachGesture` block that requests focus on the
+ * down before deciding tap-vs-drag. These tests hold that: click, repeated
+ * click, drag, and click-after-drag must all leave the hidden field focused
+ * and keyboard navigation working.
  *
- * The editor Box has THREE separate `pointerInput` modifiers:
- *   1. `detectTapGestures`  — calls `focusRequester.requestFocus()` on tap
- *   2. `detectDragGestures` — calls `focusRequester.requestFocus()` on drag start
- *   3. `awaitPointerEventScope` — hover tracking (no focus involvement)
+ * # Issue #303: DOM focus and the soft keyboard on wasmJs
  *
- * Each `pointerInput` block runs in its own coroutine and competes for pointer
- * events. When the user clicks (press + quick release), Compose's gesture
- * detection applies "slop": a pointer move below ~18px is still considered a
- * tap, but both coroutines receive the DOWN event simultaneously.
+ * Compose focus is not the whole story in a browser. Compose's canvas carries
+ * `tabindex="0"`, so an un-`preventDefault()`ed pointer down moves *DOM* focus
+ * to the canvas and blurs the backing `<textarea>` — the only element a browser
+ * raises a soft keyboard for — and Compose-web only calls `preventDefault()`
+ * when the gesture consumed a change. The editor therefore consumes the down,
+ * and calls `SoftwareKeyboardController.show()` in the same gesture because a
+ * `requestFocus()` on an already-focused field is a no-op and never asks the
+ * platform for the IME.
  *
- * On Desktop/JVM, `detectDragGestures` requires the pointer to move past the
- * drag slop threshold before it starts consuming events, so a pure click
- * normally reaches `detectTapGestures` intact.
- *
- * On **wasmJs**, the situation is more complex:
- *   - `platformFocusInput()` calls `platformFocusCanvas()`, which focuses the
- *     `<canvas>` element in Skiko's shadow DOM. A canvas click can momentarily
- *     move *browser* DOM focus to the canvas, away from any hidden textarea.
- *   - If `detectTapGestures` does not fire (e.g., drag detector consumed the
- *     event before the tap completed), `focusRequester.requestFocus()` is never
- *     called, leaving the BasicTextField without Compose focus.
- *   - The `recentlyDragged` flag (set in `onDragStart`, cleared in tap) adds
- *     another wrinkle: if drag fires first and sets `recentlyDragged = true`,
- *     the subsequent tap callback early-returns and skips `requestFocus()`.
- *
- * ## Why this test can/cannot reproduce the bug on JVM
- *
- * On JVM (Desktop Compose), `platformFocusInput()` is a no-op. Focus is
- * managed entirely by Compose's `FocusRequester`. The drag/tap race exists in
- * the pointer-input pipeline, but in the Desktop test environment Compose
- * correctly hands a click (no slop exceeded) to `detectTapGestures`, so
- * `requestFocus()` fires and the BasicTextField is focused.
- *
- * **The bug is wasmJs-specific**: it only manifests when:
- *   a) the browser moves DOM focus to the canvas on click, AND
- *   b) the Compose FocusRequester doesn't re-focus the hidden textarea, AND
- *   c) the document-level key handler (`platformRegisterKeyHandler`) does not
- *      catch keys because they target the canvas rather than the body.
- *
- * The tests below verify the *correct* JVM behavior (click → focus → keyboard
- * works) and document the wasmJs-specific failure mode as comments.
+ * Neither half is observable from a Compose UI test: `hasFocus` below reports
+ * Compose focus, not `document.activeElement`, and there is no soft keyboard in
+ * a test environment. The DOM-level evidence for #303 lives in the PR, measured
+ * against a real browser. What these tests can and do guard is that the added
+ * consume did not cost the gesture behaviour above; the pointer-type coverage
+ * that consume most affects is in [TouchGestureTest] and [DragSelectionTest].
  */
 @OptIn(ExperimentalTestApi::class)
 class FocusManagementTest {
@@ -114,12 +95,8 @@ class FocusManagementTest {
     // -------------------------------------------------------------------------
 
     /**
-     * A single click on the editor canvas should give Compose focus to the
-     * hidden BasicTextField so that subsequent key events are routed to it.
-     *
-     * On JVM: passes — detectTapGestures fires and calls requestFocus().
-     * On wasmJs: may fail — canvas click may move DOM focus away from the
-     * textarea; see class KDoc for details.
+     * A single click on the editor should give Compose focus to the hidden
+     * BasicTextField so that subsequent key events are routed to it.
      */
     @Test
     fun clickOnEditor_givesFocusToTextField() = runEditorTest(
@@ -165,10 +142,8 @@ class FocusManagementTest {
     }
 
     /**
-     * Multiple sequential clicks should each preserve focus.
-     *
-     * Each click calls detectTapGestures → requestFocus(). Clicking the second
-     * time should NOT steal focus from the BasicTextField.
+     * Multiple sequential clicks should each preserve focus. Every pointer
+     * down calls requestFocus(); a later click must not steal focus back.
      */
     @Test
     fun multipleClicks_eachPreservesFocus() = runEditorTest(
@@ -185,10 +160,9 @@ class FocusManagementTest {
     }
 
     /**
-     * After a drag gesture, the editor should remain focused.
-     *
-     * detectDragGestures.onDragStart calls requestFocus(), so a drag should
-     * also focus the editor. Subsequent key input must work.
+     * After a drag gesture, the editor should remain focused. Focus is
+     * requested on the down, before tap-vs-drag is decided, so a drag focuses
+     * the editor just as a tap does and key input must still work.
      */
     @Test
     fun dragThenKeyboard_cursorMoves() = runEditorTest(
@@ -234,18 +208,10 @@ class FocusManagementTest {
     }
 
     /**
-     * Tap immediately after a drag must NOT skip focus due to `recentlyDragged`.
-     *
-     * In KodeMirror.kt, the tap handler checks `recentlyDragged` and early-
-     * returns (skipping requestFocus) if it's true. The drag's `onDragEnd`
-     * callback sets `recentlyDragged = false`, so a fresh tap after drag
-     * completion should still call requestFocus().
-     *
-     * If the ordering is wrong (tap fires before onDragEnd clears the flag),
-     * the tap skips requestFocus and focus is lost.
-     *
-     * On JVM, `recentlyDragged` is cleared by `onDragEnd` before the next tap
-     * can fire, so this passes. The risk is on wasmJs where timing differs.
+     * A tap immediately after a drag must still focus the editor. The original
+     * defect (#2) was a `recentlyDragged` flag that made the tap handler
+     * early-return past `requestFocus()`; the unified gesture has no such flag,
+     * and this holds it that way.
      */
     @Test
     fun clickAfterDrag_focusIsRestored() = runEditorTest(
@@ -280,8 +246,7 @@ class FocusManagementTest {
             posAfter == posBefore - 1,
             "Expected cursor to move left by 1 after click-after-drag " +
                 "(from $posBefore to ${posBefore - 1}), but got $posAfter. " +
-                "This suggests `recentlyDragged` was still true when the tap fired, " +
-                "causing requestFocus() to be skipped."
+                "This suggests the tap after a drag skipped requestFocus()."
         )
     }
 

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/TouchGestureTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/TouchGestureTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view.input
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Touch-pointer coverage for the editor's unified tap/drag gesture.
+ *
+ * The mouse equivalents live in [DragSelectionTest], [ClickTargetingTest] and
+ * [ScrollClickTest]. This file exists because the gesture consumes the pointer
+ * down (#303) — on wasmJs that is what makes Compose call `preventDefault()`,
+ * which stops the browser moving DOM focus to the `tabindex=0` canvas and
+ * blurring the backing textarea the soft keyboard is raised for. Consuming a
+ * down changes what sibling and child gesture handlers observe, and touch is
+ * the pointer type where that matters most: the same vertical drag is both a
+ * text selection and a list scroll depending on who wins.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TouchGestureTest {
+
+    private val threeLineDoc = "Line one\nLine two\nLine three"
+    private val fiftyLineDoc = (1..50).joinToString("\n") { "Line $it content here" }
+
+    @Test
+    fun touchTapPlacesCursor() = runEditorTest(doc = threeLineDoc) { holder ->
+        onNodeWithTag("KodeMirror").performTouchInput {
+            down(Offset(40f, 35f))
+            up()
+        }
+        waitForIdle()
+        holder.assertCursorOnLine(2)
+    }
+
+    @Test
+    fun touchTapOnFirstLinePlacesCursor() = runEditorTest(doc = threeLineDoc) { holder ->
+        onNodeWithTag("KodeMirror").performTouchInput {
+            down(Offset(40f, 8f))
+            up()
+        }
+        waitForIdle()
+        holder.assertCursorOnLine(1)
+    }
+
+    /**
+     * A horizontal touch drag over the editor does not extend a selection: the
+     * line content sits in a horizontal scroll container, which claims the drag
+     * before the editor's gesture sees it, and the gesture falls back to placing
+     * the cursor at the down position. That is pre-existing behaviour, measured
+     * identical before and after the #303 pointer-down consume, and it is
+     * characterised here so a change to it is caught rather than shipped —
+     * touch drag-selection itself is tracked separately.
+     */
+    @Test
+    fun horizontalTouchDragPlacesCursorAndLeavesDocument() =
+        runEditorTest(doc = threeLineDoc) { holder ->
+            onNodeWithTag("KodeMirror").performTouchInput {
+                down(Offset(20f, 8f))
+                moveTo(Offset(60f, 8f))
+                moveTo(Offset(120f, 8f))
+                moveTo(Offset(200f, 8f))
+                up()
+            }
+            waitForIdle()
+            holder.assertDoc(threeLineDoc)
+            holder.assertCursorOnLine(1)
+            assertTrue(
+                holder.session.state.selection.main.empty,
+                "Expected a horizontal touch drag to leave the selection empty, but got " +
+                    "${holder.session.state.selection.main}"
+            )
+        }
+
+    /**
+     * A vertical touch drag over a document taller than the viewport must
+     * scroll the line list. The LazyColumn is a child of the node carrying the
+     * editor gesture, so it sees the pointer first; the editor consuming the
+     * down must not take that away.
+     */
+    @Test
+    fun verticalTouchDragScrollsDocument() = runEditorTest(
+        doc = fiftyLineDoc,
+        height = 300
+    ) { holder ->
+        val before = holder.firstVisibleIndex()
+        onNodeWithTag("KodeMirror").performTouchInput {
+            down(Offset(400f, 250f))
+            var y = 250f
+            while (y > 30f) {
+                y -= 20f
+                moveTo(Offset(400f, y))
+            }
+            up()
+        }
+        waitForIdle()
+        val after = holder.firstVisibleIndex()
+        assertTrue(
+            after > before,
+            "Expected a vertical touch drag to scroll the line list " +
+                "(firstVisibleIndex $before -> $after)"
+        )
+    }
+}

--- a/view/src/jvmMain/kotlin/com/monkopedia/kodemirror/view/Platform.jvm.kt
+++ b/view/src/jvmMain/kotlin/com/monkopedia/kodemirror/view/Platform.jvm.kt
@@ -52,10 +52,6 @@ internal actual fun platformUnregisterKeyHandler(token: PlatformKeyHandlerToken)
     // No-op
 }
 
-internal actual fun platformFocusInput() {
-    // No-op on JVM — Compose Desktop manages focus natively
-}
-
 internal actual fun platformWriteClipboard(text: String): Boolean {
     // No-op on JVM — Compose's ClipboardManager writes the AWT system
     // clipboard synchronously, so the command layer handles it directly.

--- a/view/src/nativeMain/kotlin/com/monkopedia/kodemirror/view/Platform.native.kt
+++ b/view/src/nativeMain/kotlin/com/monkopedia/kodemirror/view/Platform.native.kt
@@ -46,10 +46,6 @@ internal actual fun platformUnregisterKeyHandler(token: PlatformKeyHandlerToken)
     // No-op
 }
 
-internal actual fun platformFocusInput() {
-    // No-op on native — Compose manages focus natively
-}
-
 internal actual fun platformWriteClipboard(text: String): Boolean {
     // No-op on native — Compose's ClipboardManager writes the system
     // clipboard synchronously, so the command layer handles it directly.

--- a/view/src/wasmJsMain/kotlin/com/monkopedia/kodemirror/view/Platform.wasmJs.kt
+++ b/view/src/wasmJsMain/kotlin/com/monkopedia/kodemirror/view/Platform.wasmJs.kt
@@ -134,23 +134,6 @@ private fun ensureJsDispatcher() {
 @JsFun("() => globalThis.__kodeKey || ''")
 private external fun readCapturedKey(): String
 
-/**
- * Focus the canvas in the shadow DOM so keyboard events reach Skiko's
- * event handler. Skiko processes key events from the canvas element
- * and converts them to Compose KeyEvents that flow through
- * onPreviewKeyEvent.
- */
-@JsFun(
-    """() => {
-    var shadow = document.body.shadowRoot;
-    if (shadow) {
-        var canvas = shadow.querySelector('canvas');
-        if (canvas) canvas.focus();
-    }
-}"""
-)
-private external fun platformFocusCanvas()
-
 internal actual fun platformRegisterKeyHandler(
     handler: (key: String, ctrl: Boolean, alt: Boolean, meta: Boolean, shift: Boolean) -> Boolean
 ): PlatformKeyHandlerToken {
@@ -166,10 +149,6 @@ internal actual fun platformUnregisterKeyHandler(token: PlatformKeyHandlerToken)
         jsClearKeyCallback()
         jsDispatcherInstalled = false
     }
-}
-
-internal actual fun platformFocusInput() {
-    platformFocusCanvas()
 }
 
 // Write to the system clipboard via the async Clipboard API. This must be


### PR DESCRIPTION
## What

Three edits in `view/`, per the investigation on #303:

1. `KodeMirror.kt` — `awaitFirstDown().also { it.consume() }`, matching `detectTapAndPress`.
2. `KodeMirror.kt` — hoist `LocalSoftwareKeyboardController.current` and `?.show()` in the same
   gesture, mirroring `CoreTextField.requestFocusAndShowKeyboardIfNeeded`.
3. Delete `platformFocusInput()` / `platformFocusCanvas()` — dead code. `internal expect/actual`,
   so **`apiCheck` is unmoved** (verified, no `.api` diff).

Plus `TouchGestureTest`, the first touch-pointer coverage of the editor gesture.

## Reproduced first, then measured after

Everything below is Chromium (Playwright + CDP) against the showcase's `?test=true` page, which
exposes `globalThis.__kodemirror.state`. Instrumented `HTMLElement.prototype.focus`,
`focusin`/`focusout`, and `pointerdown.defaultPrevented` read after the dispatch completes.
Same script, same coordinates, two builds: `dd7dea8b` and this branch.

### D1 — the pointer down is now consumed

Touch taps, six per run, each from a fresh load:

| | before | after |
|---|---|---|
| `pointerdown.defaultPrevented` | **false 6/6** | **true 6/6** |

Mouse clicks, DOM focus after the click:

| | before | after |
|---|---|---|
| `deepActive()` ends on | **CANVAS 4/4** | **TEXTAREA 4/4** |

The before-state is the reported precondition: focus starts on
`TEXTAREA.compose-backing-field`, the click moves it to the canvas, and it stays there.

### D2 — the keyboard is now requested

`.focus()` calls made during each gesture (this is `keyboardController.show()` →
`BackingDomInput.focus()`, which focuses twice on purpose):

| | before | after |
|---|---|---|
| touch | **0 per tap, 6/6 taps** | **2 per tap, 6/6 taps** |
| mouse | **0 per click, 4/4** | **2 per click, 4/4** |

**The two are separable, and neither result implies the other.** `show()` cannot make Compose call
`preventDefault()`, and consuming a pointer cannot produce `.focus()` calls — so the
`defaultPrevented` column is evidence for (1) alone and the `.focus()` column for (2) alone.

## Correction to the investigation, measured

The investigation predicted `focusout: TEXTAREA → focusin: CANVAS` on **touch**. On the CMP version
`main` builds against (1.11.1) that does **not** happen, and the reason matters:
`ComposeWindow.initEvents` unconditionally `preventDefault()`s `touchstart` on the canvas, so the
browser never synthesises the compat mouse events and never runs the focus-on-click default action.
Stack trace from a patched `Event.prototype.preventDefault`:

```
touchstart
  at androidx.compose.ui.window.ComposeWindow$initEvents$lambda.invoke
  at androidx.compose.ui.window.ComposeWindow$addTypedEvent$lambda.invoke
  at HTMLCanvasElement.eval
```

The canvas-focus theft is real on 1.11.1, just not via touch — **a mouse click reproduces it
exactly** (CANVAS 4/4 above). The investigation ran the reporter's CMP 1.12.0 reproducer, where the
touch path is not masked. So on 1.11.1 D2 is the dominant defect and on 1.12.0 both bite; both are
fixed here.

One asymmetry worth recording: after the fix, `pointerdown.defaultPrevented` is `true` for touch and
still `false` for mouse — Compose for Web only cancels the default for touch pointer events. The
mouse case is repaired by (2) instead: the `.focus()` calls put focus back on the textarea.

Independently confirmed for edit (3): `document.body.shadowRoot` is **`null`** on the live page
(shadow host is `HTML > BODY > DIV > DIV`), so `platformFocusCanvas()`'s `if (shadow)` never fired.
It has never focused anything.

## Gesture regression — the actual risk

Consuming the down changes what siblings and children observe. Re-exercised **on both pointer
types**, before and after, identical results:

Real browser (`?test=true`, wasm):

| gesture | before | after |
|---|---|---|
| touch tap places cursor | pos 0 → 30 (line 2 col 8) | same |
| typing after touch tap | doc 229 → 232 | same |
| horizontal touch drag | no selection (see below) | no selection |
| mouse click places cursor | pos 0 → 30 | same |
| typing after mouse click | doc 229 → 232 | same |
| mouse drag selects | anchor 2 head 98 | anchor 2 head 98 |
| **Alt+drag rectangular** | 4 ranges | 5 ranges (both multi-range) |

Compose UI tests, run on **jvm (329 tests) and wasmJs (296 tests)**, all green — including the
existing `DragSelectionTest` (within-line, across-lines, reversed, bottom-to-top),
`FocusManagementTest`, `ScrollClickTest`, `MixedContentScrollTest`, and the new `TouchGestureTest`
(touch tap on two lines, horizontal touch drag, vertical touch drag scrolls the `LazyColumn`).

Why children are unaffected: Compose dispatches the Main pass leaf → root, so the line list's
scroll and the gutter's `clickable` have already seen the down before this node consumes it.

## What is characterised rather than asserted

`horizontalTouchDragPlacesCursorAndLeavesDocument` locks in today's behaviour, it does not endorse
it: a horizontal touch drag is claimed by the line's horizontal scroll container, so the editor
falls back to placing the cursor at the down position and no selection is made. **Measured
identical before and after** — it is not a regression, and filing it separately.

I first wrote that as an assertion that touch drag *selects*. It failed at `dd7dea8b` too, which is
the only reason I know it is pre-existing. Same for a JVM `performKeyInput`/`performMouseInput`
formulation of Alt+drag: it produced one range at baseline as well, while the same gesture in a real
browser produces 4–5. I did not chase that harness discrepancy — it is not #303's ground — and
Alt+drag is covered above by the browser run instead.

## What I could NOT verify

- **No real device and no actual soft keyboard.** Desktop Chromium has none. What is measured is the
  DOM-focus precondition and the keyboard-request call, not a keyboard appearing.
- **iOS Safari and Firefox for Android: untested.** The reporter says those never worked at all.
  iOS refuses programmatic `focus()` outside a trusted gesture, which could be a second obstacle
  that survives this change — `show()` here does run inside the pointer-down, which is the right
  shape for it, but I have no evidence either way. **This PR does not claim mobile-wide resolution.**
- **CMP 1.12.0 was not exercised at runtime**, only 1.11.1 (what `main` builds against). The 1.12.0
  behaviour above is the investigation's measurement, not mine.

## Verification commands

```
./gradlew ktlintFormat :view:jvmTest :view:apiCheck      # 329 tests, 0 failures, no .api diff
CHROME_BIN=/usr/bin/chromium ./gradlew :view:wasmJsBrowserTest   # 296 tests, 0 failures
./gradlew spotlessCheck ktlintCheck apiCheck             # green
python3 .github/scripts/changelog.py check               # 7 fragments valid
```

Test-result XML was deleted before each run and mtimes checked; `gap-analysis` was not used.

Fixes #303
