### PR TITLE
Port enterUnfinishedNodesBefore's two-cursor walk from @lezer/common (#253)

### DIFF
--- a/changelog.d/253.fixed.md
+++ b/changelog.d/253.fixed.md
@@ -1,0 +1,13 @@
+- Fixed `SyntaxNode.enterUnfinishedNodesBefore`, which stopped after a single level and reported
+  an unfinished node where there was none (#253). The port computed the child to test once,
+  outside its `while` loop, and every path through the loop body ended in `break`, so the walk
+  could never descend past the first child; it then returned that child rather than the node whose
+  right edge actually ends in a zero-length error node. `@lezer/common` keeps two cursors — one
+  walking down the right edge of the tree, one recording the last node whose right edge ended in
+  an unfinished (empty error) node — and returns the second, unchanged when there is no such node.
+  This is the primitive that finds the innermost still-open construct before a position, so it
+  backs continued indentation and completion context inside an unfinished block: on a JavaScript
+  document ending in `function f() {\n  if (x) {\n    a.` it returned `FunctionDeclaration(0-32)`
+  where `@lezer/javascript` returns `MemberExpression(30-32)`, and on the complete document
+  `function f() { let a = 1; }` it returned `FunctionDeclaration(0-27)` where upstream returns the
+  `Script` itself. Both cursors are now kept and the loop advances, matching `@lezer/common` 1.5.2.

--- a/lezer-common/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/common/SyntaxTree.kt
+++ b/lezer-common/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/common/SyntaxTree.kt
@@ -1300,19 +1300,21 @@ private fun stackIterator(tree: Tree, pos: Int, side: Int): NodeIterator {
 // ---- enterUnfinishedNodesBefore helper ----
 
 private fun enterUnfinishedNodesBefore(node: SyntaxNode, pos: Int): SyntaxNode {
-    var scan: SyntaxNode = node
-    val cursor = scan.childBefore(pos)
-    while (cursor != null) {
-        val last = cursor.lastChild
-        if (last == null || last.to != cursor.to) break
-        if (last.type.isError && last.from == last.to) {
-            scan = cursor
-            break
+    // `scan` walks down the right edge of the tree; `result` only advances when
+    // that edge actually ends in an unfinished (zero-length error) node.
+    var scan: SyntaxNode? = node.childBefore(pos)
+    var result: SyntaxNode = node
+    while (scan != null) {
+        val last = scan.lastChild
+        if (last == null || last.to != scan.to) break
+        scan = if (last.type.isError && last.from == last.to) {
+            result = scan
+            last.prevSibling
+        } else {
+            last
         }
-        scan = cursor
-        break
     }
-    return scan
+    return result
 }
 
 // ---- Tree.build implementation ----

--- a/lezer-common/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/common/TreeTest.kt
+++ b/lezer-common/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/common/TreeTest.kt
@@ -509,40 +509,187 @@ class TreeTest {
 
     // ---- enterUnfinishedNodesBefore tests ----
 
+    /** Error node type used by the enterUnfinishedNodesBefore fixtures. */
+    private val errorType = NodeType.define(
+        NodeTypeSpec(name = "\u26A0", id = 10, error = true)
+    )
+
+    private fun leaf(type: NodeType, length: Int) = Tree(type, emptyList(), emptyList(), length)
+
+    /** `name(from-to)` in document coordinates, so failures name a concrete node. */
+    private fun describe(node: SyntaxNode) = "${node.name}(${node.from}-${node.to})"
+
     @Test
     fun enterUnfinishedNodesBeforeOnNormalTree() {
         val tree = simple()
         val node = tree.topNode
-        // No error nodes, should return the node itself or a child
-        val result = node.enterUnfinishedNodesBefore(10)
-        assertNotNull(result)
+        // childBefore(10) is Pa(4-20), whose last child Br(16-18) does not reach
+        // Pa's end, so the walk stops immediately and the start node is returned.
+        assertEquals("T(0-20)", describe(node.enterUnfinishedNodesBefore(10)))
     }
 
     @Test
     fun enterUnfinishedNodesBeforeWithErrorNode() {
-        // Build a tree with an error node
-        val errorType = NodeType.define(
-            NodeTypeSpec(name = "\u26A0", id = 10, error = true)
-        )
+        // T(0-5) { a(0-3), err(3-3) }
         val a = types[1]
         val tree = Tree(
             types[0],
             listOf(
-                Tree(a, emptyList(), emptyList(), 3),
+                leaf(a, 3),
                 // zero-length error node
-                Tree(
-                    errorType,
-                    emptyList(),
-                    emptyList(),
-                    0
-                )
+                leaf(errorType, 0)
             ),
             listOf(0, 3),
             5
         )
-        val node = tree.topNode
-        val result = node.enterUnfinishedNodesBefore(5)
-        assertNotNull(result)
+        // childBefore(5) is the empty error node itself, which has no children,
+        // so the walk stops and the start node is returned.
+        assertEquals("T(0-5)", describe(tree.topNode.enterUnfinishedNodesBefore(5)))
+    }
+
+    @Test
+    fun enterUnfinishedNodesBeforeDescendsMoreThanOneLevel() {
+        // T(0-6) { Pa(0-6) { b(0-3), Br(3-6) { c(3-6), err(6-6) } } }
+        // The right edge is two levels deep and ends in a zero-length error
+        // node, so the walk must iterate twice to reach Br(3-6).
+        val tree = Tree(
+            types[0],
+            listOf(
+                Tree(
+                    types[4],
+                    listOf(
+                        leaf(types[2], 3),
+                        Tree(
+                            types[5],
+                            listOf(leaf(types[3], 3), leaf(errorType, 0)),
+                            listOf(0, 3),
+                            3
+                        )
+                    ),
+                    listOf(0, 3),
+                    6
+                )
+            ),
+            listOf(0),
+            6
+        )
+        assertEquals("Br(3-6)", describe(tree.topNode.enterUnfinishedNodesBefore(6)))
+    }
+
+    @Test
+    fun enterUnfinishedNodesBeforeDescendsThreeLevels() {
+        // T(0-9) { Pa(0-9) { b(0-3), Br(3-9) { c(3-6), Br(6-9) { c(6-9), err(9-9) } } } }
+        // Three descents are required before the empty error node is reached.
+        val tree = Tree(
+            types[0],
+            listOf(
+                Tree(
+                    types[4],
+                    listOf(
+                        leaf(types[2], 3),
+                        Tree(
+                            types[5],
+                            listOf(
+                                leaf(types[3], 3),
+                                Tree(
+                                    types[5],
+                                    listOf(leaf(types[3], 3), leaf(errorType, 0)),
+                                    listOf(0, 3),
+                                    3
+                                )
+                            ),
+                            listOf(0, 3),
+                            6
+                        )
+                    ),
+                    listOf(0, 3),
+                    9
+                )
+            ),
+            listOf(0),
+            9
+        )
+        assertEquals("Br(6-9)", describe(tree.topNode.enterUnfinishedNodesBefore(9)))
+    }
+
+    @Test
+    fun enterUnfinishedNodesBeforeStopsWhenRightEdgeFallsShort() {
+        // T(0-10) { Pa(0-10) { b(0-3), Br(3-6) { c(3-6), err(6-6) } } }
+        // Pa's last child ends at 6, short of Pa's own end at 10, so Pa is not
+        // "unfinished on its right edge" and the walk must stop before ever
+        // seeing the empty error node nested inside Br.
+        val tree = Tree(
+            types[0],
+            listOf(
+                Tree(
+                    types[4],
+                    listOf(
+                        leaf(types[2], 3),
+                        Tree(
+                            types[5],
+                            listOf(leaf(types[3], 3), leaf(errorType, 0)),
+                            listOf(0, 3),
+                            3
+                        )
+                    ),
+                    listOf(0, 3),
+                    10
+                )
+            ),
+            listOf(0),
+            10
+        )
+        assertEquals("T(0-10)", describe(tree.topNode.enterUnfinishedNodesBefore(10)))
+    }
+
+    @Test
+    fun enterUnfinishedNodesBeforeStaysPutWithoutErrorNode() {
+        // T(0-6) { Pa(0-6) { b(0-3), c(3-6) } } - no error node anywhere.
+        // The walk descends the right edge but never updates the result, so the
+        // start node comes back unchanged - not the visited child Pa(0-6).
+        val tree = Tree(
+            types[0],
+            listOf(
+                Tree(
+                    types[4],
+                    listOf(leaf(types[2], 3), leaf(types[3], 3)),
+                    listOf(0, 3),
+                    6
+                )
+            ),
+            listOf(0),
+            6
+        )
+        assertEquals("T(0-6)", describe(tree.topNode.enterUnfinishedNodesBefore(6)))
+    }
+
+    @Test
+    fun enterUnfinishedNodesBeforeContinuesIntoPreviousSibling() {
+        // T(0-6) { Pa(0-6) { Br(0-6) { c(0-6), err(6-6) }, err(6-6) } }
+        // After the outer empty error node the walk continues from its previous
+        // sibling Br(0-6), which itself ends in an empty error node.
+        val tree = Tree(
+            types[0],
+            listOf(
+                Tree(
+                    types[4],
+                    listOf(
+                        Tree(
+                            types[5],
+                            listOf(leaf(types[3], 6), leaf(errorType, 0)),
+                            listOf(0, 6),
+                            6
+                        ),
+                        leaf(errorType, 0)
+                    ),
+                    listOf(0, 6),
+                    6
+                )
+            ),
+            listOf(0),
+            6
+        )
+        assertEquals("Br(0-6)", describe(tree.topNode.enterUnfinishedNodesBefore(6)))
     }
 
     // ---- NodeType.match tests ----


### PR DESCRIPTION
`SyntaxNode.enterUnfinishedNodesBefore` was a one-step stub. It computed
`childBefore(pos)` once into a `val` **outside** the `while` loop — making the loop
condition constant — and every path through the body ended in `break`. It also returned
that child, where upstream returns the node whose *last child* is a zero-length error
node.

Upstream (`@lezer/common@1.5.2`, `dist/index.js:713`, verified against the npm tarball
locally) keeps **two** cursors: `scan` walks down the right edge of the tree, and `node`
advances **only** when that edge ends in a zero-length error node. The port had collapsed
them into one variable, which is why both the iteration and the return value were wrong.

```js
enterUnfinishedNodesBefore(pos) {
    let scan = this.childBefore(pos), node = this
    while (scan) {
        let last = scan.lastChild
        if (!last || last.to != scan.to) break
        if (last.type.isError && last.from == last.to) { node = scan; scan = last.prevSibling }
        else { scan = last }
    }
    return node
}
```

## What changes for a user

This is the primitive that finds the innermost still-open construct before a position; it
backs continued indentation and completion context inside an unfinished block.
`@codemirror/language`'s `syntaxIndentation` calls it as
`ast.resolveInner(pos, -1).resolve(pos, 0).enterUnfinishedNodesBefore(pos)`.

Running exactly that call on real `:lang-javascript` parses, before and after, against the
same call in upstream `@lezer/javascript@1.5.2` + `@lezer/common@1.5.2` as the oracle:

| document (cursor at end) | before (`main`) | after / upstream |
| --- | --- | --- |
| `function f() {\n  if (x) {\n    a.` | `FunctionDeclaration(0-32)` | `MemberExpression(30-32)` |
| `function f() {\n  if (x) {\n` | `FunctionDeclaration(0-26)` | `Block(24-26)` |
| `let o = {\n  a: 1,\n  b: {\n` | `VariableDeclaration(0-25)` | `ObjectExpression(23-25)` |
| `if (x) { y(` | `IfStatement(0-11)` | `ArgList(10-11)` |
| `class A { m() { if (b) {` | `ClassDeclaration(0-24)` | `Block(23-24)` |
| `foo(bar(baz(` | `ExpressionStatement(0-12)` | `ArgList(11-12)` |
| `function f() { let a = 1; }` (complete) | `FunctionDeclaration(0-27)` | `Script(0-27)` |

All seven disagreed with upstream before; all seven agree after. Note the last row: on a
**complete** document the stub reported an unfinished node where there is none.

Honest scoping caveat: today the only in-repo callers are `lang-liquid` and `lang-jinja`
completion (`LiquidComplete.kt:78`, `JinjaComplete.kt:80`), which call it directly on
`resolveInner(pos, -1)` without upstream's `.resolve(pos, 0)` — that start node is usually a
childless token, so the two implementations often agree there. `language/Indent.kt` does not
call it at all yet (the port's `TreeIndentContext` uses `resolveInner(pos)` only). So the
table above is the behaviour of the primitive itself measured on real trees, not a
demonstration of a currently-shipping indentation regression. I could not demonstrate a
user-visible change through `:lang-liquid` because its parser throws on **every** input
(see "Found separately" below).

## Tests — red first, on a concrete node

Five tests in `TreeTest.kt`, each asserting `name(from-to)` in document coordinates. The two
pre-existing tests here asserted only `assertNotNull(result)`; both are now pinned to a
concrete node (they pass unchanged on `main`, so they are strengthening, not fixing).

Copied alone onto unmodified `origin/main` @ `6fbf5757`
(`lezer-common/build/test-results/jvmTest/TEST-…TreeTest.xml`, 54 tests, 4 failures):

```
enterUnfinishedNodesBeforeDescendsMoreThanOneLevel[jvm]  expected:<Br(3-6)> but was:<Pa(0-6)>
enterUnfinishedNodesBeforeDescendsThreeLevels[jvm]       expected:<Br(6-9)> but was:<Pa(0-9)>
enterUnfinishedNodesBeforeContinuesIntoPreviousSibling[jvm] expected:<Br(0-6)> but was:<Pa(0-6)>
enterUnfinishedNodesBeforeStaysPutWithoutErrorNode[jvm]  expected:<T(0-6)>  but was:<Pa(0-6)>
```

Fixtures are two and three levels deep on the right edge, so a one-step stub and a correct
loop cannot give the same answer. Every expected value was computed by running the same
fixture through `@lezer/common@1.5.2` in node, not derived from the Kotlin.

## Mutation testing

Each defect is guarded independently. Suite run is `:lezer-common:jvmTest` + `:language:jvmTest`
(83 + 91 tests):

| mutant | killed by |
| --- | --- |
| M1 — revert the loop only (single step, correct return-value gating) | `DescendsMoreThanOneLevel`, `DescendsThreeLevels`, `ContinuesIntoPreviousSibling` (3 failed) |
| M2 — revert the return value only (`result = scan` on every iteration, loop intact) | `StaysPutWithoutErrorNode` (1 failed) |
| M3 — `last.prevSibling` → `last` | `ContinuesIntoPreviousSibling` (1 failed) |
| M4 — drop `last.to != scan.to` from the break guard | `StopsWhenRightEdgeFallsShort` (1 failed) |

M1 and M2 kill disjoint sets, so the broken iteration and the wrong return value are
separately pinned.

**M4 initially survived the entire suite** — the `last.to != scan.to` half of the break
guard could be deleted with nothing noticing. Per #328's review lesson (surviving mutant M6,
filed as #332), I hunted for that rather than reporting a clean sweep, and added
`enterUnfinishedNodesBeforeStopsWhenRightEdgeFallsShort` (Pa's last child ends at 6, short of
Pa's own end at 10, so the walk must stop before reaching an empty error node nested deeper).
That mutant is now killed.

After that, no line of the 12-line body survives deletion untested: the `result` initialiser
is pinned by `StaysPut`/`StopsWhenRightEdgeFallsShort`, `result = scan` and the `else { last }`
descent by the three descent tests, `last.prevSibling` by M3, the guard by M4. The `last == null`
half of the guard is not deletable (Kotlin null-safety).

## Regression surface

`:lezer-common`, `:language` and 10 `lang-*` suites, JVM, on a clean `origin/main` worktree
vs. this branch:

```
                     before   after
lezer-common             78      83
language                 91      91
lang-javascript          39      39
lang-python              41      41
lang-json                31      31
lang-html                32      32
lang-css                 16      16
lang-java                33      33
lang-markdown            63      63
lang-xml                 13      13
lang-liquid / lang-jinja   0       0   (no test sources)
TOTAL                   437     442    0 failed both sides
```

The +5 delta is accounted for **by name** — every added test is one of mine, and nothing was
removed:

```
+ TreeTest.enterUnfinishedNodesBeforeDescendsMoreThanOneLevel
+ TreeTest.enterUnfinishedNodesBeforeDescendsThreeLevels
+ TreeTest.enterUnfinishedNodesBeforeContinuesIntoPreviousSibling
+ TreeTest.enterUnfinishedNodesBeforeStaysPutWithoutErrorNode
+ TreeTest.enterUnfinishedNodesBeforeStopsWhenRightEdgeFallsShort
```

Counts read out of `build/test-results/**/*.xml`, not from Gradle's exit code.
`:lezer-common:wasmJsBrowserTest` also run (`CHROME_BIN=/usr/bin/chromium`): 83 tests, 0 failed,
confirmed from the XML.

`:lezer-common:apiCheck` green — no `.api` or `.klib.api` file moved (`git status` clean of
`api/`). `ktlintCheck` and `spotlessCheck` green.

## Found separately — not fixed here

- **`:lang-liquid` appears entirely non-functional.** `liquidLanguage.parser.parse(…)` throws
  on every input I tried, including plain `<p>hello</p>`
  (`IndexOutOfBoundsException: Index -12 out of bounds for length 3`) and unfinished liquid
  (`ArrayIndexOutOfBoundsException: Index 1458 out of bounds for length 1458` at
  `LRParser.getGoto`). `liquidTagLanguage.parser.parse("if a")` throws too. Identical on
  `origin/main` @ `6fbf5757` and on this branch, so it predates and is unrelated to this
  change. The module has no test sources at all, which is presumably why nobody noticed.
  Worth its own issue.
- `language/Indent.kt`'s `TreeIndentContext` uses `resolveInner(pos)` where
  `@codemirror/language` 6.11.3 uses `resolveInner(pos, -1).resolve(pos, 0)
  .enterUnfinishedNodesBefore(pos)` plus a `resolveStack` merge — a separate porting gap.
- Not touched, per instruction: #329, #330, #331, #332.

Fixes #253
