### PR TITLE
Honour the overlays flag in resolveNode (#252)

### DIFF
--- a/changelog.d/252.fixed.md
+++ b/changelog.d/252.fixed.md
@@ -1,0 +1,16 @@
+- Fixed syntax-tree resolution around overlay-mounted trees, which every mixed-language grammar
+  relies on — HTML with embedded `<script>`/`<style>`, Vue, Angular, Jinja, Liquid, and markdown
+  with fenced code (#252). `resolveNode` took an `overlays` flag and never read it, so all four
+  entry points behaved as though it were always true and none of them behaved as `@lezer/common`
+  documents. `Tree.resolve` and `SyntaxNode.resolve` descended into overlays and returned
+  inner-language nodes where the host language was asked for; `resolveInner` never climbed back
+  out of an overlay that does not cover the requested position, returning an inner node for a
+  position the mount does not cover; `SyntaxNode.resolve`/`resolveInner` never climbed up out of
+  the receiver, so a position outside the node returned the node itself; and
+  `SyntaxNode.resolveInner` resolved against the node's own subtree, treating its argument as a
+  subtree-local offset rather than an absolute document position and returning a node detached
+  from the real parent chain. Every one of these was a silently wrong answer rather than a crash,
+  and `resolve`/`resolveInner` is the primary tree query behind indentation, folding, bracket
+  matching and completion context. `resolveNode` now starts from the passed node, selects
+  `IterMode.IGNORE_OVERLAYS` for a non-overlay descent, and runs the climb-out-of-overlays pass,
+  matching `@lezer/common` 1.5.2.

--- a/lezer-common/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/common/SyntaxTree.kt
+++ b/lezer-common/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/common/SyntaxTree.kt
@@ -270,12 +270,21 @@ interface SyntaxNode : SyntaxNodeRef {
     /** Navigate to a child before a position. */
     fun childBefore(pos: Int): SyntaxNode?
 
-    /** Resolve to the innermost node at a position. */
+    /**
+     * Resolve to the innermost node at [pos], moving up out of this node
+     * first when it does not cover [pos]. Does not enter
+     * [overlays][MountedTree.overlay].
+     *
+     * [pos] is an absolute document position, not an offset into this node.
+     */
     fun resolve(pos: Int, side: Int = 0): SyntaxNode
 
     /**
-     * Like [resolve], but enters overlay-mounted trees to find
-     * the innermost node.
+     * Like [resolve], but enters [overlaid][MountedTree.overlay] nodes to
+     * find the innermost node, and climbs back out of overlays that do not
+     * cover [pos].
+     *
+     * [pos] is an absolute document position, not an offset into this node.
      */
     fun resolveInner(pos: Int, side: Int = 0): SyntaxNode
 
@@ -380,13 +389,21 @@ class Tree(
         return cursor
     }
 
-    /** Resolve to the innermost node at position [pos]. */
-    fun resolve(pos: Int, side: Int = 0): SyntaxNode = topNode.resolve(pos, side)
+    /**
+     * Resolve to the innermost node at position [pos].
+     *
+     * This does not enter [overlays][MountedTree.overlay]; use
+     * [resolveInner] when you want the innermost overlaid node.
+     */
+    fun resolve(pos: Int, side: Int = 0): SyntaxNode = resolveNode(topNode, pos, side, false)
 
     /**
-     * Like [resolve], but enters overlay-mounted trees.
+     * Like [resolve], but enters [overlaid][MountedTree.overlay] nodes,
+     * producing a syntax node pointing into the innermost overlaid tree at
+     * [pos], with parent links going through all parent structure, including
+     * the host trees.
      */
-    fun resolveInner(pos: Int, side: Int = 0): SyntaxNode = resolveNode(this, pos, side, false)
+    fun resolveInner(pos: Int, side: Int = 0): SyntaxNode = resolveNode(topNode, pos, side, true)
 
     /**
      * Returns a [NodeIterator] pointing at the innermost node at [pos],
@@ -657,16 +674,9 @@ internal class TreeNode(
         Side.BEFORE
     )
 
-    override fun resolve(pos: Int, side: Int): SyntaxNode {
-        var node: SyntaxNode = this
-        while (true) {
-            val inner = node.enter(pos, side) ?: return node
-            node = inner
-        }
-    }
+    override fun resolve(pos: Int, side: Int): SyntaxNode = resolveNode(this, pos, side, false)
 
-    override fun resolveInner(pos: Int, side: Int): SyntaxNode =
-        resolveNode(this._tree, pos, side, false)
+    override fun resolveInner(pos: Int, side: Int): SyntaxNode = resolveNode(this, pos, side, true)
 
     override fun enterUnfinishedNodesBefore(pos: Int): SyntaxNode =
         enterUnfinishedNodesBefore(this, pos)
@@ -828,16 +838,9 @@ internal class BufferNode(val context: BufferContext, val _parent: BufferNode?, 
         }
     }
 
-    override fun resolve(pos: Int, side: Int): SyntaxNode {
-        var node: SyntaxNode = this
-        while (true) {
-            val inner = node.enter(pos, side) ?: return node
-            node = inner
-        }
-    }
+    override fun resolve(pos: Int, side: Int): SyntaxNode = resolveNode(this, pos, side, false)
 
-    override fun resolveInner(pos: Int, side: Int): SyntaxNode =
-        resolveNode(context.parent._tree, pos, side, false)
+    override fun resolveInner(pos: Int, side: Int): SyntaxNode = resolveNode(this, pos, side, true)
 
     override fun enterUnfinishedNodesBefore(pos: Int): SyntaxNode =
         enterUnfinishedNodesBefore(this, pos)
@@ -1237,14 +1240,42 @@ private fun collectVisibleChildren(tree: Tree, basePos: Int, result: MutableList
 
 // ---- resolveNode helper (handles overlay-mounted trees) ----
 
-private fun resolveNode(tree: Tree, pos: Int, side: Int, overlays: Boolean): SyntaxNode {
-    var node: SyntaxNode = tree.topNode
+private fun resolveNode(startNode: SyntaxNode, pos: Int, side: Int, overlays: Boolean): SyntaxNode {
+    var node: SyntaxNode = startNode
+    // Move up to a node that actually holds the position, if possible.
+    while (node.from == node.to ||
+        (if (side < 1) node.from >= pos else node.from > pos) ||
+        (if (side > -1) node.to <= pos else node.to < pos)
+    ) {
+        val parent = if (!overlays && node is TreeNode && node.index < 0) {
+            // Without overlays, an overlay root is the end of the line.
+            null
+        } else {
+            node.parent
+        }
+        if (parent == null) return node
+        node = parent
+    }
+    val mode = if (overlays) 0 else IterMode.IGNORE_OVERLAYS
+    // Must go up out of overlays when those do not overlap with pos.
+    if (overlays) {
+        var scan: SyntaxNode = node
+        var parent = scan.parent
+        while (parent != null) {
+            if (scan is TreeNode &&
+                scan.index < 0 &&
+                parent.enter(pos, side, mode)?.from != scan.from
+            ) {
+                node = parent
+            }
+            scan = parent
+            parent = scan.parent
+        }
+    }
     while (true) {
-        val inner = node.enter(pos, side) ?: break
-        if (inner === node) break
+        val inner = node.enter(pos, side, mode) ?: return node
         node = inner
     }
-    return node
 }
 
 // ---- stackIterator helper (resolveStack) ----

--- a/lezer-common/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/common/ResolveOverlayTest.kt
+++ b/lezer-common/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/common/ResolveOverlayTest.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lezer.common
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Resolution behaviour around overlay-mounted trees, matching `resolveNode` in
+ * `@lezer/common` `test-mix.ts` / `test-tree.ts` semantics.
+ *
+ * The fixture models a mixed-language document (a host language with an inner
+ * language mounted over two non-contiguous ranges), which is the exact shape
+ * the `overlays` flag exists for. The mount deliberately does **not** start at
+ * offset 0, so a result reported in subtree-local coordinates is
+ * distinguishable from one in document coordinates.
+ *
+ * ```
+ * Doc(0-30)
+ *   Text(0-4)
+ *   Script(4-24)                 mounted overlay over doc 10-14 and 18-22
+ *     Attr(4-10)
+ *     Attr(10-14)                covered by overlay range 1
+ *     Attr(14-18)                the GAP between the two overlay ranges
+ *     Attr(18-22)                covered by overlay range 2
+ *     Attr(22-24)
+ *   Text(24-30)
+ *
+ * mounted inner tree, rooted at doc 10:
+ *   Expr(10-22)
+ *     Ident(10-14)
+ *     Ident(18-22)
+ * ```
+ */
+class ResolveOverlayTest {
+
+    private val doc = NodeType.define(NodeTypeSpec(name = "Doc", id = 0))
+    private val text = NodeType.define(NodeTypeSpec(name = "Text", id = 1))
+    private val script = NodeType.define(NodeTypeSpec(name = "Script", id = 2))
+    private val attr = NodeType.define(NodeTypeSpec(name = "Attr", id = 3))
+    private val expr = NodeType.define(NodeTypeSpec(name = "Expr", id = 4))
+    private val ident = NodeType.define(NodeTypeSpec(name = "Ident", id = 5))
+
+    private val dummyParser = object : Parser() {
+        override fun createParse(
+            input: Input,
+            fragments: List<TreeFragment>,
+            ranges: List<TextRange>
+        ): PartialParse = error("Not implemented")
+    }
+
+    private fun leaf(type: NodeType, length: Int) = Tree(type, emptyList(), emptyList(), length)
+
+    /** The inner (mounted) tree; its own coordinate space starts at doc 10. */
+    private fun innerTree(): Tree = Tree(
+        expr,
+        listOf(leaf(ident, 4), leaf(ident, 4)),
+        listOf(0, 8),
+        12
+    )
+
+    private fun mixedTree(): Tree {
+        val mounted = MountedTree(
+            innerTree(),
+            // Relative to the Script node, which starts at doc 4:
+            // doc 10-14 and doc 18-22.
+            listOf(TextRange(6, 10), TextRange(14, 18)),
+            dummyParser
+        )
+        val scriptTree = Tree(
+            script,
+            listOf(
+                leaf(attr, 6),
+                leaf(attr, 4),
+                leaf(attr, 4),
+                leaf(attr, 4),
+                leaf(attr, 2)
+            ),
+            listOf(0, 6, 10, 14, 18),
+            20,
+            mapOf(NodeProp.mounted.id to mounted)
+        )
+        return Tree(
+            doc,
+            listOf(leaf(text, 4), scriptTree, leaf(text, 6)),
+            listOf(0, 4, 24),
+            30
+        )
+    }
+
+    private fun SyntaxNode.describe() = "$name($from-$to)"
+
+    // ---- Defect 1/2: resolve() must not descend into overlay-mounted trees ----
+
+    @Test
+    fun treeResolveDoesNotEnterOverlay() {
+        val resolved = mixedTree().resolve(12, 1)
+        assertEquals(
+            "Attr(10-14)",
+            resolved.describe(),
+            "Tree.resolve must stay in the host language (IterMode.IGNORE_OVERLAYS)"
+        )
+    }
+
+    @Test
+    fun nodeResolveDoesNotEnterOverlay() {
+        val scriptNode = mixedTree().topNode.firstChild!!.nextSibling!!
+        assertEquals("Script(4-24)", scriptNode.describe())
+        assertEquals(
+            "Attr(18-22)",
+            scriptNode.resolve(20, 1).describe(),
+            "SyntaxNode.resolve must stay in the host language"
+        )
+    }
+
+    /** resolveInner is the one that *does* enter overlays; guard that too. */
+    @Test
+    fun treeResolveInnerEntersOverlay() {
+        assertEquals("Ident(10-14)", mixedTree().resolveInner(12, 1).describe())
+        assertEquals("Ident(18-22)", mixedTree().resolveInner(20, 1).describe())
+    }
+
+    // ---- Defect: resolveNode must start from the node, climbing up ----
+
+    @Test
+    fun nodeResolveClimbsToContainingNode() {
+        val firstText = mixedTree().topNode.firstChild!!
+        assertEquals("Text(0-4)", firstText.describe())
+        assertEquals(
+            "Attr(14-18)",
+            firstText.resolve(16, 1).describe(),
+            "SyntaxNode.resolve must climb out of the node when pos lies outside it"
+        )
+    }
+
+    // ---- Defect 4: SyntaxNode.resolveInner uses document coordinates ----
+
+    @Test
+    fun nodeResolveInnerUsesDocumentCoordinates() {
+        val scriptNode = mixedTree().topNode.firstChild!!.nextSibling!!
+        assertEquals("Script(4-24)", scriptNode.describe())
+        assertEquals(
+            "Ident(18-22)",
+            scriptNode.resolveInner(20, 1).describe(),
+            "SyntaxNode.resolveInner must treat pos as an absolute document offset, " +
+                "not an offset into the node's own subtree"
+        )
+    }
+
+    @Test
+    fun innerNodeResolveInnerUsesDocumentCoordinates() {
+        val firstIdent = mixedTree().resolveInner(12, 1)
+        assertEquals("Ident(10-14)", firstIdent.describe())
+        assertEquals(
+            "Ident(18-22)",
+            firstIdent.resolveInner(20, 1).describe(),
+            "resolveInner from inside the mount must still use document coordinates"
+        )
+    }
+
+    // ---- Defect 3: resolveInner must climb back out of non-covering overlays ----
+
+    @Test
+    fun resolveInnerClimbsOutOfOverlayForGapPosition() {
+        val firstIdent = mixedTree().resolveInner(12, 1)
+        assertEquals("Ident(10-14)", firstIdent.describe())
+        // doc 16 falls in the gap between the two overlay ranges, so it is not
+        // covered by the mount at all: the answer must be the host node.
+        assertEquals(
+            "Attr(14-18)",
+            firstIdent.resolveInner(16, 1).describe(),
+            "resolveInner must climb out of an overlay that does not cover pos"
+        )
+    }
+
+    @Test
+    fun resolveInnerClimbsOutOfOverlayForPositionAfterMount() {
+        val firstIdent = mixedTree().resolveInner(12, 1)
+        assertEquals(
+            "Attr(22-24)",
+            firstIdent.resolveInner(23, 1).describe(),
+            "resolveInner must climb out of the mount entirely for a position past it"
+        )
+    }
+
+    /** The parent chain of an inner-language node runs through the host tree. */
+    @Test
+    fun overlayParentChainReachesHostTree() {
+        val innermost = mixedTree().resolveInner(20, 1)
+        val chain = generateSequence(innermost) { it.parent }.map { it.describe() }.toList()
+        assertEquals(
+            listOf("Ident(18-22)", "Expr(10-22)", "Script(4-24)", "Doc(0-30)"),
+            chain
+        )
+    }
+}


### PR DESCRIPTION
Fixes #252

## What diverged

Compared against **`@lezer/common` 1.5.2** (npm dist, `dist/index.js`): `resolveNode` at
`:670-694`, `Tree.resolve` at `:464`, `Tree.resolveInner` at `:477`, and the shared
`BaseNode.resolve`/`resolveInner` at `:704-709`.

`resolveNode` in the port took an `overlays: Boolean` and never read it. Concretely:

| upstream | port (before) |
|---|---|
| `dist/index.js:672-680` — a "move up to a node that actually holds the position" loop, over the **node** passed in | absent; `resolveNode` took a `Tree` and started from `tree.topNode` |
| `dist/index.js:681` — `let mode = overlays ? 0 : IterMode.IgnoreOverlays` | absent; `node.enter(pos, side)` with `mode` defaulting to `0`, i.e. `overlays == true` behaviour, unconditionally |
| `dist/index.js:683-687` — the "go up out of overlays when those do not overlap with pos" pass | absent |
| `:705` `resolve` → `resolveNode(this, …, false)`, `:708` `resolveInner` → `resolveNode(this, …, true)` | `TreeNode.resolveInner` → `resolveNode(this._tree, …)` and `BufferNode.resolveInner` → `resolveNode(context.parent._tree, …)` — the node's **own subtree**, whose `topNode` is at offset 0; `resolve` was an inline `enter` loop with no mode and no climb |
| `:477` `Tree.resolveInner` passes `true` | passed `false` (moot, since the flag was ignored) |

Four observable consequences, each fixed and each guarded by its own test:

1. `Tree.resolve` / `SyntaxNode.resolve` descended into overlay-mounted trees and returned
   inner-language nodes where the host language was asked for.
2. `resolveInner` never climbed back out of an overlay that does not cover `pos`.
3. `SyntaxNode.resolve`/`resolveInner` never climbed up out of the receiver, so a `pos` outside
   the node returned the node itself.
4. `SyntaxNode.resolveInner` treated `pos` as a **subtree-local** offset, returning a node in the
   wrong coordinate space and detached from the real parent chain.

Upstream's per-tree `CachedNode`/`CachedInnerNode` memoisation (`:465`, `:477`) is still not
ported. It is a pure optimisation — `resolveNode` climbs up from whatever node it is handed, so a
cached start node and `topNode` give the same answer — and is out of scope here.

## Verification

New `lezer-common/src/commonTest/.../ResolveOverlayTest.kt` builds a mixed-language fixture: a
host `Script(4-24)` inside `Doc(0-30)` with a mount overlaid on **two non-contiguous** doc ranges
`10-14` and `18-22`, leaving `14-18` as a gap the mount does not cover. **The mount starts at doc
10, not 0**, so a subtree-local answer is distinguishable from a document-coordinate one — that is
what makes assertion 4 below meaningful. Every assertion names a concrete node, `name(from-to)` in
document coordinates.

7 of the 9 tests fail on unmodified `origin/main`:

```
tests=9 failures=7
FAIL innerNodeResolveInnerUsesDocumentCoordinates      expected:<Ident(18-22)>  but was:<Ident(0-4)>
FAIL resolveInnerClimbsOutOfOverlayForPositionAfterMount expected:<Attr(22-24)> but was:<Ident(0-4)>
FAIL nodeResolveClimbsToContainingNode                 expected:<Attr(14-18)>  but was:<Text(0-4)>
FAIL nodeResolveDoesNotEnterOverlay                    expected:<Attr(18-22)>  but was:<Ident(18-22)>
FAIL resolveInnerClimbsOutOfOverlayForGapPosition      expected:<Attr(14-18)>  but was:<Ident(0-4)>
FAIL nodeResolveInnerUsesDocumentCoordinates           expected:<Ident(18-22)> but was:<Script(0-20)>
FAIL treeResolveDoesNotEnterOverlay                    expected:<Attr(10-14)>  but was:<Ident(10-14)>
PASS overlayParentChainReachesHostTree
PASS treeResolveInnerEntersOverlay
```

`Script(0-20)` in the sixth line is the subtree-local bug in the clear: the node is at doc `4-24`.

### Mutation testing — each behaviour reverted separately, tests in place

| reverted | tests that go red |
|---|---|
| `mode` back to a constant `0` (ignore the `overlays` flag) | `treeResolveDoesNotEnterOverlay`, `nodeResolveDoesNotEnterOverlay` |
| the climb-out-of-overlays pass deleted | `resolveInnerClimbsOutOfOverlayForGapPosition` (`expected:<Attr(14-18)> but was:<Expr(10-22)>`) |
| `TreeNode.resolveInner` back to `resolveNode(this._tree.topNode, …)` | `nodeResolveInnerUsesDocumentCoordinates`, `innerNodeResolveInnerUsesDocumentCoordinates`, `resolveInnerClimbsOutOfOverlayForGapPosition`, `resolveInnerClimbsOutOfOverlayForPositionAfterMount` |
| the "move up to a node that holds pos" loop deleted | `nodeResolveClimbsToContainingNode`, `innerNodeResolveInnerUsesDocumentCoordinates` |

No behaviour is unguarded.

### Regression surface

`:lezer-common`, `:lezer-lr`, `:lezer-highlight`, `:language` and all 22 `lang-*` modules,
`jvmTest`, before and after (counts read from `build/test-results/jvmTest/*.xml`):

* **before:** 839 tests, 0 failures
* **after:** 848 tests, 0 failures

Accounted **by name**: the diff of the two per-test name lists is exactly the 9 new
`ResolveOverlayTest` cases, all passing. No existing test changed status. (Eight `lang-*` modules —
angular, grammar, jinja, less, liquid, sql, vue, wast — contribute 0 because they contain no test
sources at all.)

`:lezer-common:wasmJsBrowserTest` also run (`CHROME_BIN=/usr/bin/chromium`): 78 tests, 0 failures,
XML confirms all 9 new cases executed on wasmJs.

### API

`:lezer-common:apiCheck` **green, and neither `.api` nor `.klib.api` moved** — `resolveNode` is
private and no signature changed. **The observable behaviour of published API does change**,
however: `Tree.resolve`, `Tree.resolveInner`, `SyntaxNode.resolve` and `SyntaxNode.resolveInner`
all return different nodes than before for the cases above. Any caller that had adapted to the old
`SyntaxNode.resolveInner` subtree-local coordinates would need to stop doing so. This is the
documented upstream contract being restored, not a new one.

`:lezer-common:ktlintCheck` and `:lezer-common:spotlessCheck` green. Changelog fragment
`changelog.d/252.fixed.md`; `changelog.py check --base-ref origin/main` reports 13 valid fragments.

## Noted, not fixed here

* **#253** (`enterUnfinishedNodesBefore`) is in the same file and untouched; this PR does not
  address it.
* `stackIterator` (`SyntaxTree.kt`, backing `Tree.resolveStack`) is not the upstream algorithm at
  all — upstream (`dist/index.js:950-968`) walks the parent chain from `resolveInner`'s result and
  pushes a *layer* per relevant overlay, whereas the port just walks a `cursorAt` parent chain and
  so never produces the overlay layers `resolveStack` exists to expose. Separate defect, separate
  PR; filing it rather than bundling it.
