### PR TITLE
Hold editor focus across a pointer press (#259)

### DIFF
--- a/changelog.d/259.fixed.md
+++ b/changelog.d/259.fixed.md
@@ -1,0 +1,14 @@
+- Fixed a mouse click in the editor blanking its focus on Android, so every key pressed after a
+  click was dropped (#259). The click itself was never wrong — it hit-tested correctly and placed
+  the caret where it should — but Compose then took the focus away, and the arrow keys, Home, End
+  and the keymap's shortcuts all did nothing until the editor was focused again by other means.
+  Anyone using the library on an Android tablet or on ChromeOS with a mouse or trackpad hit this on
+  every click; the same gestures with a finger always worked, which is why it went unrecognised for
+  so long. The cause is a Compose policy rather than a defect in the editor: `AndroidComposeView`
+  applies `AutoClearFocusBehavior.CursorBased` — the platform default — *after* the gesture
+  handlers have run, clearing focus when a mouse or touchpad press lands outside the bounds of the
+  focused node, and the editor's focused node is a 1-dp hidden input that no press ever lands
+  inside. The editor now captures its focus for the duration of a press, which is the framework's
+  own way of refusing that clear, and releases it as soon as the pointer lifts so nothing else is
+  kept from taking focus. Thirteen Android instrumented tests across `FocusManagementTest` and
+  `KeyboardHandlingTest` had been failing on this since the suite was introduced and now pass.

--- a/view/build.gradle.kts
+++ b/view/build.gradle.kts
@@ -64,14 +64,16 @@ kotlin {
 // Robolectric — the usual answer — turns out not to give a trustworthy result here. Under
 // `graphicsMode=LEGACY` all text measures to zero width, so every coordinate-based
 // assertion is meaningless (a click 30px into a line resolves to the line's last character);
-// under `graphicsMode=NATIVE` the metrics are right but a pointer press clears Compose focus,
-// which breaks the focus and keyboard suites. That last divergence was read here as an
+// under `graphicsMode=NATIVE` the metrics were right but a pointer press cleared Compose focus,
+// which broke the focus and keyboard suites. That last divergence was read here as an
 // environment artifact rather than a finding about the editor; the instrumented suite it asked
-// for has since REFUTED that — the same 5 focus + 8 keyboard failures reproduce on an API 34
-// emulator, tracked as #259. Robolectric is still not a trustworthy substitute (the LEGACY
-// metrics problem stands), but it was not wrong about this one. Android coverage for these
-// needs instrumented tests on a device/emulator; see #215. Everything else in `commonTest`
-// still runs here.
+// for REFUTED that — the same 5 focus + 8 keyboard failures reproduced on an emulator — and the
+// cause has since been traced and fixed (#259): Compose clears focus on a mouse or touchpad
+// press that lands outside the focused node, which had nothing to do with the graphics mode and
+// everything to do with the editor's focused node being a 1-dp hidden input. Robolectric is
+// still not a trustworthy substitute here, because the LEGACY metrics problem stands, but it was
+// not wrong about this one. Android coverage for these needs instrumented tests on a
+// device/emulator; see #215. Everything else in `commonTest` still runs here.
 // `testDebugUnitTest` / `testReleaseUnitTest` are the Android local-unit-test tasks; the JVM
 // target's task is `jvmTest` and is deliberately left alone.
 tasks.withType<Test>().matching { it.name.endsWith("UnitTest") }.configureEach {

--- a/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
+++ b/view/src/commonMain/kotlin/com/monkopedia/kodemirror/view/KodeMirror.kt
@@ -766,6 +766,59 @@ fun KodeMirror(session: EditorSession, modifier: Modifier = Modifier) {
                             }
                         }
                     }
+                    .pointerInput(Unit) {
+                        // Hold the editor's focus for the length of a press.
+                        //
+                        // Compose on Android takes focus away on a mouse or
+                        // touchpad press: `AndroidComposeView.dispatchTouchEvent`
+                        // applies `AutoClearFocusBehavior.CursorBased` — the
+                        // platform default — AFTER the gesture handlers above
+                        // have run, clearing focus whenever a cursor press lands
+                        // outside the bounds of the focused node. The editor's
+                        // focused node is the 1-dp hidden input, so no press in
+                        // the editor ever lands inside it and every mouse click
+                        // blanked the focus the gesture had just requested. The
+                        // click still placed the caret correctly; it was the key
+                        // after it that went nowhere (#259). A finger press is
+                        // not a cursor press and never tripped this, which is the
+                        // whole of the mouse/touch split the two suites saw.
+                        //
+                        // That clear is not forced, and a captured focus target
+                        // refuses a non-forced clear, so capturing across the
+                        // press vetoes it. Taken on the Final pass, which runs
+                        // after every Main-pass handler in the tree and therefore
+                        // after the gesture above has requested focus, and
+                        // released as soon as the last pointer lifts so nothing
+                        // else is ever kept from taking focus.
+                        var focusCaptured = false
+                        try {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    val event = awaitPointerEvent(
+                                        PointerEventPass.Final
+                                    )
+                                    val pressed = event.changes.any { it.pressed }
+                                    if (pressed) {
+                                        if (!focusCaptured) {
+                                            focusCaptured =
+                                                focusRequester.captureFocus()
+                                        }
+                                    } else if (focusCaptured) {
+                                        focusRequester.freeFocus()
+                                        focusCaptured = false
+                                    }
+                                }
+                            }
+                        } finally {
+                            // Only reached when this node detaches, where the
+                            // focus target's own detach forcibly clears the
+                            // capture anyway; freeing through a requester whose
+                            // node has already gone throws, so it is guarded.
+                            if (focusCaptured) {
+                                runCatching { focusRequester.freeFocus() }
+                            }
+                        }
+                    }
                     .pointerInput(session) {
                         awaitPointerEventScope {
                             var lastHoverDocPos: Int? = -1

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/PointerFocusRetentionTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/PointerFocusRetentionTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view.input
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTouchInput
+import com.monkopedia.kodemirror.commands.standardKeymap
+import com.monkopedia.kodemirror.view.EditorSessionImpl
+import com.monkopedia.kodemirror.view.keymapOf
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * A press on the editor must leave the editor still focused, whatever kind of
+ * pointer made it.
+ *
+ * # What this isolates (#259)
+ *
+ * Thirteen instrumented tests failed on Android with `Expected cursor at 11 but
+ * was at 0`, which reads as a hit-test failure and is not one: the press
+ * hit-tests correctly and dispatches the right selection, and it is the *key*
+ * afterwards that does nothing, because the press has taken the editor's focus
+ * away in between. Three diagnoses were reverse-engineered from that offset
+ * before anyone measured focus.
+ *
+ * The mechanism is Compose's, not the editor's. `AndroidComposeView`
+ * `dispatchTouchEvent` applies `AutoClearFocusBehavior.CursorBased` — the
+ * platform default — *after* the gesture handlers have run: on a press from a
+ * mouse or touchpad it clears focus whenever the press lands outside the bounds
+ * of the focused node. The editor's focused node is the 1-dp hidden input, so
+ * every mouse press anywhere in the editor lands "outside" it. Touch presses are
+ * not cursor presses and never trip it, which is why the same gesture worked
+ * with a finger and not with a mouse.
+ *
+ * # Why the two tests are a pair
+ *
+ * They differ in one thing: the pointer type. Keeping both means a fix for the
+ * mouse path that broke the touch path — the more likely accident, since the
+ * fix has to hold focus across a press without stopping anything else from ever
+ * taking it — fails here immediately rather than somewhere unrelated.
+ *
+ * Each asserts an exact offset, not "the cursor moved": the press at x=8 is two
+ * pixels into the content's 6-dp start padding, so it resolves to the first
+ * character of line 1 on any font, and `End` from there must land on 11, the
+ * end of `"Hello world"`. Position 0 is what a dropped key leaves behind, so an
+ * exact 11 is the only outcome that says the key was delivered.
+ */
+@OptIn(ExperimentalTestApi::class)
+class PointerFocusRetentionTest {
+
+    private val doc = "Hello world\nSecond line"
+    private val keymapExt = keymapOf(standardKeymap)
+
+    private fun SessionHolder.assertFocusHeld(pointer: String) {
+        val impl = session as EditorSessionImpl
+        assertTrue(
+            impl.hasFocus,
+            "Expected the editor to still hold focus after a $pointer press, but " +
+                "hasFocus=false. The press reached the editor and placed the cursor at " +
+                "${session.state.selection.main.head.value}; focus was then taken away " +
+                "from it, so every key that follows is dropped (#259)."
+        )
+    }
+
+    private fun SessionHolder.assertEndOfLineReached(pointer: String) {
+        val head = session.state.selection.main.head.value
+        assertTrue(
+            head == 11,
+            "Expected End to move the cursor to 11, the end of \"Hello world\", after a " +
+                "$pointer press, but it is at $head. At 0 the key was never delivered — " +
+                "the press placed the cursor there and the editor lost focus before the " +
+                "key arrived (#259)."
+        )
+    }
+
+    /**
+     * A mouse press must not cost the editor its focus: the key after it has to
+     * reach the keymap and move the cursor to the end of the line.
+     */
+    @Test
+    fun mousePress_keepsFocus_andTheKeyAfterItIsDelivered() = runEditorTest(
+        doc = doc,
+        extensions = keymapExt
+    ) { holder ->
+        onNodeWithTag("KodeMirror").performMouseInput {
+            click(Offset(8f, 15f))
+        }
+        waitForIdle()
+        holder.assertFocusHeld("mouse")
+
+        onNodeWithTag("KodeMirror_input").performKeyInput {
+            keyDown(Key.MoveEnd)
+            keyUp(Key.MoveEnd)
+        }
+        waitForIdle()
+        holder.assertEndOfLineReached("mouse")
+    }
+
+    /**
+     * The same gesture with a finger, which already worked on every platform.
+     * It is here so that holding focus across a mouse press cannot be bought by
+     * breaking the touch path.
+     */
+    @Test
+    fun touchPress_keepsFocus_andTheKeyAfterItIsDelivered() = runEditorTest(
+        doc = doc,
+        extensions = keymapExt
+    ) { holder ->
+        onNodeWithTag("KodeMirror").performTouchInput {
+            down(Offset(8f, 15f))
+            up()
+        }
+        waitForIdle()
+        holder.assertFocusHeld("touch")
+
+        onNodeWithTag("KodeMirror_input").performKeyInput {
+            keyDown(Key.MoveEnd)
+            keyUp(Key.MoveEnd)
+        }
+        waitForIdle()
+        holder.assertEndOfLineReached("touch")
+    }
+}


### PR DESCRIPTION
Fixes #259.

## What was wrong

On Android a **mouse click in the editor blanked its focus**, so every key pressed after a click
was dropped. Arrow keys, `Home`, `End` and the keymap's shortcuts all did nothing until the editor
was focused again by other means. Anyone using this library on an Android tablet or on ChromeOS
with a mouse or trackpad hit it on every click; the same gestures with a finger always worked.

The click itself was never wrong — it hit-tested correctly and dispatched the right selection. The
failing operation was the key press after it. Three diagnoses on the issue were reverse-engineered
from the assertion message `Expected cursor at 11 but was at 0` and all three were refuted, because
that `0` is the *click's correct answer*, not a wrong one.

## The mechanism, and it is Compose's rather than ours

`AndroidComposeView.dispatchTouchEvent` (androidx `ui-android`, since 1.10) applies
`AutoClearFocusBehavior.CursorBased` — **the platform default** — *after* it has run the gesture
handlers:

```
handleMotionEvent(event)                       // gestures run here; requestFocus() happens
...
isDown = actionMasked == ACTION_DOWN || ACTION_POINTER_DOWN
isCursor = event.isFromSource(SOURCE_MOUSE) || event.isFromSource(SOURCE_TOUCHPAD)
if (isDown && isCursor) {
    behavior = (parent as? View)?.getTag(R.id.auto_clear_focus_behavior_tag)
        ?: AutoClearFocusBehavior.Default          // Default == CursorBased
    if (behavior == CursorBased) {
        node = focusOwner.activeFocusTargetNode
        if (node != null && !node.requireLayoutCoordinates().boundsInRoot()
                .contains(Offset(event.x, event.y))) {
            focusOwner.clearFocus()                // clearFocus(force = false)
        }
    }
}
```

Read off the shipped bytecode of `ui-android`; `AutoClearFocusBehavior.Companion.getDefault` is
literally `getCursorBased`. Two facts follow directly:

- **Why mouse and not touch.** The guard is on the event *source*: `SOURCE_MOUSE` (`8194`) or
  `SOURCE_TOUCHPAD` (`1048584`). A touchscreen press is neither. That is the entire mouse/touch
  split the issue measured.
- **Why it is a teardown and not a missing request.** The clear runs *after* `handleMotionEvent`,
  i.e. after the editor's gesture has already called `focusRequester.requestFocus()` — which is
  exactly the issue's `focusBefore=true, focusAfterClick=false`.

The editor's focused node is the 1-dp hidden `BasicTextField`, so **no press anywhere in the editor
ever lands inside it** and every mouse press qualifies as "outside".

## The fix

`FocusOwnerImpl.clearFocus(force = false)`, and `FocusTransactions.clearFocus` returns `forced` for
a target in the `Captured` state — a captured target **refuses a non-forced clear**, and
`clearOwnerFocus()` runs only when the clear succeeded, so the View-level focus is untouched too.
So the editor now captures its focus for the duration of a press:

- taken on the **Final** pass, which runs after every Main-pass handler in the tree and therefore
  after the gesture above has requested focus (so the first click on an unfocused editor is covered
  too), and still inside `handleMotionEvent`, ahead of the auto-clear;
- released as soon as the last pointer lifts, so nothing else is ever kept from taking focus. The
  window is one press.

Compose does expose an opt-out — `AbstractComposeView.autoClearFocusBehavior` — but it lives on the
**host** view and would change focus behaviour for the whole window. That is not a library's to
set, so the fix is scoped to this editor and to the press.

The `view/build.gradle.kts` note that read the Robolectric `graphicsMode=NATIVE` focus divergence as
an environment artifact is corrected in the same change: it was this bug, seen early.

## Verification

**Red first.** `PointerFocusRetentionTest` was written before the fix and run against it. On an API
33 emulator (`:view:connectedDebugAndroidTest`), with the test present and the `KodeMirror.kt` hunk
absent — which is also the mutation control, since that hunk is the only functional difference
between the two trees:

```
107 executed, 14 failed, 0 skipped
```

failing set, by name (`build/outputs/androidTest-results/connected/debug/*.xml`, not the log):

```
FocusManagementTest.clickAfterDrag_focusIsRestored
FocusManagementTest.clickOnEditor_givesFocusToTextField
FocusManagementTest.clickThenArrowRight_cursorMoves
FocusManagementTest.dragThenKeyboard_cursorMoves
FocusManagementTest.multipleClicks_eachPreservesFocus
KeyboardHandlingTest.arrowDown_movesToNextLine
KeyboardHandlingTest.arrowLeft_movesCursorBackward
KeyboardHandlingTest.arrowRight_movesCursorForward
KeyboardHandlingTest.arrowUp_movesToPreviousLine
KeyboardHandlingTest.end_movesToLineEnd
KeyboardHandlingTest.home_movesToLineStart
KeyboardHandlingTest.modX_cutsSelectedText_offMacFamily
KeyboardHandlingTest.modX_cutsSelectedText_onMacFamily
PointerFocusRetentionTest.mousePress_keepsFocus_andTheKeyAfterItIsDelivered
```

The new **touch** twin passed in that same red run, which is the discriminator working: identical
test but for the pointer type.

**Green after.** Same emulator, same command:

```
107 executed, 0 failed, 0 skipped
```

All thirteen cleared **by name** — the list above, minus the new mouse test which also passes — and
nothing was substituted for them, which is the reason the comparison is by name and not by count.

Also green locally: `:view:jvmTest`, `:view:wasmJsBrowserTest` (303 tests, 0 failures — the new pair
runs there too), `:view:apiCheck`, `:view:ktlintCheck`, `spotlessCheck`.

**`.api` did not move** — no public API change; `apiCheck` passes against the committed dumps.

## Where the new test executes

`view/src/commonTest/.../input/PointerFocusRetentionTest.kt`. `view/build.gradle.kts` excludes
`com.monkopedia.kodemirror.view.input.*` from every `*UnitTest` task, so on **Android it runs
instrumented only**. Confirmed present in the results of all three suites run here:

- `view/build/test-results/jvmTest/TEST-…PointerFocusRetentionTest.xml` — `tests=2 failures=0`
- `view/build/test-results/wasmJsBrowserTest/TEST-wasmJsBrowserTest.…PointerFocusRetentionTest.xml`
  — `tests=2 failures=0`
- `view/build/outputs/androidTest-results/connected/debug/TEST-….xml` — both cases, and the mouse
  case is the one that was red before the fix

Both assertions are exact and font-metric independent: the press at `x=8` is two pixels into the
content's 6-dp start padding, so it resolves to the first character of line 1 on any font, and
`End` from there must land on **11**, the end of `"Hello world"`. Position 0 is what a dropped key
leaves behind, so an exact 11 is the only outcome that says the key was delivered.

## Not covered here

#275 stays open regardless: it is about the instrumented suite emitting a constant with no
expected-failure baseline, which remains true whatever these thirteen do.
