### PR TITLE
Make verifyBomCoverage fail on BOM version drift (#300)

### DIFF
--- a/changelog.d/300.build.md
+++ b/changelog.d/300.build.md
@@ -1,0 +1,8 @@
+- The BOM drift guard (`:kodemirror-bom:verifyBomCoverage`) now also checks the **versions** in the
+  generated BOM POM, not just the artifactIds (#300). The project version is written as two
+  independent literals — one in the `kodemirror.library` convention plugin (every library module)
+  and one in `kodemirror-bom/build.gradle.kts` (the BOM's own coordinate) — and the release process
+  asks a human to edit both. Editing only one produced a BOM published at X that constrained all 56
+  modules at Y: it resolves cleanly and silently hands consumers the previous release, and the
+  guard reported success. The guard now parses whole `<dependency>` blocks and fails if any
+  constrained `<version>` differs from the BOM's own, naming the mismatched version and modules.

--- a/kodemirror-bom/build.gradle.kts
+++ b/kodemirror-bom/build.gradle.kts
@@ -53,6 +53,19 @@ dependencies {
 // silently produces nothing (e.g. the publish plugin id changes). The expected set is every
 // module applying the `kodemirror.library` convention plugin, minus the documented exclusions;
 // that is a deliberately different criterion from the one the derivation uses.
+//
+// It guards TWO independent kinds of drift, because the POM can be wrong in two ways:
+//
+//  1. the set of constrained artifactIds not matching the set of published modules (#244);
+//  2. a constrained `<version>` not matching the BOM's own version (#300).
+//
+// (2) exists because the project version is written out twice, as two independent string
+// literals — `convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts` (which sets the
+// version of all library modules, and therefore of every constraint here) and the `version =`
+// line above (the BOM's own coordinate). The release process instructs a human to edit both.
+// Editing only one publishes a BOM at X whose constraints all say Y: it resolves cleanly and
+// silently hands consumers the *previous* release, which is worse than #244's hard resolution
+// failure because nothing surfaces it.
 val expectedBomModules = provider {
     rootProject.subprojects
         .filter {
@@ -71,22 +84,36 @@ val pomTasks = tasks.withType<GenerateMavenPom>()
 val verifyBomCoverage = tasks.register("verifyBomCoverage") {
     group = "verification"
     description =
-        "Fails if the generated BOM POM does not constrain exactly the published modules."
+        "Fails if the generated BOM POM does not constrain exactly the published modules, " +
+            "each at the BOM's own version."
     dependsOn(pomTasks)
     val pomFiles = provider { pomTasks.map { it.destination } }
     val expected = expectedBomModules
+    // Read at configuration time: `project` must not be touched from a task action.
+    val bomVersion = project.version.toString()
     inputs.files(pomFiles)
     inputs.property("expectedModules", expected)
+    inputs.property("bomVersion", bomVersion)
     doLast {
         val pom = pomFiles.get().single().readText()
         val managed = Regex(
             "<dependencyManagement>(.*?)</dependencyManagement>",
             RegexOption.DOT_MATCHES_ALL
         ).find(pom)?.groupValues?.get(1).orEmpty()
-        val declared = Regex("<artifactId>([^<]+)</artifactId>")
+        // Parse whole `<dependency>` blocks rather than bare `<artifactId>`s, so the artifactId
+        // and the version that ships beside it stay associated. A missing `<version>` maps to
+        // the empty string, which can never equal `bomVersion` and so is reported rather than
+        // silently accepted.
+        val constrained = Regex("<dependency>(.*?)</dependency>", RegexOption.DOT_MATCHES_ALL)
             .findAll(managed)
             .map { it.groupValues[1] }
-            .toSortedSet()
+            .map { entry ->
+                fun tag(name: String) =
+                    Regex("<$name>([^<]*)</$name>").find(entry)?.groupValues?.get(1).orEmpty()
+                tag("artifactId") to tag("version")
+            }
+            .toList()
+        val declared = constrained.map { it.first }.toSortedSet()
         val expectedModules = expected.get()
         check(expectedModules.isNotEmpty()) {
             "No published modules were detected — the BOM constraint derivation is broken."
@@ -110,7 +137,39 @@ val verifyBomCoverage = tasks.register("verifyBomCoverage") {
                 )
             }
         }
-        logger.lifecycle("kodemirror-bom constrains all ${declared.size} published modules.")
+        // Every constraint is a kodemirror module, so requiring the BOM's own version of all of
+        // them is exact rather than approximate: the coverage check above runs first and already
+        // rejects anything "in the BOM but NOT published", so a third-party constraint could
+        // never reach here and be mistaken for drift.
+        val mismatched = constrained.filter { it.second != bomVersion }
+        check(mismatched.isEmpty()) {
+            buildString {
+                appendLine(
+                    "kodemirror-bom constrains modules at a version other than its own (#300)."
+                )
+                appendLine("  kodemirror-bom version: $bomVersion")
+                appendLine("  mismatched constraints: ${mismatched.size} of ${constrained.size}")
+                mismatched
+                    .groupBy({ it.second }, { it.first })
+                    .toSortedMap()
+                    .forEach { (version, modules) ->
+                        val shown = if (version.isEmpty()) "<no version element>" else version
+                        appendLine(
+                            "  constrained at $shown (${modules.size}): " +
+                                modules.sorted().joinToString()
+                        )
+                    }
+                appendLine(
+                    "  The project version is two independent literals: " +
+                        "convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts " +
+                        "(every library module) and kodemirror-bom/build.gradle.kts (the BOM " +
+                        "itself). Set both to the same value."
+                )
+            }
+        }
+        logger.lifecycle(
+            "kodemirror-bom constrains all ${declared.size} published modules at $bomVersion."
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #300

## The defect

`verifyBomCoverage` is the #244 BOM-drift guard — named explicitly in `ci.yml` and required by
branch protection. It parsed the generated POM for `<artifactId>` only and never looked at
`<version>`.

The project version exists as **two independent string literals**:

- `convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts:41` — sets the version of every
  library module, and therefore of every constraint the BOM derives;
- `kodemirror-bom/build.gradle.kts:10` — the BOM's own coordinate.

The release process (`CLAUDE.md` step 1) instructs a human to edit both. Edit one and not the other
and you publish a BOM at X constraining all 56 modules at Y. That is worse than #244: #244 gave the
consumer a hard resolution failure, this resolves cleanly and silently hands them the *previous*
release.

## The fix

`doLast` now parses whole `<dependency>` blocks rather than bare `<artifactId>`s, so each artifactId
stays associated with the version shipping beside it, and `check`s that every constrained
`<version>` equals the BOM's own version. A missing `<version>` maps to the empty string, which can
never equal the BOM version, so it is reported rather than silently accepted.

`project.version` is read at configuration time and registered as a task input, alongside the
existing `expectedModules` input.

The artifactId coverage check is unchanged.

## Verification — all four controls, run in order

**1. Positive control (the issue's premise still holds at `origin/main` @ `8a308c59`).**
Unmodified tree, only `kodemirror-bom/build.gradle.kts:10` changed to `version = "0.3.7"`:

```
> Task :kodemirror-bom:verifyBomCoverage
kodemirror-bom constrains all 56 published modules.
BUILD SUCCESSFUL in 9s

$ grep -o '<version>[^<]*' kodemirror-bom/build/publications/maven/pom-default.xml | sort | uniq -c
     56 <version>0.3.6
      1 <version>0.3.7
```

Reproduced exactly as reported.

**2. Negative control — the same one-line drift, with this fix in place. The guard now FAILS:**

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':kodemirror-bom:verifyBomCoverage' (registered in build file 'kodemirror-bom/build.gradle.kts').
> kodemirror-bom constrains modules at a version other than its own (#300).
    kodemirror-bom version: 0.3.7
    mismatched constraints: 56 of 56
    constrained at 0.3.6 (56): autocomplete, basic-setup, collab, commands, lang-angular, lang-cpp, lang-css, lang-go, lang-grammar, lang-html, lang-java, lang-javascript, lang-jinja, lang-json, lang-less, lang-liquid, lang-markdown, lang-php, lang-python, lang-rust, lang-sass, lang-sql, lang-vue, lang-wast, lang-xml, lang-yaml, language, legacy-modes, lezer-common, lezer-highlight, lezer-lr, lint, lsp-client, material-theme, merge, search, state, theme-amy, theme-ayu-light, theme-barf, theme-bespin, theme-birds-of-paradise, theme-boys-and-girls, theme-clouds, theme-cobalt, theme-cool-glow, theme-dracula, theme-espresso, theme-noctis-lilac, theme-one-dark, theme-rose-pine-dawn, theme-smoothy, theme-solarized-light, theme-tomorrow, view, vim
    The project version is two independent literals: convention-plugins/src/main/kotlin/kodemirror.library.gradle.kts (every library module) and kodemirror-bom/build.gradle.kts (the BOM itself). Set both to the same value.

BUILD FAILED in 4s
```

**3. No false positive.** Drift reverted, `git status` clean:

```
kodemirror-bom constrains all 56 published modules at 0.3.6.
BUILD SUCCESSFUL in 4s
```

56 constraints parsed by the new `<dependency>`-block regex — the same count the old
artifactId-only regex found, so the new parse is not under-matching.

**4. #244 not regressed.** Dropped one module (`search`) from the constraint derivation only:

```
> kodemirror-bom does not match the set of published modules (#244).
    expected constraints: 56
    BOM constraints:      55
    published but NOT in the BOM: search
    deliberately excluded: kodemirror-test (#240 — undecided whether to delete or rebuild the published coordinate)

BUILD FAILED in 6s
```

Reverted; tree clean.

Also green: `spotlessApply` (no reformatting of the edited file), `ktlintCheck`, `apiCheck`,
`python3 .github/scripts/changelog.py check --base-ref origin/main`.

## Stage 2 (single-sourcing the version) — deliberately NOT done here

The issue offers single-sourcing the literal as an optional stage 2. I did not do it, on purpose,
and it is not a prerequisite for the guard above.

`convention-plugins` is a separate included build, so the two literals cannot simply share one.
More decisively, the BOM's `version =` line is **load-bearing outside the build**:

```
.github/workflows/deploy.yml:72:  VERSION=$(grep -E '^version = ' kodemirror-bom/build.gradle.kts | sed -E 's/.*"([^"]+)".*/\1/')
docs/release-checklist.md:38,113,180,183
CLAUDE.md:97
```

`deploy.yml` derives the tag it publishes and verifies (`--verify-tag`) from that exact line.
Replacing the literal with a property lookup silently breaks that grep, and rewriting it means
editing the authoritative release process in `CLAUDE.md` and its checklist — a release-path change
that wants an owner decision, not a rider on a guard fix. Filed separately as #317 so it is not lost.

Note that the guard here is **not** made redundant by single-sourcing: it asserts the property on
the artifact that actually ships, so it keeps holding if a second literal is ever reintroduced.

## Blast radius

Build logic only. No source change, no public API, no change to any published artifact's contents.
`main` passes as written (all 57 versions agree), so it lands green.

---

## Note on the two force-pushes (branch is now FINAL at `1e0768d6`)

The head moved twice shortly after opening, before any review started. Neither amend was a fix to
a hole in the guard — both were documentation of correctness properties that were already true:

- `1097673c` → `259658dd`: added a comment recording *why* the version check may assume every
  constraint is a kodemirror module — the #244 coverage check runs first and already rejects
  anything "in the BOM but NOT published", so a third-party constraint can never reach the version
  check and be misreported as drift. Comment only.
- `259658dd` → `1e0768d6`: the task's own `description` (what `./gradlew tasks` prints) still read
  "does not constrain exactly the published modules" and no longer described what the task checks.
  String only.

`git diff 1097673c 1e0768d6 -- kodemirror-bom/build.gradle.kts` is exactly those two hunks: **no
executable logic changed across the three SHAs.**

All three controls were nevertheless re-run against the final tree `1e0768d6` rather than assumed
to carry over, and all three reproduce the outputs quoted above verbatim: version drift → `#300`
failure; `search` dropped from the constraint derivation → `#244` failure; unmodified tree → passes
with 56 constraints at 0.3.6. `git status` clean after each.

No further force-pushes are planned; this SHA is final.
