### PR TITLE
Run ktlintCheck and spotlessCheck in the gating CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,20 @@ jobs:
       # `:kodemirror-bom:verifyBomCoverage` checks the generated BOM POM against the set of
       # modules that publish, failing on drift in either direction (#244). It is named here
       # because this job does not run `check`.
+      #
+      # `ktlintCheck` and `spotlessCheck` are named for the same reason, and are named *here*
+      # rather than in a job of their own because this is the only Linux job in `main`'s branch
+      # protection (which requires `check`, `check-macos` and `check-ios`). Until #299 neither
+      # task appeared in any workflow file: both hang off `check`, which this job deliberately
+      # does not run, so listing tasks explicitly had silently dropped them. `spotlessCheck` is
+      # the consequential one -- it is what applies `spotless/license-header.kt` over
+      # `src/**/*.kt` in all 57 modules, and that header carries both the Apache-2.0 notice and
+      # the "Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT" line this
+      # MIT-derived port is obliged to keep. A source file stripped of its header passed every
+      # gating task before this line existed. `ktlintCheck` is a separate tool with separate
+      # rules (.editorconfig), so both names are needed; neither compiles anything, and together
+      # they add ~25s to a job that already pays for configuration.
+      #
       # The wasmJsTest tasks below are exactly the modules that opt in via
       # `kodemirrorLibrary { wasmJsTests.set(true) }`; they are listed one by one so that a
       # module dropping out of the opt-in set shows up as a diff here rather than as a silent
@@ -52,7 +66,7 @@ jobs:
       # docs.yml: linking ~29 wasm test binaries OOMs the Kotlin daemon at the 2g default.
       - name: Lint and test (JVM + wasmJs + Android)
         run: >-
-          ./gradlew apiCheck jvmTest :kodemirror-bom:verifyBomCoverage
+          ./gradlew apiCheck ktlintCheck spotlessCheck jvmTest :kodemirror-bom:verifyBomCoverage
           -Dkotlin.daemon.jvmargs="-Xmx4g"
           -Dorg.gradle.jvmargs="-Xmx4g -Dfile.encoding=UTF-8"
           :view:verifyRoborazziJvm

--- a/changelog.d/299.build.md
+++ b/changelog.d/299.build.md
@@ -1,0 +1,10 @@
+- CI now runs `ktlintCheck` and `spotlessCheck` in the branch-protection-required `check` job
+  (#299). Both hang off Gradle's `check`, which that job deliberately does not run, so naming
+  its tasks explicitly had dropped them: neither appeared in any workflow file, and a source
+  file stripped of its license header passed every gating task. `spotlessCheck` is what applies
+  `spotless/license-header.kt` over `src/**/*.kt` in all 57 modules, so the Apache-2.0 notice
+  and the "Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT"
+  attribution this port is obliged to carry were enforced only by developer discipline. The
+  tree was already compliant -- 57 modules, 563 Kotlin files, ~136k lines pass unchanged -- so
+  this is enforcement only, with no reformatting in front of it. It compiles nothing and adds
+  about 25s to a job that already pays for configuration.


### PR DESCRIPTION
## The hole

`ci.yml`'s `check` job — the only Linux job in `main`'s branch protection — ran no style or
license check at all. `ktlintCheck` and `spotlessCheck` appeared in **zero** workflow files.
Both hang off Gradle's `check`, which the job deliberately does not run (`ci.yml` says so at
the comment above the `run:` line), so naming tasks explicitly silently dropped them.

Re-confirmed at `origin/main` @ `fb3cf400`:

```
$ grep -rn "ktlint\|spotless" .github/workflows/
$ echo $?
1
```

(positive control: the same grep for `gradlew` over the same path returns nine hits, so the
empty result above is a real absence and not a broken pattern.)

Branch protection requires exactly `["check","check-macos","check-ios"]`
(`gh api repos/Monkopedia/kodemirror/branches/main/protection`). None of the three ran either
task.

The consequential half is `spotlessCheck`: the convention plugin
(`kodemirror.library.gradle.kts:221-226`) applies
`licenseHeaderFile(rootProject.file("spotless/license-header.kt"))` over `src/**/*.kt` in all
57 modules, and that header carries the Apache-2.0 notice **and** the "Originally based on
CodeMirror 6 by Marijn Haverbeke, licensed under MIT. See NOTICE file for details."
attribution. This is an MIT-derived port; that line is a licensing obligation. Nothing
verified it.

## The change

Two task names on the existing gating `run:` line, plus the comment explaining why they are
named there. `check` is the required context, so the enforcement lands **inside** branch
protection — deliberately not a new job, which would reproduce the same hole one level down
(`ci.yml`'s `lint` job is already an example of a check that runs and gates nothing).

No source change. No `apiCheck` surface. No reformatting commit in front of it.

## The tree was already clean

`./gradlew ktlintCheck spotlessCheck` at `origin/main` is **green with zero violations**, so
this PR carries no mass-format diff. Drift count: **0**.

Coverage, positive-controlled rather than asserted — the task ran in 57 projects, which is
exactly the set applying the `kodemirror.library` convention plugin (`comm` of the two lists
is empty in both directions):

| | |
|---|---|
| modules running `spotlessCheck` | 57 |
| modules running `ktlintCheck` | 57 |
| distinct ktlint source-set tasks | 1568, over 24 source-set kinds (`commonMain`, `jvmMain`, `wasmJsMain`, `androidMain`, `appleMain`, `iosMain`, `macosMain`, `nativeMain`, `webMain`, `jvmDev` + their `*Test` twins) |
| Kotlin files under those modules' `src/` | 563 |
| lines | ~136,020 |

(`samples/*` does not apply the convention plugin, so its 46 files are outside both tasks
today. Pre-existing and out of scope here; filed separately.)

## Verification — both negative controls, run with this change in place

**1. Strip the license header** from `state/…/CharCategory.kt` and run the gating tasks:

```
$ ./gradlew apiCheck ktlintCheck spotlessCheck
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':state:spotlessKotlinCheck' (registered by plugin 'kodemirror.library').
> The following files had format violations:
      src/commonMain/kotlin/com/monkopedia/kodemirror/state/CharCategory.kt
          @@ -1,3 +1,21 @@
          +/*
          +·*·Copyright·2026·Jason·Monk
          ...
          +·*·Originally·based·on·CodeMirror·6·by·Marijn·Haverbeke,·licensed·under·MIT.
          +·*·See·NOTICE·file·for·details.
          +·*/
           package·com.monkopedia.kodemirror.state
  Run './gradlew spotlessApply' to fix all violations.
BUILD FAILED in 2m 51s
```

Every `ktlintCheck` task passed in that same run — ktlint does not enforce the header, which
is why both names are needed and not just one.

**2. Introduce a ktlint violation** (8-space indent), header intact:

```
$ ./gradlew ktlintCheck spotlessCheck
> Task :state:ktlintCommonMainSourceSetCheck FAILED
/…/state/src/commonMain/kotlin/com/monkopedia/kodemirror/state/CharCategory.kt:30:1 Unexpected indentation (8) (should be 4)
* What went wrong:
Execution failed for task ':state:ktlintCommonMainSourceSetCheck' (registered by plugin 'org.jlleitschuh.gradle.ktlint').
> KtLint found code style violations.
BUILD FAILED in 19s
```

Every `spotlessCheck` task was `UP-TO-DATE`/green in that run — the two tools are genuinely
independent and both are now wired.

**3. No false positive.** Both files restored; clean tree passes:

```
$ ./gradlew ktlintCheck spotlessCheck --rerun-tasks
BUILD SUCCESSFUL in 28s
490 actionable tasks: 490 executed
```

`--rerun-tasks` is deliberate: an up-to-date green is exactly the inert-control failure mode
this repo keeps hitting (#197, #263), so the passing run above executed all 490 tasks from
scratch.

## Cost

Measured on this machine, whole repo:

- warm daemon, incremental: **~22–28s**
- cold daemon, `--rerun-tasks --no-build-cache`: **1m 05s** wall, of which ~35–40s is JVM
  start plus configuration that the job already pays for in the same invocation

Neither task compiles anything, and they run in the same Gradle invocation as `apiCheck` /
`jvmTest`, so they reuse the configured build. Realistic added wall time on `check`: **under a
minute**, against a job whose `apiCheck` phase alone took 2m 51s locally.

## Not done

Nothing in the ruleset was relaxed — no new spotless exclusions, no ktlint rule disabled, no
`.editorconfig` change. The enforcement goes green because the tree complies, not because the
enforcement was narrowed.

Fixes #299
