### PR TITLE
Resolve clicks against the current document after a replacement (#313)

### DIFF
--- a/changelog.d/313.fixed.md
+++ b/changelog.d/313.fixed.md
@@ -1,0 +1,10 @@
+- Fixed a crash when the editor is clicked after its document has been replaced with a shorter one
+  (#313). `Modifier.pointerInput` was keyed on the session, which keeps its identity when its
+  document changes, so the gesture coroutine kept the position resolver it was started with — one
+  closed over the previous document's line spans. A click on the second line of a shorter
+  replacement resolved through the old line's start offset, past the end of the new document, and
+  the resulting selection threw `Selection points outside of document`. The gesture coroutines now
+  read the current resolver through `rememberUpdatedState`, so they stay stable across a document
+  change while hit-testing against the current layout. A hit-test result the current document
+  cannot contain is now also dropped rather than dispatched, which loses a click that raced a
+  document update instead of placing the caret somewhere the user did not click.

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
@@ -485,7 +485,7 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
     // every hit-test through the live layout keeps clicks/drags/hover on the
     // glyph under the pointer instead of its pre-scroll position.
     val resolvePos: (Offset) -> Int? = { offset ->
-        posFromVisibleItems(
+        val pos = posFromVisibleItems(
             offset,
             lazyState,
             columnItems,
@@ -496,7 +496,31 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
             if (wrapLines) 0 else horizontalScrollState.value,
             contentTopPaddingPx
         ) ?: session.posAtCoords(offset.x, offset.y)
+        // Drop — never clamp — a result the current document cannot contain.
+        // Pointer events are delivered before the frame's composition, so a
+        // document swapped in from outside a gesture (setDoc, an LSP edit) can
+        // land between the event and the recomposition that re-derives the
+        // layout from it. Everything above is then self-consistent but
+        // describes the PREVIOUS document, and there is no honest mapping from
+        // such a position into the new one. Coercing it into range would place
+        // the caret somewhere the user did not click and say nothing about it;
+        // returning null makes the gesture a no-op, so the click is simply lost
+        // and the next one — against a settled layout — lands correctly.
+        pos?.takeIf { it in 0..session.state.doc.length }
     }
+
+    // The two gesture coroutines below are keyed on `session`, and a session
+    // keeps its identity when its document changes — so their key never fires
+    // and the handler lambda they were started with is the one they keep. Held
+    // directly, `resolvePos` would be whichever composition's copy happened to
+    // be current when the first pointer event started them, closed over that
+    // composition's `columnItems` — the OLD document's line spans. Clicking
+    // after the document was replaced with a shorter one then resolved through
+    // a line start past the new document's end and the dispatch threw
+    // "Selection points outside of document" (#313). Reading the latest
+    // resolver keeps the gesture coroutines stable and their hit-testing
+    // current, the same treatment `currentColumnItems` gets above.
+    val currentResolvePos by rememberUpdatedState(resolvePos)
 
     CompositionLocalProvider(
         LocalEditorTheme provides theme,
@@ -604,18 +628,18 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
                                         session,
                                         dragStart,
                                         dragCurrent,
-                                        resolvePos
+                                        currentResolvePos
                                     )
                                 } else {
                                     handleDrag(
                                         session,
                                         dragStart,
                                         dragCurrent,
-                                        resolvePos
+                                        currentResolvePos
                                     )
                                 }
                                 session.plugin(dropCursorViewPlugin)
-                                    ?.moveTo(resolvePos(dragCurrent))
+                                    ?.moveTo(currentResolvePos(dragCurrent))
 
                                 drag(slopChange.id) { change ->
                                     change.consume()
@@ -625,18 +649,18 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
                                             session,
                                             dragStart,
                                             dragCurrent,
-                                            resolvePos
+                                            currentResolvePos
                                         )
                                     } else {
                                         handleDrag(
                                             session,
                                             dragStart,
                                             dragCurrent,
-                                            resolvePos
+                                            currentResolvePos
                                         )
                                     }
                                     session.plugin(dropCursorViewPlugin)
-                                        ?.moveTo(resolvePos(dragCurrent))
+                                        ?.moveTo(currentResolvePos(dragCurrent))
                                 }
                                 // Drag ended
                                 session.plugin(dropCursorViewPlugin)
@@ -644,7 +668,7 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
                             } else if (!isDrag) {
                                 // Pointer released without exceeding slop —
                                 // treat as a tap for cursor positioning.
-                                val pos = resolvePos(downPosition)
+                                val pos = currentResolvePos(downPosition)
                                     ?: return@awaitEachGesture
                                 session.dispatch(
                                     TransactionSpec(
@@ -669,7 +693,7 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
                                 val pos = event.changes
                                     .firstOrNull()?.position
                                 if (pos != null) {
-                                    val docPos = resolvePos(pos)
+                                    val docPos = currentResolvePos(pos)
                                     if (docPos != lastHoverDocPos) {
                                         lastHoverDocPos = docPos
                                         val hoverTooltips =

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/DocReplacementClickTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/DocReplacementClickTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view.input
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import com.monkopedia.kodemirror.view.setDoc
+import kotlin.test.Test
+
+/**
+ * Clicking after the document is replaced in place (#313).
+ *
+ * The pointer-input gesture coroutine is keyed on the session, which does not
+ * change when its document does, so it kept whichever position resolver the
+ * first composition handed it. That resolver closed over that composition's
+ * `columnItems`, i.e. the OLD document's line spans. Clicking the second line
+ * of a shorter replacement document resolved through the old line's `from`
+ * (offset 201 here) and the dispatch threw `Selection points outside of
+ * document`.
+ *
+ * Both tests assert an exact offset rather than merely surviving: clamping the
+ * out-of-bounds result to `doc.length` would also stop the throw, but would
+ * park the caret at 3 (the end of `"a\nb"`) instead of 2 (the start of the line
+ * that was actually clicked).
+ */
+@OptIn(ExperimentalTestApi::class)
+class DocReplacementClickTest {
+
+    /** A first line long enough that the old line 2 starts past the new doc's end. */
+    private val longDoc = "A".repeat(200) + "\nold second line"
+
+    /** Replacement: two short lines, so line 2 starts at offset 2 and the doc ends at 3. */
+    private val shortDoc = "a\nb"
+
+    /** Left edge of the content area, so the click lands on the line's first character. */
+    private val lineStartClick = Offset(8f, 35f)
+
+    @Test
+    fun clickAfterReplacingWithShorterDoc() = runEditorTest(
+        doc = longDoc,
+        width = 400,
+        height = 160
+    ) { holder ->
+        // Interact with the editor BEFORE the replacement. This is what arms
+        // the bug: the gesture coroutine is started lazily by the first pointer
+        // event, so without a prior interaction it is launched after the
+        // replacement and closes over the fresh resolver by luck.
+        onNodeWithTag("KodeMirror").performMouseInput {
+            click(Offset(50f, 15f))
+        }
+        waitForIdle()
+        holder.assertCursorOnLine(1)
+
+        holder.session.setDoc(shortDoc)
+        waitForIdle()
+        holder.assertDoc(shortDoc)
+
+        onNodeWithTag("KodeMirror").performMouseInput {
+            click(lineStartClick)
+        }
+        waitForIdle()
+
+        holder.assertCursorAt(2)
+    }
+
+    /**
+     * The same click on the same document with no replacement — the resolver
+     * this test guards must keep placing an ordinary click exactly where it did
+     * before, not become a no-op that leaves the caret wherever it was.
+     */
+    @Test
+    fun clickWithoutReplacement() = runEditorTest(
+        doc = shortDoc,
+        width = 400,
+        height = 160
+    ) { holder ->
+        onNodeWithTag("KodeMirror").performMouseInput {
+            click(lineStartClick)
+        }
+        waitForIdle()
+
+        holder.assertCursorAt(2)
+    }
+}


### PR DESCRIPTION
Fixes #313.

## Reproduced first

The reporter's chain holds, and the missing ingredient for a deterministic repro is
**an interaction with the editor before the replacement**. `Modifier.pointerInput` starts its
handler coroutine lazily, on the first pointer event; with no prior interaction it is started
*after* the replacement and closes over the fresh resolver by luck. Instrumenting `resolvePos`
and the tap branch on unmodified `main`:

```
DBG recompute columnItems docLen=216
DBG pointerInput LAUNCH resolver=453485293
DBG resolvePos closure=-1952592720 items=[0, 201] docLen=216
DBG tap pos=5 docLen=216            <- click on line 1, arms the gesture coroutine
DBG recompute columnItems docLen=3  <- setDoc("a\nb")
DBG resolvePos closure=-1952592720 items=[0, 201] docLen=3   <- SAME closure, OLD line spans
DBG tap pos=201 docLen=3
```

which throws the reported exception, from the same frame the report names:

```
java.lang.IllegalArgumentException: Selection points outside of document
    at com.monkopedia.kodemirror.state.SelectionKt.checkSelection(Selection.kt:473)
    at com.monkopedia.kodemirror.state.Transaction.<init>(Transaction.kt:192)
    at com.monkopedia.kodemirror.state.TransactionKt.resolveTransaction(Transaction.kt:447)
    at com.monkopedia.kodemirror.state.EditorState.update(State.kt:122)
    at com.monkopedia.kodemirror.view.EditorSessionImpl.dispatch(EditorSessionImpl.kt:115)
    at com.monkopedia.kodemirror.view.KodeMirrorKt$KodeMirror$6$1$4$1$1.invokeSuspend(KodeMirror.kt:653)
```

## Which layer is at fault, and why it is fixed there

**The pointer-input layer, not the hit-test and not the dispatch.** `posFromVisibleItems` is
correct — given the current `columnItems` it resolves the right offset, as the second test here
shows. `checkSelection` is also correct: a selection outside the document is a genuine error and
should keep throwing.

The defect is that the resolver reaching the hit-test is not the current one.
`.pointerInput(session)` is keyed on the session alone, and a session keeps its identity when its
document changes, so the key never fires; `SuspendPointerInputElement` compares only its keys, so
the node is not updated and the handler lambda the coroutine was started with is the one it keeps.
That lambda closes over one composition's `columnItems` — the previous document's line spans — and
also its `density`, `hasGutters`, `gutterWidthDp`, `contentTopPaddingPx` and `wrapLines`.

Fixed by reading the latest resolver through `rememberUpdatedState`, which is **already the idiom
in this composable** (`currentColumnItems`, used by the cursor overlay for the same reason). Two
alternatives were considered and rejected:

- **Re-keying `pointerInput` on the document** would restart the gesture coroutine on every
  document change, cancelling an in-progress drag selection whenever the document changed under it
  — a worse bug than the one being fixed, and it discards the reason the key is `session` today.
- **Clamping to `doc.length`** would stop the throw and put the caret at the end of the document
  instead of on the line that was clicked. This PR asserts the exact offset precisely so that a
  clamp cannot pass.

## What happens to a click that arrives genuinely mid-update

There is a narrower window the resolver fix does not close: pointer events are delivered before a
frame's composition, so a document replaced from outside a gesture (an LSP edit, a collab update,
`setDoc` from a coroutine) can land between the event and the recomposition that re-derives the
layout. Everything the resolver reads is then self-consistent but describes the *previous*
document, and there is no honest mapping from such a position into the new one.

`resolvePos` therefore **drops** a result the current document cannot contain — returns null,
which every call site already handles (the tap becomes a no-op, the drop-cursor hides, the hover
tooltip clears). The click is lost and the next one, against a settled layout, lands correctly.
That is deliberately not a clamp: losing a click is recoverable and visible to the user, a caret
silently placed where they did not click is neither.

**This gate is reasoned, not demonstrated, and it carries no test of its own.** The race cannot be
synthesised in `runComposeUiTest` — `performMouseInput` pumps a frame before delivering the event,
so a probe that calls `setDoc` and clicks with no `waitForIdle` in between still recomposes first
and resolves correctly (measured: cursor lands at 2, not the stale 201). It is exercised
incidentally by mutation 1 below.

## Tests

`view/src/commonTest/.../input/DocReplacementClickTest.kt`, two tests, both asserting an **exact
offset** rather than absence-of-throw.

**Where they actually execute:** `commonTest`, so the JVM (`:view:jvmTest`) and wasmJs
(`:view:wasmJsBrowserTest`) suites, plus the native suites in `check-macos`/`check-ios`. The
`view.input.*` package is excluded from every `*UnitTest` task (`view/build.gradle.kts:74-76`), so
on Android they compile but run only in the instrumented suite, not in local unit tests.

- Red first: `clickAfterReplacingWithShorterDoc` fails on unmodified `main` with the exception
  quoted above. Green after the fix.
- Both directions: `clickWithoutReplacement` clicks the same coordinate on the same document with
  no replacement and asserts the same offset 2, so the fix cannot pass by turning ordinary clicks
  into no-ops.

Mutation controls, each naming the line it perturbs:

| mutation | result |
| --- | --- |
| `KodeMirror.kt:671` tap reverted to the stale `resolvePos`, bounds gate kept | `clickAfterReplacingWithShorterDoc` FAILS `Expected cursor at 2 but was at 0` (the click is dropped, not misplaced) — this is the check that a drop-only or clamp-only fix cannot pass; `clickWithoutReplacement` still passes |
| final expression of `resolvePos` changed to `pos?.takeIf { false }` (drop everything) | both tests FAIL `Expected cursor at 2 but was at 0` — the ordinary-click direction is genuinely guarded |
| wasm negative control: expected offset changed to 999 | wasm suite FAILS `Expected cursor at 999 but was at 2` — the assertion really evaluates in the browser runner, and resolves to the correct offset there |

## Verification

Run with `build/test-results/<task>/` deleted first and the XML read back, not the exit code.

- `:view:jvmTest` — 331 tests, 0 failures, 0 skipped
- `:view:wasmJsBrowserTest` — 298 tests, 0 failures, 0 skipped (ChromeHeadless)
- `:view:apiCheck` — passes, **no `api/*.api` movement**; the change adds no public declarations
- `:view:spotlessApply` / `:view:ktlintFormat` — clean
- `changelog.py check --base-ref origin/main` — 9 fragments valid, `CHANGELOG.md` untouched

No test in this PR carries a `parity:` comment, and none of the tests it touches does — the file
is new and no existing test was changed.

## On #259 — measured, and the hypothesis is refuted

#313's mechanism predicts the `Expected cursor at 11 but was at 0` signature of the thirteen
long-standing Android instrumented failures (#259/#275), because a null `resolvePos` makes the tap
handler dispatch nothing. **It does not explain them.** This branch's instrumented run
([34079418854](https://github.com/Monkopedia/kodemirror/actions/runs/34079418854)) reports
`102 executed, 13 failed, 0 skipped` — the denominator moved `100 -> 102` from the two tests added
here, and the failing **set is identical to the one recorded by name on #275**, compared name by
name rather than by count. None of the thirteen moved.

The same run carries a stronger datum: the two new `DocReplacementClickTest` cases **pass on the
emulator**, asserting an exact click-driven cursor offset, as do `ClickTargetingTest` (8) and
`DragSelectionTest` (4). So a click on that device does resolve to a non-null position and does
dispatch the correct selection — which rules out the null-resolver reading of `cursor at 0`.
Written up on #259; no label or state changed there.

The instrumented job is red on this PR at the pre-existing baseline and is not one of the three
required checks.
