### PR TITLE
Apply upstream's full fragment-reuse condition set in useCachedResult (#321)

### DIFF
--- a/changelog.d/321.fixed.md
+++ b/changelog.d/321.fixed.md
@@ -1,0 +1,10 @@
+- The LR parser now applies all of `@lezer/lr` 1.4.10's conditions before reusing a node from an
+  incremental-parse fragment (#321). Four were missing: a zero-length node was reused even though
+  reusing one cannot advance the parse position (`@lezer/lr` refuses it, and every caller of
+  `advanceStack` loops while it reports progress); a node whose type object came from a different
+  node set — a reconfigured parser, or a fragment from another language — was reused on a bare id
+  match; a strict `ContextTracker`'s `contextHash` was ignored, so a context-sensitive parse could
+  reuse a node built under a different context; and reuse gave up on a node that did not match
+  instead of retrying with its first child when that child starts at the same position, losing
+  reuse `@lezer/lr` performs. Each condition is covered by a test whose expectation is the tree
+  `@lezer/lr` 1.4.10 produces for the same table, input and fragment.

--- a/lezer-lr/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/lr/Parse.kt
+++ b/lezer-lr/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/lr/Parse.kt
@@ -19,6 +19,7 @@
 package com.monkopedia.kodemirror.lezer.lr
 
 import com.monkopedia.kodemirror.lezer.common.Input
+import com.monkopedia.kodemirror.lezer.common.NodeProp
 import com.monkopedia.kodemirror.lezer.common.PartialParse
 import com.monkopedia.kodemirror.lezer.common.TextRange
 import com.monkopedia.kodemirror.lezer.common.Tree
@@ -411,8 +412,7 @@ internal class Parse(
 
         // Try to use a cached tree fragment
         if (main != null && !parser.hasWrappers()) {
-            val cached = useCachedResult(stack, main)
-            if (cached) return true
+            if (useCachedResult(stack)) return true
         }
 
         // Default reduce (no token needed)
@@ -453,18 +453,46 @@ internal class Parse(
 
     /**
      * Try to reuse a cached tree node at the current position.
+     *
+     * Mirrors the fragment-reuse block of `@lezer/lr` 1.4.10's
+     * `LRParse.advanceStack` (`dist/index.js:1411-1428`). A node is only
+     * reusable when it belongs to this parser's node set, the current state
+     * has a goto for its term, it actually covers some input, and — under a
+     * strict [ContextTracker] — it was parsed under the same context hash.
+     * When the node itself does not qualify, upstream retries with its first
+     * child if that child starts at the same position.
      */
-    private fun useCachedResult(stack: Stack, main: CachedToken): Boolean {
+    private fun useCachedResult(stack: Stack): Boolean {
         val frags = fragments ?: return false
-        val cached = frags.nodeAt(stack.pos) ?: return false
-        val type = cached.type
-        if (type.id == 0) return false // error node
-
-        val goto = parser.getGoto(stack.state, type.id, false)
-        if (goto < 0) return false
-
-        stack.useNode(cached, goto)
-        return true
+        val context = stack.curContext
+        val strictCx = context != null && context.tracker.strict
+        val cxHash = if (strictCx) context.hash else 0
+        var cached: Tree? = frags.nodeAt(stack.pos)
+        while (cached != null) {
+            val type = cached.type
+            // The type object must be the very one this parser's node set
+            // holds at that id; a same-id type from another node set (a
+            // reconfigured parser, a mixed-language fragment) is not reusable.
+            val match = if (parser.nodeSet.types.getOrNull(type.id) === type) {
+                parser.getGoto(stack.state, type.id, false)
+            } else {
+                -1
+            }
+            if (match > -1 &&
+                // A zero-length node would not move `stack.pos`, and every
+                // caller loops while `advanceStack` returns true.
+                cached.length > 0 &&
+                (!strictCx || (cached.prop(NodeProp.contextHash) ?: 0) == cxHash)
+            ) {
+                stack.useNode(cached, match)
+                return true
+            }
+            if (cached.children.isEmpty() || cached.positions[0] > 0) break
+            val inner = cached.children[0]
+            if (inner !is Tree) break
+            cached = inner
+        }
+        return false
     }
 
     /**

--- a/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/UseCachedResultTest.kt
+++ b/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/UseCachedResultTest.kt
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2025 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lezer.lr
+
+import com.monkopedia.kodemirror.lezer.common.NodeProp
+import com.monkopedia.kodemirror.lezer.common.NodeType
+import com.monkopedia.kodemirror.lezer.common.NodeTypeSpec
+import com.monkopedia.kodemirror.lezer.common.Tree
+import com.monkopedia.kodemirror.lezer.common.TreeFragment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+/**
+ * Fragment-reuse parity with `@lezer/lr` 1.4.10's `LRParse.advanceStack`
+ * (`dist/index.js:1411-1428`), the block the port factors out into
+ * `Parse.useCachedResult`.
+ *
+ * Every expectation below is what `@lezer/lr` 1.4.10 itself produces for the
+ * same parser table, the same input and the same hand-built fragment.
+ *
+ * The document is `"12345"`, which a fresh parse reads as a `Number`. Each
+ * scenario offers the parser a fragment holding a `String` node covering the
+ * same five characters, so "was the cached node reused" is legible directly in
+ * the tree: `JsonText(String)` means reused, `JsonText(Number)` means not.
+ */
+class UseCachedResultTest {
+
+    // `bufferLength` 1 is load-bearing: upstream only builds a
+    // `FragmentCursor` when `stream.end - from > bufferLength * 4`, so a
+    // five-character document needs a small buffer length for upstream to
+    // consider reuse at all. Without it the comparison runs would be vacuous
+    // on the upstream side.
+    private val parser = jsonParser.configure(ParserConfig(bufferLength = 1))
+
+    private val doc = "12345"
+
+    private fun type(name: String): NodeType = parser.nodeSet.types.first { it.name == name }
+
+    /** Wrap [node] as the sole, zero-offset child of a whole-document fragment. */
+    private fun fragmentOf(node: Tree): List<TreeFragment> {
+        val root = Tree(NodeType.none, listOf(node), listOf(0), doc.length)
+        return listOf(TreeFragment(0, doc.length, root, 0))
+    }
+
+    /**
+     * Parse [doc] with [fragments], capping the number of `advance()` calls.
+     *
+     * The cap is what keeps a missing `cached.length` guard from being able to
+     * hang CI: reusing a zero-length node does not move `stack.pos`, and every
+     * caller of `advanceStack` loops while it returns `true`, so the failure
+     * mode this file guards against is an unbounded parse. A complete parse of
+     * this five-character document takes a handful of steps; 200 is several
+     * orders of magnitude of headroom, and exceeding it fails the test rather
+     * than spinning.
+     */
+    private fun parseBounded(fragments: List<TreeFragment>): Tree {
+        val partial = parser.startParse(doc, fragments)
+        var steps = 0
+        while (true) {
+            val tree = partial.advance()
+            if (tree != null) return tree
+            if (++steps > MAX_ADVANCE_STEPS) {
+                fail(
+                    "Parse of \"$doc\" did not finish within $MAX_ADVANCE_STEPS " +
+                        "advance() calls (parsedPos=${partial.parsedPos})"
+                )
+            }
+        }
+    }
+
+    private fun shape(fragments: List<TreeFragment>): String = treeToString(parseBounded(fragments))
+
+    // --- Fixture guards -------------------------------------------------
+
+    @Test
+    fun plainParseReadsTheDocumentAsANumber() {
+        // If this ever stops holding, every "not reused" expectation below
+        // becomes meaningless.
+        assertEquals("JsonText(Number)", shape(emptyList()))
+    }
+
+    @Test
+    fun matchingCachedNodeIsReused() {
+        // Positive control for the whole file: the reuse path is genuinely
+        // reached with these fragments, so a "not reused" result elsewhere is
+        // a decision, not a dead code path.
+        val cached = Tree(type("String"), emptyList(), emptyList(), doc.length)
+        assertEquals("JsonText(String)", shape(fragmentOf(cached)))
+    }
+
+    // --- 1. `cached.length` ---------------------------------------------
+
+    @Test
+    fun zeroLengthCachedNodeIsNotReused() {
+        // Upstream: `match > -1 && cached.length && ...`. A zero-length node
+        // is refused, because `useNode` would not move `stack.pos` and the
+        // caller loops while `advanceStack` returns true.
+        val cached = Tree(type("String"), emptyList(), emptyList(), 0)
+        val tree = parseBounded(fragmentOf(cached))
+        val detail = "tree=${treeToString(tree)} length=${tree.length}"
+        assertEquals(
+            "JsonText(Number)",
+            treeToString(tree),
+            "Zero-length cached node must not be reused; $detail"
+        )
+        assertEquals(5, tree.length, "Tree length; $detail")
+    }
+
+    // --- 2. `nodeSet.types[cached.type.id] == cached.type` ---------------
+
+    @Test
+    fun cachedNodeFromAForeignNodeSetIsNotReused() {
+        // Upstream computes `match` only when the cached node's type is the
+        // very object this parser's node set holds at that id. A same-id type
+        // object from somewhere else (a reconfigured parser, a mixed-language
+        // fragment) is refused.
+        val foreign = NodeType.define(
+            NodeTypeSpec(name = "Foreign", id = type("String").id)
+        )
+        val cached = Tree(foreign, emptyList(), emptyList(), doc.length)
+        val tree = parseBounded(fragmentOf(cached))
+        val detail = "tree=${treeToString(tree)} length=${tree.length}"
+        assertEquals(
+            "JsonText(Number)",
+            treeToString(tree),
+            "Foreign-node-set cached node must not be reused; $detail"
+        )
+    }
+
+    // --- 3. strict `contextHash` -----------------------------------------
+
+    private fun contextualParser(startContext: Int) = jsonParser.configure(
+        ParserConfig(
+            bufferLength = 1,
+            contextTracker = ContextTracker(
+                start = startContext as Any?,
+                hash = { it as Int },
+                strict = true
+            )
+        )
+    )
+
+    private fun contextualShape(startContext: Int, cachedHash: Int?): String {
+        val contextual = contextualParser(startContext)
+        val props = if (cachedHash == null) {
+            emptyMap()
+        } else {
+            mapOf(NodeProp.contextHash.id to cachedHash as Any?)
+        }
+        val stringType = contextual.nodeSet.types.first { it.name == "String" }
+        val cached = Tree(stringType, emptyList(), emptyList(), doc.length, props)
+        val root = Tree(NodeType.none, listOf(cached), listOf(0), doc.length)
+        val fragments = listOf(TreeFragment(0, doc.length, root, 0))
+        val partial = contextual.startParse(doc, fragments)
+        var steps = 0
+        while (true) {
+            val tree = partial.advance()
+            if (tree != null) return treeToString(tree)
+            if (++steps > MAX_ADVANCE_STEPS) {
+                fail("Contextual parse of \"$doc\" did not finish in $MAX_ADVANCE_STEPS steps")
+            }
+        }
+    }
+
+    @Test
+    fun strictContextTrackerAllowsReuseWhenTheHashMatches() {
+        // Positive control for the two expectations below: with a strict
+        // tracker in place, a matching hash still reuses.
+        assertEquals("JsonText(String)", contextualShape(7, 7))
+    }
+
+    @Test
+    fun strictContextTrackerBlocksReuseWhenTheHashDiffers() {
+        assertEquals("JsonText(Number)", contextualShape(7, 5))
+    }
+
+    @Test
+    fun strictContextTrackerBlocksReuseWhenTheNodeCarriesNoHash() {
+        // Upstream reads a missing `contextHash` prop as 0, which does not
+        // match a non-zero stack context hash.
+        assertEquals("JsonText(Number)", contextualShape(7, null))
+    }
+
+    // --- 4. descent into a zero-offset first child ------------------------
+
+    @Test
+    fun reuseDescendsIntoAZeroOffsetFirstChild() {
+        // The outer `Property` has no goto from the start state, so upstream
+        // retries with its first child, which starts at offset 0 and does
+        // match. Giving up on the outer node loses that reuse.
+        val inner = Tree(type("String"), emptyList(), emptyList(), doc.length)
+        val outer = Tree(
+            type("Property"),
+            listOf(inner),
+            listOf(0),
+            doc.length
+        )
+        val tree = parseBounded(fragmentOf(outer))
+        val detail = "tree=${treeToString(tree)} length=${tree.length}"
+        assertEquals(
+            "JsonText(String)",
+            treeToString(tree),
+            "Reuse must descend into a zero-offset first child; $detail"
+        )
+    }
+
+    @Test
+    fun reuseDoesNotDescendIntoAnOffsetFirstChild() {
+        // Guard on the descent's own condition: upstream only descends when
+        // `positions[0] == 0`. A first child that starts later is not a
+        // stand-in for the node at this position.
+        val inner = Tree(type("String"), emptyList(), emptyList(), doc.length - 1)
+        val outer = Tree(
+            type("Property"),
+            listOf(inner),
+            listOf(1),
+            doc.length
+        )
+        assertEquals("JsonText(Number)", shape(fragmentOf(outer)))
+    }
+
+    private companion object {
+        const val MAX_ADVANCE_STEPS = 200
+    }
+}


### PR DESCRIPTION
Fixes #321

## What was compared against

`@lezer/lr@1.4.10` (`npm pack`ed, `dist/index.js`), specifically the fragment-reuse block inside
**`LRParse.advanceStack`, `dist/index.js:1411-1428`**:

```js
if (this.fragments) {
    let strictCx = stack.curContext && stack.curContext.tracker.strict,
        cxHash = strictCx ? stack.curContext.hash : 0;
    for (let cached = this.fragments.nodeAt(start); cached;) {
        let match = this.parser.nodeSet.types[cached.type.id] == cached.type
            ? parser.getGoto(stack.state, cached.type.id) : -1;
        if (match > -1 && cached.length &&
            (!strictCx || (cached.prop(NodeProp.contextHash) || 0) == cxHash)) {
            stack.useNode(cached, match); return true;
        }
        if (!(cached instanceof Tree) || cached.children.length == 0 || cached.positions[0] > 0)
            break;
        let inner = cached.children[0];
        if (inner instanceof Tree && cached.positions[0] == 0) cached = inner; else break;
    }
}
```

The port factors this into `Parse.useCachedResult`
(`lezer-lr/.../lezer/lr/Parse.kt`), which checked only `type.id != 0` and `getGoto(...) >= 0`
before calling `stack.useNode`.

## Framing: pre-existing, not a regression from #324

This divergence predates #324 and is **not** something that PR introduced. #324 replaced
`advanceFully`'s standalone reimplementation with a loop over `advanceStack`, which removed a
ten-step force-reduce counter that had been an *incidental* backstop on that one path. The same
hazard was already present on the main advance path, where `advance()`'s inner loop has always
`continue`d while `advanceStack` returns `true`. #324 did not create the hazard; it removed a
coincidental cushion in one caller and made it worth closing at the source.

## The four dropped conditions

Every "upstream" tree below was produced by running `@lezer/lr@1.4.10` itself on the same parser
table (the `:lezer-lr` `TestJsonParser` spec, transcribed field-for-field into
`LRParser.deserialize` on the JS side), the same input and the same hand-built fragment. Every
"port before" tree is what this repo actually produced for the same case.

The shared scenario is the five-character document `"12345"`, which a fresh parse reads as
`JsonText(Number)`. Each case offers the parser a fragment holding a `String` node over the same
five characters, so reuse is legible directly in the tree: `JsonText(String)` means reused,
`JsonText(Number)` means not.

`bufferLength` is configured to 1 in these tests. That is load-bearing: upstream only builds a
`FragmentCursor` at all when `stream.end - from > bufferLength * 4`, so a short document needs a
small buffer length for upstream to consider reuse. Without it the upstream side of the comparison
would be vacuous.

### 1. `cached.length` — the latent non-termination

- **Upstream:** `match > -1 && cached.length && …` — a zero-length node is never reused.
- **Port:** reused it.
- **What it prevents:** `Stack.useNode` sets `pos = start + value.length`, so reusing a zero-length
  node does not move `stack.pos`, yet `advanceStack` reports `true`. Every caller loops while
  `advanceStack` returns `true` — `advance()`'s inner `while (true) { … continue }` and, since
  #324, `advanceFully` — so a grammar whose goto table lets the same zero-length node match again
  from the state it lands in spins forever.
- **Observed consequence on this grammar** (the JSON goto table has no such cycle, so it corrupts
  rather than hangs): the zero-length node was consumed twice and the document was mis-parsed.

  ```
  @lezer/lr 1.4.10:  JsonText(Number)
  port before:       JsonText(String,⚠,String,⚠(Number))
  ```

### 2. `nodeSet.types[cached.type.id] == cached.type` — node-set identity

- **Upstream:** computes `match` only when the cached node's type is *the very object* this
  parser's node set holds at that id; otherwise `match = -1`.
- **Port:** substituted `type.id == 0` (reject error nodes) and matched on the id alone.
- **What it prevents:** reusing a node whose type belongs to a *different* node set that happens to
  share the id — what a reconfigured parser (`configure(props = …)` rebuilds `nodeSet`) or a
  mixed-language fragment produces. The reused node keeps its own type object, so the wrong node
  type lands in the output tree.

  ```
  @lezer/lr 1.4.10:  JsonText(Number)
  port before:       JsonText(Foreign)      // a NodeType named "Foreign" carrying String's id
  ```

### 3. `contextHash` under a strict `ContextTracker`

- **Upstream:** when `stack.curContext.tracker.strict`, requires
  `(cached.prop(NodeProp.contextHash) || 0) == stack.curContext.hash`.
- **Port:** ignored the context entirely.
- **What it prevents:** a context-sensitive incremental parse reusing a node that was built under a
  *different* context and must be rebuilt. A missing `contextHash` prop reads as `0`, which is why
  a node with no prop is also refused against a non-zero stack hash.

  With a strict tracker whose start context hashes to 7:

  | cached node | `@lezer/lr` 1.4.10 | port before |
  | --- | --- | --- |
  | `contextHash` 7 | `JsonText(String)` | `JsonText(String)` (control — still reuses) |
  | `contextHash` 5 | `JsonText(Number)` | `JsonText(String)` |
  | no `contextHash` prop | `JsonText(Number)` | `JsonText(String)` |

### 4. Descent into a zero-offset first child

- **Upstream:** when the node itself does not qualify, retries with `cached.children[0]` provided
  the outer node is a `Tree` with children and `positions[0] == 0`.
- **Port:** gave up after the first node.
- **What it prevents:** losing reuse upstream performs. A fragment whose outer node has no goto
  from the current state can still contain a reusable node starting at the same position.

  ```
  @lezer/lr 1.4.10:  JsonText(String)   // descends into the String inside a Property at offset 0
  port before:       JsonText(Number)
  ```

  `reuseDoesNotDescendIntoAnOffsetFirstChild` guards the descent's own condition: a first child at
  `positions[0] == 1` is *not* descended into, on either side.

## Red-first

New `UseCachedResultTest` alone, on unmodified `origin/main` production code — **9 tests, 5
failed**:

```
UseCachedResultTest[jvm] > zeroLengthCachedNodeIsNotReused[jvm] FAILED
    Zero-length cached node must not be reused; tree=JsonText(String,⚠,String,⚠(Number)) length=5
    expected:<JsonText([Number])> but was:<JsonText([String,⚠,String,⚠(Number)])>
UseCachedResultTest[jvm] > cachedNodeFromAForeignNodeSetIsNotReused[jvm] FAILED
    Foreign-node-set cached node must not be reused; tree=JsonText(Foreign) length=5
    expected:<JsonText([Number])> but was:<JsonText([Foreign])>
UseCachedResultTest[jvm] > strictContextTrackerBlocksReuseWhenTheHashDiffers[jvm] FAILED
    expected:<JsonText([Number])> but was:<JsonText([String])>
UseCachedResultTest[jvm] > strictContextTrackerBlocksReuseWhenTheNodeCarriesNoHash[jvm] FAILED
    expected:<JsonText([Number])> but was:<JsonText([String])>
UseCachedResultTest[jvm] > reuseDescendsIntoAZeroOffsetFirstChild[jvm] FAILED
    Reuse must descend into a zero-offset first child; tree=JsonText(Number) length=5
    expected:<JsonText([String])> but was:<JsonText([Number])>
9 tests completed, 5 failed
```

The four that stayed green in that same run are the controls, and they matter:

- `plainParseReadsTheDocumentAsANumber` — without it every "not reused" expectation is vacuous.
- `matchingCachedNodeIsReused` — a plain matching `String` node *is* reused
  (`JsonText(String)`), so the reuse path is genuinely reached with these fragments and a
  "not reused" result elsewhere is a decision, not a dead code path.
- `strictContextTrackerAllowsReuseWhenTheHashMatches` — with a strict tracker installed, a matching
  hash still reuses.
- `reuseDoesNotDescendIntoAnOffsetFirstChild` — the descent is conditional, not unconditional.

Each port-before tree above is **byte-identical** to what a copy of upstream `dist/index.js`
patched to the port's condition set produces for the same case, which is an independent check that
the JS comparison harness models the port faithfully.

## How the non-termination test is bounded

No test can hang CI. `UseCachedResultTest` never calls `Parser.parse`; every case drives
`startParse` and counts `advance()` calls, failing with `MAX_ADVANCE_STEPS = 200` exceeded rather
than looping. A complete parse of this five-character document takes a handful of steps, so the cap
is several orders of magnitude of headroom.

To be explicit about what that does and does not prove: **on the JSON goto table the missing
`cached.length` guard corrupts the tree rather than hanging**, because `getGoto(4, String)` is `-1`
so the reuse cannot repeat from the state it lands in. The unbounded loop is the general hazard,
argued from `useNode` not advancing `pos` plus the `while`-on-`true` callers, not demonstrated —
I did not write a test that relies on a spinning parse.

## Mutation — four independent reverts

Each condition reverted on its own, with all tests in place. `210 tests completed` each time:

| revert | failing test(s) |
| --- | --- |
| drop `cached.length > 0` | `zeroLengthCachedNodeIsNotReused` (1 failed) |
| identity check → `type.id != 0` | `cachedNodeFromAForeignNodeSetIsNotReused` (1 failed) |
| drop the `contextHash` clause | `strictContextTrackerBlocksReuseWhenTheHashDiffers`, `strictContextTrackerBlocksReuseWhenTheNodeCarriesNoHash` (2 failed) |
| replace the descent with `break` | `reuseDescendsIntoAZeroOffsetFirstChild` (1 failed) |

No revert left the suite green, and no revert failed a test belonging to a different condition.

## Differential against real upstream, and honest scope

A differential harness ran this port against `@lezer/lr@1.4.10` over **1,336 generated incremental
cases** — 600 well-formed and 600 mangled JSON documents with a random edit at `bufferLength` 1,
plus 200 documents over 4,600 characters at the default `bufferLength` so upstream builds a
`FragmentCursor` without any configuration — asserting tree shape and `tree.length` on both sides
with the same `treeToString`.

**3 diffs before the change, the same 3 diffs after** — byte-identical sets. All three are
pre-existing error-recovery divergences on mangled input, unrelated to fragment reuse (e.g.
upstream `…,⚠,⚠` where the port produces `…,⚠,Object(⚠)`); they are unchanged by this PR and are
not claimed to be fixed by it.

The port's own output over that corpus is **identical before and after**, so on realistic JSON
incremental editing this is a **fidelity** change, not an observable bug fix. Rather than assert
that, I instrumented `useCachedResult` and measured it, with the counters as the control:

```
calls=1541187 withFragments=799794 nodeAtHit=2591 reused=877 strictCxSeen=0
identityBlocked=0 zeroLengthBlocked=0 contextHashBlocked=0 descents=381 reuseAfterDescent=0
```

- The site is demonstrably reached: 799,794 calls with fragments available, 2,591 candidate nodes
  from `FragmentCursor.nodeAt`, and **877 actual reuses** — the reuse branch is live in this
  corpus, so a zero elsewhere is a real zero and not a dead probe.
- **Condition 4 activates 381 times** in this corpus (the descent runs), but never reached a
  reusable child, which is why the corpus output does not move.
- **Conditions 1-3 are latent here**: 0 activations. `strictCxSeen=0` is definitional — the JSON
  grammar has no `ContextTracker`, so condition 3 cannot fire in this corpus at all.

The three latent branches were then made **fatal** (throwing when the condition is met) and the
whole corpus re-run: **no throw**. A negative control proves those probes can fire — driving the
three synthetic fragments from `UseCachedResultTest` with the same flags set raises
`PROBE zeroLength`, `PROBE identity` and `PROBE contextHash` respectively. All instrumentation was
removed before this PR; the diff is three files.

So: **all four are fidelity fixes with respect to a plain single-language JSON incremental corpus,
and all four are red-first observable** on fragments that a reconfigured parser, a mixed-language
fragment, a context-tracking grammar or a zero-length node genuinely produce.

## Verification

- `:lezer-lr:jvmTest` — **201 before, 210 after**, 0 failures. The nine added are exactly the nine
  `UseCachedResultTest` cases named above; no existing test changed, was renamed or removed
  (verified by diffing the full testcase-name lists from `build/test-results/jvmTest/*.xml`, not by
  the delta).
- `:lezer-lr:wasmJsBrowserTest` — 210 tests, 0 failures (10 result XMLs read).
- Dependent modules, all from `build/test-results/jvmTest/*.xml`, **811 before / 820 after** on the
  pre-rebase base, +9 all in `:lezer-lr` by name, 0 failures: `:lezer-common` 69, `:language` 91,
  `lang-cpp` 30, `lang-css` 16, `lang-go` 46, `lang-html` 32, `lang-java` 33, `lang-javascript` 39,
  `lang-json` 31, `lang-markdown` 63, `lang-php` 29, `lang-python` 41, `lang-rust` 32, `lang-sass`
  25, `lang-xml` 13, `lang-yaml` 20. Re-run after rebasing onto `6fbf5757`: 829 total, 0 failures —
  the +9 there is `:lezer-common` 69 → 78, which is #328's, not this PR's.
- `:lezer-lr:apiCheck` green; **no `.api` or `.klib.api` file moved** (`useCachedResult` is
  private).
- `:lezer-lr:ktlintCheck` and `:lezer-lr:spotlessCheck` green (both now gate `check` per #319).
- `changelog.py check --base-ref origin/main` — 15 fragments valid, `CHANGELOG.md` untouched.
- No `parity:` comments exist in any file this PR touches (positive-controlled: the same grep
  matches `CLAUDE.md` and `docs/testing-strategy.md`).

## Seen, not bundled

- **#323** (`getActions` before the default-reduce branch; split-stack routing) is untouched. It is
  entangled with one of the two port-only gates at the call site: the port guards reuse with
  `main != null`, where upstream gates only on `this.fragments` and does not even have a main token
  at that point, because it calls `getActions` *after* the reuse block. Removing that gate
  correctly means moving `getActions`, which is #323's change, so it is deliberately left alone.
- The other port-only gate, `!parser.hasWrappers()`, also has no upstream counterpart (upstream
  wraps the parse *around* an inner `Parse` that still reuses fragments). Left alone for the same
  scope reason; neither gate is one of the four conditions #321 lists.
- **A fifth divergence, not in #321 and not fixed here:** the port builds its `FragmentCursor`
  whenever `fragments.isNotEmpty() && parser.nodeSet.types.isNotEmpty()`, where upstream requires
  `fragments.length && this.stream.end - from > parser.bufferLength * 4` (`dist/index.js:1278`).
  The port therefore attempts fragment reuse on documents upstream would not, at default settings
  anything under ~4 KB. Worth its own issue; it changes *when* reuse is attempted, not what the
  conditions are, and folding it in here would have masked the four fixes rather than exposed them.
- **#327** (`Rec.CUT_DEPTH` stack-depth cut) is untouched.
- `lezer-common/.../SyntaxTree.kt` is untouched.
