### PR TITLE
Never drop chunks after the last updated range in :merge (#250)

### DIFF
--- a/changelog.d/250.fixed.md
+++ b/changelog.d/250.fixed.md
@@ -1,0 +1,10 @@
+- Fixed `MergeView` and the unified merge editor duplicating chunks at the start of the document
+  after an edit (#250). When recomputing chunks for a change, `Chunk.updateA`/`Chunk.updateB`
+  carried an old chunk across whenever it ended one position before the start of an update range,
+  and then recomputed the same region inside that range, so the returned list held two chunks
+  covering the same start offsets. That produced doubled change decorations and gutter markers,
+  and let `acceptChunk`/`rejectChunk` select the wrong chunk and apply the wrong range. The
+  overlap test now compares against the chunk's `toA`/`toB` rather than `endA`/`endB`, and is
+  skipped entirely on the final pass so chunks past the last updated range are never dropped —
+  matching the upstream `@codemirror/merge` fix (`db4a11a`, `codemirror/dev#1680`), whose
+  regression test is ported alongside it.

--- a/merge/src/commonMain/kotlin/com/monkopedia/kodemirror/merge/Chunk.kt
+++ b/merge/src/commonMain/kotlin/com/monkopedia/kodemirror/merge/Chunk.kt
@@ -264,7 +264,7 @@ private fun updateChunks(
         val fromB = if (range != null) range.fromB + offB else b.endPos
         while (chunkI < chunks.size) {
             val next = chunks[chunkI]
-            if (next.endA + offA > fromA || next.endB + offB > fromB) break
+            if (range != null && (next.toA + offA > fromA || next.toB + offB > fromB)) break
             result.add(next.offset(offA, offB))
             chunkI++
         }

--- a/merge/src/commonTest/kotlin/com/monkopedia/kodemirror/merge/ChunkTest.kt
+++ b/merge/src/commonTest/kotlin/com/monkopedia/kodemirror/merge/ChunkTest.kt
@@ -45,6 +45,10 @@ class ChunkTest {
     private val docA = Text.of(linesA)
     private val docB = Text.of(linesB)
 
+    private fun List<Chunk>.describe(): String = joinToString(" ") {
+        "${it.fromA.value}-${it.toA.value}/${it.fromB.value}-${it.toB.value}"
+    }
+
     @Test
     fun enumeratesChangedChunks() {
         val chunks = Chunk.build(docA, docB)
@@ -311,5 +315,98 @@ class ChunkTest {
         )
         val updated = Chunk.updateB(chs, sA.doc, tr.newDoc, tr.changes)
         assertEquals(0, updated.size)
+    }
+
+    @Test
+    fun properlyDropsRangesAtTheStartOfTheDocument() {
+        val sA = EditorState.create(EditorStateConfig(doc = "\na\n".asDoc()))
+        val sB = EditorState.create(EditorStateConfig(doc = "a\n".asDoc()))
+        val chs = Chunk.build(sA.doc, sB.doc)
+        assertEquals(1, chs.size)
+        val tr = sA.update(
+            TransactionSpec(
+                changes = ChangeSpec.Single(
+                    from = DocPos(1),
+                    insert = InsertContent.StringContent("\n")
+                )
+            )
+        )
+        val updated = Chunk.updateA(chs, tr.newDoc, sB.doc, tr.changes)
+        assertEquals("0-2/0-0", updated.describe())
+        assertEquals(1, updated.size)
+    }
+
+    @Test
+    fun updatesChunksForAChangeInTheMiddleOfTheDocument() {
+        val stateA = EditorState.create(EditorStateConfig(doc = docA.toString().asDoc()))
+        val stateB = EditorState.create(EditorStateConfig(doc = docB.toString().asDoc()))
+        val chunks = Chunk.build(stateA.doc, stateB.doc)
+        assertEquals("4383-4392/4383-4390 6183-6633/6181-6197", chunks.describe())
+        val tr = stateA.update(
+            TransactionSpec(
+                changes = ChangeSpec.Single(
+                    from = stateA.doc.line(LineNumber(300)).from,
+                    insert = InsertContent.StringContent("line MID\n")
+                )
+            )
+        )
+        val updated = Chunk.updateA(chunks, tr.newDoc, stateB.doc, tr.changes)
+        assertEquals(
+            "2583-2592/2583-2583 4392-4401/4383-4390 6192-6642/6181-6197",
+            updated.describe()
+        )
+    }
+
+    @Test
+    fun updatesChunksForAChangeAtTheEndOfTheDocument() {
+        val stateA = EditorState.create(EditorStateConfig(doc = docA.toString().asDoc()))
+        val stateB = EditorState.create(EditorStateConfig(doc = docB.toString().asDoc()))
+        val chunks = Chunk.build(stateA.doc, stateB.doc)
+        val tr = stateA.update(
+            TransactionSpec(
+                changes = ChangeSpec.Single(
+                    from = stateA.doc.endPos,
+                    insert = InsertContent.StringContent("\nline END")
+                )
+            )
+        )
+        val updated = Chunk.updateA(chunks, tr.newDoc, stateB.doc, tr.changes)
+        assertEquals(
+            "4383-4392/4383-4390 6183-6633/6181-6197 8883-8902/8447-8457",
+            updated.describe()
+        )
+    }
+
+    @Test
+    fun keepsChunksPastTheLastUpdateRange() {
+        val tailA = (1..1000).map { "line $it" }
+        val tailB = tailA.toMutableList().also {
+            it[499] = "line D"
+            it.add("line EXTRA")
+        }
+        val sA = EditorState.create(
+            EditorStateConfig(doc = tailA.joinToString("\n").asDoc())
+        )
+        val sB = EditorState.create(
+            EditorStateConfig(doc = tailB.joinToString("\n").asDoc())
+        )
+        val chs = Chunk.build(sA.doc, sB.doc)
+        assertEquals("4383-4392/4383-4390 8883-8893/8881-8902", chs.describe())
+        val tr = sA.update(
+            TransactionSpec(
+                changes = ChangeSpec.Single(
+                    from = DocPos.ZERO,
+                    insert = InsertContent.StringContent("line NULL\n")
+                )
+            )
+        )
+        val updated = Chunk.updateA(chs, tr.newDoc, sB.doc, tr.changes)
+        // The trailing chunk sits past the last update range and its `toA` (8903) is one
+        // past the end of the updated document A (8902); it must still be carried over.
+        assertEquals(
+            "0-10/0-0 4393-4402/4383-4390 8893-8903/8881-8902",
+            updated.describe()
+        )
+        assertEquals(sA.doc.length + 10 + 1, updated[2].toA.value)
     }
 }


### PR DESCRIPTION
Fixes #250

## What was wrong

`updateChunks` in `merge/src/commonMain/kotlin/com/monkopedia/kodemirror/merge/Chunk.kt` carried the
pre-fix form of the upstream loop that flushes old chunks ahead of the next update range:

```kotlin
if (next.endA + offA > fromA || next.endB + offB > fromB) break
```

`endA`/`endB` are `toA - 1`/`toB - 1`, so a chunk ending *exactly one position before* the start of
an update range failed the test, was copied through, and was then recomputed by that range's
`toChunks(...)` — producing two chunks covering the same start offsets. The same expression on the
final `range == null` pass could also `break` out and leave chunks behind, which is why upstream
made the trailing flush unconditional rather than merely swapping `endA` for `toA`.

Blast radius: any `MergeView` / unified merge editor edited after construction gets doubled chunk
decorations and gutter markers, and `acceptChunk`/`rejectChunk` (`Unified.kt:328`, `:364`) pick a
chunk by position, so a duplicate pair sharing a start lets the wrong range be applied.

## Upstream compared against

- File/function: `src/chunk.ts`, `function updateChunks(...)` in
  [`codemirror/merge`](https://github.com/codemirror/merge).
- Commit: [`db4a11a`](https://github.com/codemirror/merge/commit/db4a11a69b1dbe0191a1f771ad7882668b8ca817)
  — "Never drop chunks after the last updated range", `codemirror/dev#1680`.

Upstream, post-`db4a11a`:

```js
if (range && (next.toA + offA > fromA || next.toB + offB > fromB)) break
```

This PR:

```kotlin
if (range != null && (next.toA + offA > fromA || next.toB + offB > fromB)) break
```

That is the whole production change — a 1-line, structurally identical port, not a
locally-reasoned equivalent. `endA`/`endB` stay on `Chunk` (still used by `Unified.kt` and part of
the published API, as upstream keeps them). The only other hunk in `db4a11a` is a doc-comment
tweak on the `toA` constructor parameter; this port has a condensed class-level KDoc with no
per-parameter docs, so there is nothing to apply it to.

## The omitted CM6 test, ported

Upstream `test/test-chunk.ts` has 12 cases; this repo's `ChunkTest.kt` had 11. The missing one is
exactly the regression test `db4a11a` added in the same commit:

```js
it("properly drops ranges at the start of the document", () => {
  let sA = EditorState.create({doc: "\na\n"}), sB = EditorState.create({doc: "a\n"})
  let chs = Chunk.build(sA.doc, sB.doc)
  ist(chs.length, 1)
  let tr = sA.update({changes: {from: 1, insert: "\n"}})
  let updated = Chunk.updateA(chs, tr.newDoc, sB.doc, tr.changes)
  ist(updated.length, 1)
})
```

Ported as `properlyDropsRangesAtTheStartOfTheDocument`, strengthened from upstream's length-only
assertion to the exact chunk offsets on both sides (`"0-2/0-0"`), because a length-only check is
precisely what would miss a start-of-document duplicate that happened to keep the count.

Three further cases guard against a fix that only works on one fixture — an update range at the
**start**, in the **middle**, and at the **end** of the document, plus a **chunk past the last
update range** whose `toA` is one position past the end of document A (the case the `range != null`
guard exists for). All four assert concrete `fromA-toA/fromB-toB` for every chunk.

## Verification

**Red first** — the four new tests against the unmodified `origin/main` `Chunk.kt`:

```
ChunkTest[jvm] > properlyDropsRangesAtTheStartOfTheDocument[jvm] FAILED
    org.junit.ComparisonFailure: expected:<0-[]2/0-0> but was:<0-[1/0-0 0-]2/0-0>
```

Two chunks, both starting at 0 in both documents, where upstream produces one — the duplication
from the issue, verbatim.

**Mutation, both halves of the fix independently:**

- `toA`/`toB` but *no* `range != null` guard:
  ```
  ChunkTest[jvm] > keepsChunksPastTheLastUpdateRange[jvm] FAILED
      ComparisonFailure: expected:<... 4393-4402/4383-4390[ 8893-8903/8881-8902]> but was:<... 4393-4402/4383-4390[]>
  ChunkTest[jvm] > properlyCopiesOverUnaffectedChunksAtEndOfDoc[jvm] FAILED
      java.lang.AssertionError: expected:<2> but was:<1>
  ```
- `range != null` guard but back to `endA`/`endB`:
  ```
  ChunkTest[jvm] > properlyDropsRangesAtTheStartOfTheDocument[jvm] FAILED
      ComparisonFailure: expected:<0-[]2/0-0> but was:<0-[1/0-0 0-]2/0-0>
  ```

**Suite counts** (read from `merge/build/test-results/**/*.xml`, not from task exit codes):

| | ChunkTest | DiffTest | PresentableDiffTest | total |
|---|---|---|---|---|
| before | 11 | 5 | 14 | 30, 0 failures |
| after | 15 | 5 | 14 | 34, 0 failures |

The +4 is `properlyDropsRangesAtTheStartOfTheDocument`,
`updatesChunksForAChangeInTheMiddleOfTheDocument`, `updatesChunksForAChangeAtTheEndOfTheDocument`,
`keepsChunksPastTheLastUpdateRange`. No existing test was renamed, removed, or altered; no
`parity:` comments exist anywhere under `merge/`.

- `:merge:jvmTest` — 34 tests, 0 failures.
- `:merge:wasmJsBrowserTest` (`CHROME_BIN=/usr/bin/chromium`) — 34 tests, 0 failures, same
  per-class counts.
- `:merge:ktlintCheck` / `:merge:spotlessCheck` — green.
- `:merge:apiCheck` — green; neither `merge/api/merge.api` nor `merge/api/merge.klib.api` moved
  (`git status --porcelain merge/api/` is empty). No `apiDump`.
- `python3 .github/scripts/changelog.py check --base-ref origin/main` — 13 fragments valid,
  including the new `changelog.d/250.fixed.md`. `CHANGELOG.md` untouched.
