### PR TITLE
Make LR advanceFully delegate to advanceStack (#286)

### DIFF
--- a/changelog.d/286.fixed.md
+++ b/changelog.d/286.fixed.md
@@ -1,0 +1,7 @@
+- Error recovery in the LR parser no longer abandons a stack after ten non-advancing reductions
+  (#286). `advanceFully` reimplemented `advanceStack` rather than calling it, and its standalone
+  copy needed a ten-step guard to terminate; a grammar whose reduce chain is longer than that
+  (twelve unit productions in the new test fixture) lost the recovered node entirely, yielding
+  `Program(⚠(Comma),⚠(Comma),Item(…))` where `@lezer/lr` 1.4.10 yields
+  `Program(Item(…),Comma,⚠,Comma,Item(…))`. `advanceFully` now delegates to `advanceStack`, as
+  upstream does, so the `stoppedAt` brake and cached-fragment reuse also reach the recovery path.

--- a/lezer-lr/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/lr/Parse.kt
+++ b/lezer-lr/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/lr/Parse.kt
@@ -468,35 +468,18 @@ internal class Parse(
     }
 
     /**
-     * Advance a stack through nested reductions until it progresses
-     * past its current position, or until a limit is reached. Used
-     * during error recovery after inserting a synthetic token.
+     * Advance a given stack forward as far as it will go, handing it to
+     * [pushStackDedup] once it moves past its starting position. Returns true
+     * if it moved forward, false if it got stuck. Used during error recovery.
      */
     private fun advanceFully(stack: Stack, newStacks: MutableList<Stack>): Boolean {
-        val startPos = stack.pos
-        var limit = 0
+        val pos = stack.pos
         while (true) {
-            if (stack.pos > startPos) {
+            if (!advanceStack(stack, null, null)) return false
+            if (stack.pos > pos) {
                 pushStackDedup(stack, newStacks)
                 return true
             }
-            val defaultReduce = parser.stateSlot(
-                stack.state,
-                ParseState.DEFAULT_REDUCE
-            )
-            if (defaultReduce > 0) {
-                stack.reduce(defaultReduce)
-            } else {
-                val actions = tokens.getActions(stack)
-                if (actions.isEmpty()) return false
-                stack.apply(
-                    actions[0],
-                    if (actions.size >= 2) actions[1] else 0,
-                    startPos,
-                    if (actions.size >= 3) actions[2] else startPos
-                )
-            }
-            if (++limit > Rec.FORCE_REDUCE_LIMIT) return false
         }
     }
 

--- a/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/ParseTest.kt
+++ b/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/ParseTest.kt
@@ -62,6 +62,43 @@ class ParseTest {
         assertTrue(result.contains("PropertyName"), "Should recover a PropertyName")
     }
 
+    // --- Error recovery through a reduce chain deeper than the force-reduce
+    // limit. `chainParser` needs twelve non-advancing reductions to fold a
+    // `Num` up into an `Item`, which is more than `Rec.FORCE_REDUCE_LIMIT`.
+    // Both expectations below are what @lezer/lr 1.4.10 produces for this
+    // grammar and input. ---
+
+    @Test
+    fun deepChainParsesWellFormedInput() {
+        // Guards the fixture itself: a mis-transcribed parser table would make
+        // the recovery expectation below meaningless.
+        val tree = chainParser.parse("1,2")
+        assertEquals(
+            "Program(" + CHAIN_ITEM_NUM + ",Comma," + CHAIN_ITEM_NUM + ")",
+            treeToString(tree)
+        )
+        assertEquals(3, tree.length)
+    }
+
+    @Test
+    fun recoveryFoldsChainsDeeperThanForceReduceLimit() {
+        // The leading commas make the parse stall on its first token, so the
+        // whole document is rebuilt through `runRecovery` -> `advanceFully`.
+        // Recovering the leading `Item` takes more non-advancing steps than
+        // `Rec.FORCE_REDUCE_LIMIT` allows, so an `advanceFully` that gives up
+        // after ten steps drops that stack and produces
+        // `Program(\u26A0(Comma),\u26A0(Comma),Item(...))` instead.
+        val tree = chainParser.parse(",,11")
+        val detail = "tree=${treeToString(tree)} length=${tree.length}"
+        assertEquals(
+            "Program(" + CHAIN_ITEM_ERR + ",Comma,\u26A0,Comma," +
+                CHAIN_ITEM_NUM + ")",
+            treeToString(tree),
+            "Recovered tree shape; $detail"
+        )
+        assertEquals(4, tree.length, "Recovered tree length; $detail")
+    }
+
     // --- Incremental parsing ---
 
     @Test
@@ -172,5 +209,15 @@ class ParseTest {
         assertFailsWith<IllegalArgumentException> {
             partial.stopAt(15)
         }
+    }
+
+    private companion object {
+        /** `Item` wrapping a `Num`, spelled out through the unit-production chain. */
+        const val CHAIN_ITEM_NUM =
+            "Item(L1(L2(L3(L4(L5(L6(L7(L8(L9(L10(L11(L12(Num)))))))))))))"
+
+        /** The same chain wrapping an error node. */
+        const val CHAIN_ITEM_ERR =
+            "Item(L1(L2(L3(L4(L5(L6(L7(L8(L9(L10(L11(L12(\u26A0)))))))))))))"
     }
 }

--- a/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/TestChainParser.kt
+++ b/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/TestChainParser.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lezer.lr
+
+/**
+ * A tiny grammar whose reduce chain is deliberately longer than
+ * [Rec.FORCE_REDUCE_LIMIT], used to exercise error recovery through deep
+ * reductions. Built with lezer-generator from:
+ *
+ * ```
+ * @top Program { Item (Comma Item)* }
+ * Item { L1 }
+ * L1 { L2 }
+ * ... (unit productions L1..L11)
+ * L12 { Num }
+ * @tokens {
+ *   Num { $[0-9]+ }
+ *   Comma { "," }
+ *   space { $[ \t\n]+ }
+ * }
+ * @skip { space }
+ * ```
+ *
+ * Reducing a single `Num` all the way up to `Item` takes twelve reductions,
+ * none of which move the parse position, so recovering this grammar drives
+ * far more non-advancing steps than the JSON fixture does.
+ */
+val chainParser: LRParser = LRParser.deserialize(
+    ParserSpec(
+        version = 14,
+        states = "#fOVQPOOOOQO'#Cj'#CjOOQO'#Ci'#CiOOQO'#Ch'#ChOOQO'#Cg'#Cg" +
+            "OOQO'#Cf'#CfOOQO'#Ce'#CeOOQO'#Cd'#CdOOQO'#Cc'#CcOOQO'#Cb'#Cb" +
+            "OOQO'#Ca'#CaOOQO'#C`'#C`OOQO'#C_'#C_OOQO'#C^'#C^Q[QPOOOVQPO'#Cm" +
+            "Q[QPOOOOQO,59X,59XOOQO-E6k-E6k",
+        stateData = "a~OdOS~O_PO~O`_O~O",
+        goto = "!qbPPcimquy}!R!V!Z!_!c!gPP!kQ^ORa_T]O_T[O_TZO_TYO_TXO_TWO_" +
+            "TVO_TUO_TTO_TSO_TRO_TQO_Q`^Rb`",
+        nodeNames = "\u26A0 Program Item L1 L2 L3 L4 L5 L6 L7 L8 L9 L10 L11 " +
+            "L12 Num Comma",
+        maxTerm = 20,
+        skippedNodes = listOf(0),
+        repeatNodeCount = 1,
+        tokenData = "}~RTXYbYZbpqb|}p!Q![u~gRd~XYbYZbpqb~uO`~~zP_~!Q![u",
+        tokenizers = listOf(0),
+        topRules = mapOf("Program" to listOf(0, 1)),
+        tokenPrec = 0
+    )
+)


### PR DESCRIPTION
Fixes #286

## What was compared against

`@lezer/lr@1.4.10` (`npm pack`ed, `dist/index.js`), specifically:

- `LRParse.advanceFully` — `dist/index.js:1462-1473`
- `LRParse.advanceStack` — `dist/index.js:1406-1457`
- `LRParse.advance`'s recovery dispatch — `dist/index.js:1347-1355`
- `pushStackDedup` — `dist/index.js:1539` and `findFinished` — `dist/index.js:1870` (both already
  faithful in the port)

Upstream `advanceFully` is a six-line loop over `advanceStack(stack, null, null)`. The port had an
independent reimplementation of two of `advanceStack`'s branches (default reduce, then the first
action) that never called it. This PR replaces the body with upstream's loop.

Termination without the counter is safe for the same reason it is upstream: the port's
`advanceStack` returns `false` on exactly the paths upstream's does — `actions.isEmpty()`, and the
braked path where `stack.forceReduce()` fails (upstream returns `null` there; the port returns
`false`). `Rec.FORCE_REDUCE_LIMIT` is still used by `runRecovery`'s own force-reduce loop, so the
constant stays.

## The divergence that is actually observable

Of the four gaps #286 lists, the one with a behavioural consequence is **(4), the ten-step
counter** the standalone copy needed to terminate. Upstream has no such cap, so a grammar whose
reduce chain is longer than `Rec.FORCE_REDUCE_LIMIT` loses the recovered stack: `advanceFully`
gives up before the chain folds and returns `false` where upstream returns `true` and hands the
stack to `pushStackDedup`.

New fixture `TestChainParser.kt` is a twelve-deep unit-production chain built with
`lezer-generator`; folding one `Num` up to an `Item` takes twelve non-advancing reductions. On
`",,11"`:

```
@lezer/lr 1.4.10:  Program(Item(L1(…L12(⚠)…)),Comma,⚠,Comma,Item(L1(…L12(Num)…)))
port before:       Program(⚠(Comma),⚠(Comma),Item(L1(…L12(Num)…)))
```

Both trees have `length` 4 — only the shape separates them, which is why the assertion is on the
shape (the same lesson #254's review recorded).

`deepChainParsesWellFormedInput` guards the fixture itself: a mis-transcribed table would make the
recovery expectation meaningless.

## Red-first

Test alone on unmodified `origin/main` production code:

```
ParseTest[jvm] > recoveryFoldsChainsDeeperThanForceReduceLimit[jvm] FAILED
    org.junit.ComparisonFailure: Recovered tree shape;
    tree=Program(⚠(Comma),⚠(Comma),Item(L1(L2(L3(L4(L5(L6(L7(L8(L9(L10(L11(L12(Num)))))))))))))) length=4
    expected:<Program([Item(L1(L2(L3(L4(L5(L6(L7(L8(L9(L10(L11(L12(⚠))))))))))))),Comma,⚠,Comma],Item(L1(L2(L3(L4(L5...>
    but was:<Program([⚠(Comma),⚠(Comma)],Item(L1(L2(L3(L4(L5...>
12 tests completed, 1 failed
```

`deepChainParsesWellFormedInput` passed in that same run, so the fixture is faithful and only the
recovery path is red.

## Mutation

Fix reverted with both tests in place — red again, same comparison:

```
ParseTest[jvm] > recoveryFoldsChainsDeeperThanForceReduceLimit[jvm] FAILED
    org.junit.ComparisonFailure: Recovered tree shape; …
201 tests completed, 1 failed
```

## Honest scope: gaps (1) and (2) are latent, not observable

The issue's headline — the `stoppedAt` brake never reaching recovery — is **structurally real but
dynamically unreachable**, and I could not build a red-first test for it. Both an argument and
measurements:

- `advance()` only enters `runRecovery` when `stopped[0].pos <= stoppedAt`. Every stack that lands
  in `stopped` does so at `minStackPos` (a stack with `pos > pos` goes straight to `newStacks`, and
  `advanceStack` only returns `false` without moving `pos`), so *all* stopped stacks share that
  position — `stopped[0]` is representative, and the shortcut above `runRecovery` catches the
  braked case. Inside `advanceFully`, `start` cannot exceed `startPos` before the loop returns, so
  `start > stoppedAt` never holds.
- Measured: instrumenting `advanceStack` to log calls made from `advanceFully` over the module
  suite plus 2,405 generated differential cases gives **184,471** such calls, **12,946** of them
  with `stoppedAt` set and **89,341** with fragments available (positive control — the
  instrumentation was reached), and **zero** activations of either the brake or `useCachedResult`
  on that path.
- Fragment reuse in recovery is unreachable for a related reason: the main loop has already probed
  `fragments.nodeAt(pos)` at that position before the stack got stuck, and the cursor is
  forward-only.

Fixing them is still correct — the port had a second, differently-shaped copy of code that can
drift independently, which is exactly how the counter divergence arose — but the PR should not be
read as fixing an active `stoppedAt` bug.

## No regression against upstream

A differential harness ran the port against `@lezer/lr@1.4.10` + `@lezer/json@1.0.3` (same
`treeToString` on both sides; validated by reproducing #254's `partialParseStopsAtPosition`
numbers exactly) on 2,405 cases — 605 `stopAt`-grid cases over malformed/deeply-nested JSON, 300
incremental fragment cases, and 1,500 randomised two-generation incremental cases with `stopAt` —
asserting shape, `tree.length` and `parsedPos`. **0 diffs before the change, 0 diffs after.** A
mirror experiment in JS, substituting the port's `advanceFully` shape into upstream over 8,000
randomised JSON scenarios, also produced 0 diffs, which is why the fixture needs a grammar JSON's
short reduce chains cannot supply.

## Verification

- `:lezer-lr:jvmTest` — **199 before, 201 after**, 0 failures. The two added tests are
  `ParseTest.deepChainParsesWellFormedInput` and
  `ParseTest.recoveryFoldsChainsDeeperThanForceReduceLimit`; no existing test changed, was renamed
  or removed. Counts read from `lezer-lr/build/test-results/jvmTest/*.xml`.
- `:lezer-lr:apiCheck` green; **no `.api` file moved** (`advanceFully` is private).
- `spotlessApply` / `ktlintFormat` clean.
- `changelog.py check --base-ref origin/main` — 11 fragments valid, `CHANGELOG.md` untouched.
- No `parity:` comments exist under `lezer-lr/src/` (positive-controlled: the same grep matches
  `CLAUDE.md` and `gap-analysis/tests/*.spec.ts`).

## Filed separately, not bundled

- Monkopedia/kodemirror#321 — `useCachedResult` diverges from upstream's fragment-reuse
  block (no `cached.length` guard, no `nodeSet.types[id] == type` identity check, no
  `contextHash`/strict-context check, no descent into a zero-offset first child; plus port-only
  `main != null` and `!hasWrappers()` gates upstream does not have). The missing `cached.length`
  guard is a latent non-termination: a zero-length reused node would spin `advanceStack`'s caller.
- Monkopedia/kodemirror#323 — the port's `advanceStack` calls `tokens.getActions(stack)`
  *before* the default-reduce branch, where upstream calls it after; and it routes every split
  stack to `split` where upstream routes pos-advancing splits to `stacks`.
