### PR TITLE
Select text on a long-press touch drag (#311)

### DIFF
--- a/changelog.d/311.fixed.md
+++ b/changelog.d/311.fixed.md
@@ -1,0 +1,9 @@
+- Touch drag now selects text after a long press (#311). Dragging a finger across the editor
+  extended no selection: the line list (`LazyColumn`) and the line content (`horizontalScroll`) are
+  children of the node carrying the editor's gesture, so they saw the pointer first, and
+  `scrollable` claims any drag whose pointer is not a mouse — which is why the same drag with a
+  mouse selected normally. Taking the drag back outright would have cost touch scrolling, so the
+  editor now waits: a press held past the long-press timeout anchors a selection at that position
+  and the moves after it are consumed ahead of the scroll containers, while a press that travels
+  first still scrolls. This matches CodeMirror 6 on mobile, where a plain drag scrolls and a long
+  press begins a selection.

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/InputHandling.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/InputHandling.kt
@@ -28,6 +28,10 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import com.monkopedia.kodemirror.state.ChangeSpec
 import com.monkopedia.kodemirror.state.DocPos
 import com.monkopedia.kodemirror.state.EditorSelection
@@ -657,3 +661,55 @@ internal fun handleRectangularDrag(
         )
     )
 }
+
+/**
+ * What a press did while the editor waited to see whether it was a long press.
+ *
+ * @see awaitTouchLongPress
+ */
+internal enum class TouchHoldOutcome {
+    /** Held in place past the long-press timeout — the editor claims the drag. */
+    LongPress,
+
+    /** Travelled past the touch slop first — the gesture belongs to whoever else wants it. */
+    Moved,
+
+    /** Lifted before the timeout — an ordinary tap. */
+    Released
+}
+
+/**
+ * Wait out the long-press timeout on [pointerId], reporting what the pointer did.
+ *
+ * Observes in [PointerEventPass.Initial] — ahead of the children — but consumes
+ * nothing, so a press that turns into a drag before the timeout is still the
+ * enclosing scroll containers' to claim. That is the whole point of the wait:
+ * a touch drag over the editor scrolls the line list (vertically) or the line
+ * content (horizontally), and only a drag that begins from a long press is a
+ * text selection, as CodeMirror 6 behaves on mobile (#311).
+ *
+ * Returns [TouchHoldOutcome.Released] rather than leaving the caller to
+ * discover the lift for itself: after this returns the pointer may already be
+ * up, and a caller that then awaited another event for it would hang instead
+ * of handling the tap.
+ */
+internal suspend fun AwaitPointerEventScope.awaitTouchLongPress(
+    pointerId: PointerId,
+    downPosition: Offset,
+    slop: Float,
+    timeoutMillis: Long
+): TouchHoldOutcome = withTimeoutOrNull(timeoutMillis) {
+    while (true) {
+        val event = awaitPointerEvent(PointerEventPass.Initial)
+        val change = event.changes.firstOrNull { it.id == pointerId }
+            ?: return@withTimeoutOrNull TouchHoldOutcome.Released
+        if (change.changedToUpIgnoreConsumed()) {
+            return@withTimeoutOrNull TouchHoldOutcome.Released
+        }
+        if ((change.position - downPosition).getDistance() > slop) {
+            return@withTimeoutOrNull TouchHoldOutcome.Moved
+        }
+    }
+    @Suppress("UNREACHABLE_CODE")
+    TouchHoldOutcome.Moved
+} ?: TouchHoldOutcome.LongPress

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
@@ -80,6 +80,8 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.layout
@@ -610,6 +612,87 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
                             var isDrag = false
                             var dragStart = downPosition
                             var dragCurrent = downPosition
+
+                            // A touch drag is not ours to take. The line list
+                            // (LazyColumn) and the line content
+                            // (horizontalScroll) are children of this node, so
+                            // they see the Main pass first and `scrollable`
+                            // claims any drag whose pointer is not a mouse —
+                            // which is exactly why a mouse drag selects here and
+                            // a finger drag did not (#311). Scrolling with a
+                            // finger must keep working, so instead of taking the
+                            // drag back, wait: a press held in place past the
+                            // long-press timeout starts a selection and the
+                            // moves after it are consumed in the Initial pass,
+                            // ahead of the scroll containers. That is CodeMirror
+                            // 6's mobile behaviour too — a plain drag scrolls,
+                            // a long press begins a selection.
+                            val hold = if (down.type != PointerType.Mouse) {
+                                awaitTouchLongPress(
+                                    down.id,
+                                    downPosition,
+                                    viewConfiguration.touchSlop,
+                                    viewConfiguration.longPressTimeoutMillis
+                                )
+                            } else {
+                                // A mouse never waits: `scrollable` ignores
+                                // mouse drags, so this one was always ours.
+                                TouchHoldOutcome.Moved
+                            }
+
+                            if (hold == TouchHoldOutcome.LongPress) {
+                                // Anchor the selection where the finger has been
+                                // resting, then extend it for as long as the
+                                // finger moves.
+                                handleDrag(
+                                    session,
+                                    downPosition,
+                                    downPosition,
+                                    currentResolvePos
+                                )
+                                session.plugin(dropCursorViewPlugin)
+                                    ?.moveTo(currentResolvePos(downPosition))
+                                while (true) {
+                                    val event = awaitPointerEvent(
+                                        PointerEventPass.Initial
+                                    )
+                                    val change = event.changes.firstOrNull {
+                                        it.id == down.id
+                                    } ?: break
+                                    // Consuming in the Initial pass is what
+                                    // keeps the scroll containers out: they read
+                                    // the Main pass and skip a change that is
+                                    // already consumed.
+                                    change.consume()
+                                    if (change.changedToUpIgnoreConsumed()) break
+                                    dragCurrent = change.position
+                                    handleDrag(
+                                        session,
+                                        downPosition,
+                                        dragCurrent,
+                                        currentResolvePos
+                                    )
+                                    session.plugin(dropCursorViewPlugin)
+                                        ?.moveTo(currentResolvePos(dragCurrent))
+                                }
+                                session.plugin(dropCursorViewPlugin)
+                                    ?.moveTo(null)
+                                return@awaitEachGesture
+                            }
+
+                            if (hold == TouchHoldOutcome.Released) {
+                                // Lifted before the timeout: the pointer is
+                                // already up, so there is no slop to wait for.
+                                val pos = currentResolvePos(downPosition)
+                                    ?: return@awaitEachGesture
+                                session.dispatch(
+                                    TransactionSpec(
+                                        selection = SelectionSpec
+                                            .CursorSpec(DocPos(pos))
+                                    )
+                                )
+                                return@awaitEachGesture
+                            }
 
                             // Try to detect if this becomes a drag
                             val slopChange = awaitTouchSlopOrCancellation(

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/TouchGestureTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/TouchGestureTest.kt
@@ -203,4 +203,61 @@ class TouchGestureTest {
                 "selected, but the first visible item moved"
         )
     }
+
+    /**
+     * A long-press drag *along* a line wider than the viewport selects and does
+     * not scroll the line under the finger.
+     *
+     * This is the case the two vertical tests cannot reach, and the one that
+     * makes the drag loop's [PointerEventPass.Initial] load-bearing rather than
+     * merely principled: the `LazyColumn` happens to leave the gesture alone
+     * either way, but the `horizontalScroll` container does not. Consuming in
+     * the Main pass instead lets it take the same drag — measured at 2358px of
+     * scroll, with the selection landing on the offsets that scrolled text
+     * happened to be under — so without this test a refactor to `Main` would
+     * pass the suite green and silently break selecting on a long line.
+     *
+     * The two assertions are both font-metric independent, which is what lets
+     * the same literals hold on JVM, in a browser and on a device: the scroll
+     * offset is a pixel count that must not move at all, and the drag ends at
+     * x=8, inside the content's 6dp start padding, so its head is the line's
+     * first character exactly. The anchor is left unpinned on purpose — where
+     * x=300 falls in the text depends on the platform's font — and is reported
+     * in the failure message instead.
+     */
+    @Test
+    fun longPressThenHorizontalDragSelectsWithoutScrollingTheLine() = runEditorTest(
+        doc = "A very long line ".repeat(40) + "\nsecond\nthird"
+    ) { holder ->
+        onNodeWithTag("KodeMirror").performTouchInput {
+            down(Offset(300f, 8f))
+            repeat(10) {
+                advanceEventTime(viewConfiguration.longPressTimeoutMillis / 5)
+                moveTo(Offset(300f, 8f))
+            }
+            moveTo(Offset(220f, 8f))
+            moveTo(Offset(140f, 8f))
+            moveTo(Offset(60f, 8f))
+            moveTo(Offset(8f, 8f))
+            up()
+        }
+        waitForIdle()
+        val sel = holder.session.state.selection.main
+        assertEquals(
+            0,
+            holder.horizontalScrollPx(),
+            "Expected the line not to scroll under a long-press drag along it, " +
+                "but the content scrolled (selection was $sel)"
+        )
+        assertEquals(
+            0,
+            sel.head.value,
+            "Expected the drag to end on the line's first character, but got $sel"
+        )
+        assertTrue(
+            sel.anchor.value > 0,
+            "Expected the selection anchored where the long press landed, " +
+                "further into the line than its start, but got $sel"
+        )
+    }
 }

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/TouchGestureTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/TouchGestureTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
@@ -64,13 +65,13 @@ class TouchGestureTest {
     }
 
     /**
-     * A horizontal touch drag over the editor does not extend a selection: the
-     * line content sits in a horizontal scroll container, which claims the drag
-     * before the editor's gesture sees it, and the gesture falls back to placing
-     * the cursor at the down position. That is pre-existing behaviour, measured
-     * identical before and after the #303 pointer-down consume, and it is
-     * characterised here so a change to it is caught rather than shipped —
-     * touch drag-selection itself is tracked separately.
+     * A horizontal touch drag that does *not* begin with a long press still
+     * belongs to the horizontal scroll container the line content sits in: the
+     * gesture falls back to placing the cursor at the down position and selects
+     * nothing. That was the whole of the behaviour before #311 and is now the
+     * deliberate half of it — dragging a finger over a line too wide for the
+     * viewport has to scroll it, since touch has no wheel. Selecting with a
+     * finger goes through [longPressThenTouchDragSelectsAcrossLines] instead.
      */
     @Test
     fun horizontalTouchDragPlacesCursorAndLeavesDocument() =
@@ -119,6 +120,87 @@ class TouchGestureTest {
             after > before,
             "Expected a vertical touch drag to scroll the line list " +
                 "(firstVisibleIndex $before -> $after)"
+        )
+    }
+
+    /**
+     * A long press followed by a touch drag selects text, like CodeMirror 6 on
+     * mobile. The drag is claimed away from the enclosing scroll containers only
+     * once the long press has fired, so a plain drag still scrolls (#311).
+     *
+     * The coordinates are chosen to be font-metric independent: x=8 is just
+     * inside the content's 6dp start padding, so every press resolves to the
+     * first character of its line, and the assertion is an exact anchor/head
+     * pair rather than "something is selected".
+     */
+    @Test
+    fun longPressThenTouchDragSelectsAcrossLines() = runEditorTest(doc = threeLineDoc) { holder ->
+        onNodeWithTag("KodeMirror").performTouchInput {
+            down(Offset(8f, 8f))
+            // Hold still past the long-press timeout, emitting moves the
+            // way `longClick` does so the gesture stays alive.
+            repeat(10) {
+                advanceEventTime(viewConfiguration.longPressTimeoutMillis / 5)
+                moveTo(Offset(8f, 8f))
+            }
+            moveTo(Offset(8f, 35f))
+            moveTo(Offset(8f, 55f))
+            up()
+        }
+        waitForIdle()
+        val sel = holder.session.state.selection.main
+        assertEquals(
+            0,
+            sel.anchor.value,
+            "Expected the selection anchored at the long-pressed position, " +
+                "but got $sel"
+        )
+        assertEquals(
+            18,
+            sel.head.value,
+            "Expected the selection head at the start of line 3, but got $sel"
+        )
+    }
+
+    /**
+     * The same long-press drag over a document taller than the viewport selects
+     * text and leaves the line list where it was. This is the half of #311 the
+     * three-line case cannot show: there is nothing there to scroll, so the
+     * gesture would look the same whether or not the editor actually claimed it.
+     * Here the LazyColumn takes this very drag when it is not preceded by a long
+     * press — the same three moves without the hold scroll it twelve lines and
+     * leave the caret at 60 — so both the exact anchor/head pair and the unmoved
+     * first-visible index say the editor took the gesture away from it.
+     */
+    @Test
+    fun longPressThenTouchDragSelectsWithoutScrollingTheList() = runEditorTest(
+        doc = fiftyLineDoc,
+        height = 300
+    ) { holder ->
+        onNodeWithTag("KodeMirror").performTouchInput {
+            down(Offset(8f, 55f))
+            repeat(10) {
+                advanceEventTime(viewConfiguration.longPressTimeoutMillis / 5)
+                moveTo(Offset(8f, 55f))
+            }
+            moveTo(Offset(8f, 40f))
+            moveTo(Offset(8f, 25f))
+            moveTo(Offset(8f, 8f))
+            up()
+        }
+        waitForIdle()
+        val sel = holder.session.state.selection.main
+        assertEquals(
+            40 to 0,
+            sel.anchor.value to sel.head.value,
+            "Expected a selection anchored at the start of line 3 and headed at " +
+                "the start of line 1, but got $sel"
+        )
+        assertEquals(
+            0,
+            holder.firstVisibleIndex(),
+            "Expected the line list not to scroll while the long-press drag " +
+                "selected, but the first visible item moved"
         )
     }
 }


### PR DESCRIPTION
Fixes #311.

## The defect

Dragging a finger across the editor extended no selection — the gesture fell back to placing the
cursor at the down position. The same drag with a mouse selected normally.

The line list (`LazyColumn`) and the line content (`horizontalScroll`) are children of the node
carrying the editor's gesture, so they see the Main pass first, and Compose's `scrollable` claims
any drag whose pointer is **not a mouse** (`DragGestureNode`'s `canDrag`). That is exactly the
asymmetry reported: `scrollable` consumes the move, the editor's `awaitTouchSlopOrCancellation`
sees a consumed change and returns `null`, and the gesture falls through to its tap branch.

## The behaviour chosen

The issue asked for the behaviour to be agreed before implementing, and recommended **not** simply
taking the drag back — a vertical touch drag has to keep scrolling the list, and a horizontal one
is the only way to scroll a long line on a device with no wheel. This takes the issue's default:
**CodeMirror 6's mobile behaviour — a plain drag scrolls, a long press begins a selection.**

- Press and hold past the platform long-press timeout without moving → the editor anchors a
  selection at that position and every subsequent move is consumed in the **Initial** pass, ahead
  of the scroll containers, extending the selection until the finger lifts.
- Press and move first → nothing changes; the scroll containers claim it exactly as before.
- Tap → unchanged.
- Mouse → completely unchanged: `scrollable` ignores mouse drags, so the wait is skipped and the
  existing `awaitTouchSlopOrCancellation` path runs untouched.

## The characterisation test #311 asked about

#311 says `horizontalTouchDragPlacesCursorAndLeavesDocument` "should be rewritten when this is
fixed". Its **assertions are unchanged and still pass**: a plain horizontal touch drag still places
the cursor and selects nothing. Under the behaviour chosen here that is no longer a characterised
defect but the deliberate half of the fix — that drag is how you reach the end of a long line on a
touch device — so what was rewritten is the comment explaining why it holds, not the test. Its name
is also left alone on purpose: the Android instrumented suite is compared to a named baseline on
#259, and renaming would have muddied that comparison for no gain.

No file in this PR carries a `parity:` comment (checked against a positive control — the pattern
does match, in `KeymapParityTest.kt`), so there is no counterpart to open.

## Verification

**Red first.** `longPressThenTouchDragSelectsAcrossLines` on unmodified `origin/main`
(`fb3cf400`), with only the test added:

```
longPressThenTouchDragSelectsAcrossLines[jvm]
java.lang.AssertionError: Expected the selection head at the start of line 3,
  but got SelectionRange@0 expected:<18> but was:<0>
```

Both new tests assert an **exact** anchor/head pair, not "something is selected". The coordinates
are font-metric independent (x=8 is inside the content's 6dp start padding, so a press resolves to
its line's first character), which is why the same literals hold on every target.

**Mutation tests**, both with the tests in place:

1. Production change reverted entirely → `expected:<18> but was:<0>` (as above).
2. `change.consume()` removed from the long-press drag loop → the list scrolls under the finger and
   the anchor drifts: `Expected <(40, 0)>, actual <(60, 0)>`.

A third mutation — swapping the drag loop's `PointerEventPass.Initial` for `Main` — is **not**
caught by either test; both still pass. `Initial` is kept as the principled choice (the parent is
guaranteed to run before its children there), but the suite does not prove it, and that is stated
rather than implied.

The second test's discriminating power is measured, not assumed: the same three moves *without*
the hold scroll the list twelve lines and leave the caret at 60.

**Where the tests execute** (verified by reading `build/test-results/**/*.xml`, not by exit code):

| target | result |
| --- | --- |
| `:view:jvmTest` | 333 tests, 0 failures — both new tests present and timed |
| `:view:wasmJsTest` (headless Chrome) | 300 tests, 0 failures — both new tests present |
| `:view:connectedDebugAndroidTest` (API 33 emulator) | both new tests pass |

`view/src/.../input/*` is excluded from every `*UnitTest` task, so on Android these run
instrumented only.

wasmJs **negative control**: flipping the two expectations to 17 and `(41, 0)` turns the wasm run
red with `Expected <17>, actual <18>` and `Expected <(41, 0)>`, so the browser suite is genuinely
evaluating these assertions rather than reporting a count.

`:view:apiCheck` passes and no `.api` file moved — everything added is `internal`.

## #259 — refuted, and diagnosed

**#259 stays open — this is not a closing reference for it, and nothing here addresses it.** (An
earlier revision of this body phrased that with a closing keyword next to the number and GitHub
duly linked it for closure; qualifiers do not scope those keywords.) What this PR does do is answer
the discriminator that issue has been waiting on, measured on an API 33 emulator: `hasFocus` **and** the cursor offset from the same
click. The result is a third case #259 did not enumerate, and it eliminates the leading hypothesis.
The measurement is written up on #259 itself.

None of the thirteen moved — the failing set is the same thirteen by name, which is expected: all
thirteen drive the editor with `performMouseInput`, and this change alters only the non-mouse path.
