### PR TITLE
Restore parseMixed's base-tree origin so nested mixed parses read the right text

### DIFF
--- a/changelog.d/341.fixed.md
+++ b/changelog.d/341.fixed.md
@@ -1,0 +1,13 @@
+- `parseMixed` no longer loses the base tree's origin when it runs inside another `parseMixed`
+  (#341). A parse started over ranges builds its tree relative to `ranges[0].from`, but
+  `MixedParse` walked that tree from an origin of 0. At the top level the two agree, so the
+  defect was invisible until a nested parser was itself a mixed parser — from there every range
+  handed to the parsers below was short by the mounting node's start, and the innermost parser
+  silently lexed the wrong characters. `:lang-vue` and `:lang-angular` are exactly that shape
+  (`html` -> template grammar -> `javascript`), so every Vue interpolation and bound, directive
+  or event attribute, and every Angular interpolation and bound, event or structural attribute,
+  was parsed from text taken from the wrong place in the document: `<img [src]="url">` lexed
+  `rc]` in place of `url`, and `<button (click)="go()">` produced a bare `VariableName` over
+  `clic` — no exception, no error node, correct-looking node positions, wrong tree. The fix
+  restores `@lezer/common`'s origin, and is covered by a regression test asserting that the same
+  fragment parsed at five different document offsets yields the same tree shape.

--- a/lezer-common/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/common/Mix.kt
+++ b/lezer-common/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/common/Mix.kt
@@ -163,7 +163,13 @@ private class MixedParse(
         val fragmentCursor = FragmentCursor(fragments)
         var overlay: ActiveOverlay? = null
         var covered: CoverInfo? = null
-        val cursor = baseTree!!.cursor(
+        // The base tree is built relative to `ranges[0].from` (`@lezer/lr`'s `Parse.finish`
+        // passes it to `Tree.build` as `start`), so the walk has to begin at that offset to
+        // yield document coordinates. At the top level it is 0; nested inside another
+        // `parseMixed` it is the mounting node's start, and losing it shifts every range handed
+        // to the parsers below by exactly that much (#341).
+        val cursor = TreeCursor(
+            TreeNode(baseTree!!, ranges[0].from, null, 0),
             IterMode.INCLUDE_ANONYMOUS or IterMode.IGNORE_MOUNTS
         )
 

--- a/lezer-common/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/common/SyntaxTree.kt
+++ b/lezer-common/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/common/SyntaxTree.kt
@@ -872,9 +872,16 @@ internal class BufferNode(val context: BufferContext, val _parent: BufferNode?, 
  * Mutable tree walker. Walks a [Tree] depth-first, handling both
  * [Tree] and [TreeBuffer] children.
  */
-class TreeCursor internal constructor(root: Tree, internal val mode: Int = 0) : SyntaxNodeRef {
+class TreeCursor internal constructor(root: TreeNode, internal val mode: Int = 0) : SyntaxNodeRef {
+    /**
+     * Cursor over a whole tree, in that tree's own coordinates. A tree parsed over ranges is
+     * built relative to `ranges[0].from` (see `MixedParse.startInner`), so a caller that needs
+     * document coordinates must use the primary constructor with an offset [TreeNode] instead.
+     */
+    internal constructor(root: Tree, mode: Int = 0) : this(TreeNode(root, 0, null, 0), mode)
+
     @Suppress("ktlint:standard:property-naming", "ktlint:standard:backing-property-naming")
-    internal var _tree: TreeNode = TreeNode(root, 0, null, 0)
+    internal var _tree: TreeNode = root
     internal var buffer: BufferContext? = null
     private val stack = mutableListOf<Int>()
     internal var index: Int = 0
@@ -882,9 +889,9 @@ class TreeCursor internal constructor(root: Tree, internal val mode: Int = 0) : 
 
     override var type: NodeType = root.type
         private set
-    override var from: Int = 0
+    override var from: Int = root.from
         private set
-    override var to: Int = root.length
+    override var to: Int = root.to
         private set
     override val name: String get() = type.name
 

--- a/lezer-common/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/common/MixNestedOffsetTest.kt
+++ b/lezer-common/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/common/MixNestedOffsetTest.kt
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lezer.common
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * `parseMixed` nested inside another `parseMixed` — the three-deep shape used by every
+ * template language whose expressions are a third language (`:lang-vue` and `:lang-angular`
+ * are `html` -> template grammar -> `javascript`).
+ *
+ * A parse started over ranges builds its tree in coordinates relative to `ranges[0].from`
+ * (`@lezer/lr`'s `Parse.finish` passes `start = this.ranges[0].from` to `Tree.build`), so
+ * `MixedParse.startInner` has to walk that tree from an origin of `ranges[0].from` to get
+ * document coordinates back. At the top level `ranges[0].from` is 0 and the distinction is
+ * invisible; one level down it is the mounting node's start, and getting it wrong shifts the
+ * ranges handed to the *next* parser down by exactly that much — so the innermost parser
+ * silently lexes the wrong characters (#341).
+ *
+ * ## What these tests assert
+ *
+ * The property is **offset invariance**: the same fragment, parsed at several different
+ * document offsets, must produce the same tree shape with correspondingly shifted ranges.
+ * That is the mechanism itself, and it cannot pass vacuously — a shifted read produces a
+ * different shape at every offset but zero.
+ *
+ * Asserting one expected tree would be weaker. Under the defect the mounted subtree keeps its
+ * *length*, so it re-bases onto the correct document range at its mount point: the node
+ * positions look right and only the node **types** — which are derived from the characters
+ * actually read — are wrong. `assertOffsetInvariant` therefore compares full shape, not just
+ * positions.
+ *
+ * ## Fixture
+ *
+ * ```
+ * <pad>[[abc123]]<tail>
+ * ```
+ *
+ * - `outerParser` (level 1) finds `[[` ... `]]` and emits `Outer` over the brackets and their
+ *   contents. It nests `midParser` on that node.
+ * - `midParser` (level 2) emits `Mid` over its whole range with an `Inner` child covering the
+ *   contents between the two-character brackets. It nests `charParser` on `Inner`.
+ * - `charParser` (level 3) emits one leaf per character, typed `Letter` or `Digit`, so its
+ *   output is a direct readout of the text it was given.
+ *
+ * `abc123` must therefore always come back as `Letter Letter Letter Digit Digit Digit`. With
+ * the origin lost, level 3 is asked for `doc[from - pad, to - pad]`: at `pad = "xx"` that is
+ * `[[abc1`, and the readout changes to `Other Other Letter Letter Letter Digit`.
+ */
+class MixNestedOffsetTest {
+
+    // ---- Node types ----
+
+    private val outerTop = NodeType.define(NodeTypeSpec(name = "Doc", id = 0, top = true))
+    private val outerNode = NodeType.define(NodeTypeSpec(name = "Outer", id = 1))
+    private val midTop = NodeType.define(NodeTypeSpec(name = "Mid", id = 2, top = true))
+    private val innerNode = NodeType.define(NodeTypeSpec(name = "Inner", id = 3))
+    private val charTop = NodeType.define(NodeTypeSpec(name = "Chars", id = 4, top = true))
+    private val letter = NodeType.define(NodeTypeSpec(name = "Letter", id = 5))
+    private val digit = NodeType.define(NodeTypeSpec(name = "Digit", id = 6))
+    private val other = NodeType.define(NodeTypeSpec(name = "Other", id = 7))
+
+    /**
+     * A parse that reports its tree in coordinates relative to `ranges[0].from`, the way
+     * `@lezer/lr` does, and builds it from the text it is handed. Single contiguous range —
+     * these fixtures use no overlays, so `punchRanges` never splits one.
+     */
+    private class ImmediateParse(val tree: Tree) : PartialParse {
+        override var stoppedAt: Int? = null
+            private set
+        override val parsedPos: Int get() = tree.length
+        override fun stopAt(pos: Int) {
+            stoppedAt = pos
+        }
+        override fun advance(): Tree = tree
+    }
+
+    private fun parserOf(build: (text: String) -> Tree): Parser = object : Parser() {
+        override fun createParse(
+            input: Input,
+            fragments: List<TreeFragment>,
+            ranges: List<TextRange>
+        ): PartialParse {
+            val from = ranges.first().from
+            val to = ranges.last().to
+            return ImmediateParse(build(input.read(from, to)))
+        }
+    }
+
+    /** Level 3: one leaf per character, typed by what that character actually is. */
+    private val charParser: Parser = parserOf { text ->
+        Tree(
+            charTop,
+            text.map { c ->
+                val type = when {
+                    c in 'a'..'z' -> letter
+                    c in '0'..'9' -> digit
+                    else -> other
+                }
+                Tree(type, emptyList(), emptyList(), 1)
+            },
+            text.indices.toList(),
+            text.length
+        )
+    }
+
+    /**
+     * Level 2: `Mid` over the whole range with an `Inner` child covering everything but the
+     * two-character brackets at each end.
+     */
+    private val midBase: Parser = parserOf { text ->
+        Tree(
+            midTop,
+            listOf(Tree(innerNode, emptyList(), emptyList(), text.length - 4)),
+            listOf(2),
+            text.length
+        )
+    }
+
+    private val midParser: Parser = object : Parser() {
+        override fun createParse(
+            input: Input,
+            fragments: List<TreeFragment>,
+            ranges: List<TextRange>
+        ): PartialParse = parseMixed { node, _ ->
+            // Name-based, like `:lang-vue`'s `"Text" -> textMixed`: the nesting decision itself
+            // must not depend on the coordinates under test, so that a failure isolates the
+            // range handed to the inner parser rather than whether nesting happened at all.
+            if (node.name == "Inner") NestedParse(parser = charParser) else null
+        }(midBase.createParse(input, fragments, ranges), input, fragments, ranges)
+    }
+
+    /** Level 1: `Outer` over `[[` ... `]]`, with `midParser` nested on it. */
+    private val outerBase: Parser = parserOf { text ->
+        val start = text.indexOf("[[")
+        val end = text.indexOf("]]") + 2
+        Tree(
+            outerTop,
+            listOf(Tree(outerNode, emptyList(), emptyList(), end - start)),
+            listOf(start),
+            text.length
+        )
+    }
+
+    private val outerParser: Parser = object : Parser() {
+        override fun createParse(
+            input: Input,
+            fragments: List<TreeFragment>,
+            ranges: List<TextRange>
+        ): PartialParse = parseMixed { node, _ ->
+            if (node.name == "Outer") NestedParse(parser = midParser) else null
+        }(outerBase.createParse(input, fragments, ranges), input, fragments, ranges)
+    }
+
+    // ---- Helpers ----
+
+    /** Full shape including ranges, descending through mounted trees. */
+    private fun shape(tree: Tree): String = buildString {
+        tree.iterate(
+            IterateSpec(
+                enter = { node ->
+                    if (isNotEmpty()) append(' ')
+                    append("${node.name}[${node.from},${node.to}]")
+                    null
+                }
+            )
+        )
+    }
+
+    /** Just the node names, so a shape can be compared across offsets. */
+    private fun names(tree: Tree): String = buildString {
+        tree.iterate(
+            IterateSpec(
+                enter = { node ->
+                    if (isNotEmpty()) append(' ')
+                    append(node.name)
+                    null
+                }
+            )
+        )
+    }
+
+    private fun parseAt(pad: String, body: String = "abc123", tail: String = "!") =
+        outerParser.parse("$pad[[$body]]$tail")
+
+    /**
+     * Asserts the property: identical markup at different document offsets yields identical
+     * node names, and ranges that differ by exactly the offset.
+     */
+    private fun assertOffsetInvariant(pads: List<String>) {
+        val reference = parseAt(pads.first())
+        val referenceNames = names(reference)
+        val referencePad = pads.first().length
+        for (pad in pads.drop(1)) {
+            val tree = parseAt(pad)
+            assertEquals(
+                referenceNames,
+                names(tree),
+                "same fragment at offset ${pad.length} produced a different tree shape than at " +
+                    "offset $referencePad — the nested parse read shifted text"
+            )
+            // The document root always starts at 0 and simply grows with the padding, so it is
+            // the one node whose range does not translate; every node inside it must.
+            val delta = pad.length - referencePad
+            assertEquals(
+                shiftRanges(shape(reference).substringAfter(' '), delta),
+                shape(tree).substringAfter(' '),
+                "ranges at offset ${pad.length} are not the offset-$referencePad ranges " +
+                    "shifted by $delta"
+            )
+        }
+    }
+
+    private val rangeRegex = Regex("""\[(\d+),(\d+)]""")
+
+    private fun shiftRanges(s: String, delta: Int): String = rangeRegex.replace(s) { m ->
+        "[${m.groupValues[1].toInt() + delta},${m.groupValues[2].toInt() + delta}]"
+    }
+
+    // ---- Tests ----
+
+    @Test
+    fun oneLevelOfNestingIsUnaffected() {
+        // Control: level 1 -> level 2 only. `ranges[0].from` is 0 for the outer parse, so this
+        // path is correct with or without the fix, and its passing is what made the defect
+        // invisible.
+        val single = object : Parser() {
+            override fun createParse(
+                input: Input,
+                fragments: List<TreeFragment>,
+                ranges: List<TextRange>
+            ): PartialParse = parseMixed { node, _ ->
+                if (node.name == "Outer") NestedParse(parser = midBase) else null
+            }(outerBase.createParse(input, fragments, ranges), input, fragments, ranges)
+        }
+        // `iterate` descends through a non-overlay mount, so `Outer` is replaced by the `Mid`
+        // tree mounted on it — the level-2 parse is reported directly at document coordinates.
+        assertEquals(
+            "Doc[0,15] Mid[2,12] Inner[4,10]",
+            shape(single.parse("xx[[abc123]]!!!"))
+        )
+    }
+
+    @Test
+    fun twoLevelsDeepReadsTheDocumentAtTheRightOffset() {
+        assertEquals(
+            "Doc[0,11] Mid[0,10] Chars[2,8] " +
+                "Letter[2,3] Letter[3,4] Letter[4,5] Digit[5,6] Digit[6,7] Digit[7,8]",
+            shape(parseAt(""))
+        )
+        assertEquals(
+            "Doc[0,13] Mid[2,12] Chars[4,10] " +
+                "Letter[4,5] Letter[5,6] Letter[6,7] Digit[7,8] Digit[8,9] Digit[9,10]",
+            shape(parseAt("xx"))
+        )
+    }
+
+    @Test
+    fun twoLevelsDeepIsOffsetInvariant() {
+        assertOffsetInvariant(listOf("", "x", "xx", "xxxxxxx", "xxxxxxxxxxxxxxxxxxxx"))
+    }
+
+    @Test
+    fun offsetInvariantForAllDigitContent() {
+        // A body whose readout differs from the reference body, so a fixture that accidentally
+        // agreed with a shifted read of `abc123` cannot carry the suite.
+        val pads = listOf("", "xy", "xyzxyzx")
+        val reference = names(outerParser.parse("[[9a8b7c]]!"))
+        assertEquals("Doc Mid Chars Digit Letter Digit Letter Digit Letter", reference)
+        for (pad in pads.drop(1)) {
+            assertEquals(
+                reference,
+                names(outerParser.parse("$pad[[9a8b7c]]!")),
+                "offset ${pad.length} changed the readout of the innermost parse"
+            )
+        }
+    }
+
+    @Test
+    fun cursorOverAnOffsetRootReportsDocumentCoordinatesBeforeMoving() {
+        // `startInner` calls `nest(cursor, input)` on the root of the base tree before moving the
+        // cursor anywhere, so the root's own `from`/`to` are observable — a nest predicate whose
+        // node name matches the nested grammar's top rule reads them directly, and `input.read`
+        // against them would be off by the offset. Asserted here rather than through a parse
+        // because none of the fixtures above nest on a top node.
+        val tree = Tree(
+            midTop,
+            listOf(Tree(innerNode, emptyList(), emptyList(), 6)),
+            listOf(2),
+            10
+        )
+        val cursor = TreeCursor(TreeNode(tree, 7, null, 0), IterMode.INCLUDE_ANONYMOUS)
+        assertEquals("Mid[7,17]", "${cursor.name}[${cursor.from},${cursor.to}]")
+        cursor.firstChild()
+        assertEquals("Inner[9,15]", "${cursor.name}[${cursor.from},${cursor.to}]")
+        cursor.parent()
+        assertEquals("Mid[7,17]", "${cursor.name}[${cursor.from},${cursor.to}]")
+
+        // And the Tree-rooted convenience constructor keeps its zero origin.
+        val plain = TreeCursor(tree, IterMode.INCLUDE_ANONYMOUS)
+        assertEquals("Mid[0,10]", "${plain.name}[${plain.from},${plain.to}]")
+    }
+
+    @Test
+    fun shiftedReadIsNotDetectableFromPositionsAlone() {
+        // A negative control, and the standing argument against a weaker bar: this assertion
+        // passes both WITH and WITHOUT the #341 fix (verified — it was the one test in this
+        // class that stayed green against the defect). The mounted subtree keeps its length and
+        // re-bases onto the correct document range, so positions and node count come out
+        // identical to a correct parse and only the node types differ. Angular's
+        // `(click)="go()"` was the real-world instance: it lexed `clic` into a bare
+        // four-character `VariableName` sitting on the right four-character range, with no error
+        // node anywhere in the tree. Any future test here must assert node names, not spans.
+        val tree = parseAt("xx")
+        val positions = buildString {
+            tree.iterate(
+                IterateSpec(
+                    enter = { node ->
+                        if (isNotEmpty()) append(' ')
+                        append("[${node.from},${node.to}]")
+                        null
+                    }
+                )
+            )
+        }
+        assertEquals(
+            "[0,13] [2,12] [4,10] [4,5] [5,6] [6,7] [7,8] [8,9] [9,10]",
+            positions,
+            "positions must stay correct — this is the assertion that does NOT catch #341"
+        )
+    }
+}


### PR DESCRIPTION
Fixes #341

## The defect

A parse started over ranges builds its tree relative to `ranges[0].from` — `@lezer/lr`'s
`Parse.finish` passes it to `Tree.build` as `start` — but `MixedParse.startInner` walked that tree
with `baseTree.cursor(...)`, whose root sits at offset 0. Upstream `@lezer/common` `src/mix.ts:149`
seeds the walk explicitly:

```js
let cursor = new TreeCursor(new TreeNode(this.baseTree!, this.ranges[0].from, 0, null),
                            IterMode.IncludeAnonymous | IterMode.IgnoreMounts)
```

At the top level `ranges[0].from` is 0 and the two agree, which is why every existing test passed.
One level down it is the mounting node's start, so every `cursor.from`/`cursor.to` in `startInner`
was short by that amount — and those values feed both the `nest` predicate's `input.read` and the
`parseRanges` handed to the next parser down, which runs against the **full document**. A parser
nested two deep therefore lexed `doc[pos - ranges[0].from]`.

`:lang-vue` and `:lang-angular` are exactly that shape (`html` → template grammar → `javascript`).
Nothing threw; because the mounted subtree keeps its length it re-based onto the correct document
range, so positions and node counts looked right and several wrong subtrees contained no error node
at all.

## The fix

`TreeCursor` gains an internal primary constructor taking a `TreeNode`, mirroring upstream, with
the existing `Tree` form kept as a secondary constructor for `Tree.cursor` / `Tree.cursorAt`. The
constructor form was chosen over a local `cursorAtOffset` helper deliberately: this repo is a port,
and its recurring defect class is a locally-reasoned equivalent drifting from upstream control flow.

Both constructors are `internal`. **No public API moves** — `:lezer-common:apiCheck` green,
`git diff --name-only | grep '\.api$'` empty.

## Red-first

The test file at its final state, against unpatched `origin/main` @ `3c663304`:

```
MixNestedOffsetTest > twoLevelsDeepIsOffsetInvariant FAILED
    same fragment at offset 1 produced a different tree shape than at offset 0 —
    the nested parse read shifted text
    expected:<Doc Mid Chars [Letter Letter Letter Digit] Digit Digit>
     but was:<Doc Mid Chars [Other  Letter Letter Letter] Digit Digit>

MixNestedOffsetTest > twoLevelsDeepReadsTheDocumentAtTheRightOffset FAILED
    expected:<...Chars[4,10] [Letter[4,5] Letter[5,6] Letter[6,7] Digit[7,8] Digit][8,9] Digit[9,10]>
     but was:<...Chars[4,10] [Other[4,5]  Other[5,6]  Letter[6,7] Letter[7,8] Letter][8,9] Digit[9,10]>

MixNestedOffsetTest > offsetInvariantForAllDigitContent FAILED
    offset 2 changed the readout of the innermost parse
    expected:<Doc Mid Chars [Digit Lett]er Digit Letter Digi...>
     but was:<Doc Mid Chars [Other Oth]er Digit Letter Digi...>

MixNestedOffsetTest > oneLevelOfNestingIsUnaffected                 PASSED   (control)
MixNestedOffsetTest > shiftedReadIsNotDetectableFromPositionsAlone  PASSED   (control)
```

Both controls behaving as designed against the defect is what makes them controls rather than
padding.

## The test

The asserted property is **offset invariance**: the same fragment parsed at five different document
offsets must produce the same tree shape with correspondingly shifted ranges. That is the mechanism
itself, and it cannot pass vacuously — a shifted read produces a different shape at every offset but
zero.

The fixture is three parsers deep, mirroring vue/angular. The innermost emits one leaf per character
typed `Letter` / `Digit` / `Other`, so its output is a direct readout of the text it was handed; the
nest predicates are name-based (like `:lang-vue`'s `"Text" -> textMixed`) so a failure isolates the
*range* passed down rather than whether nesting happened at all.

Two controls ship with it:

- `oneLevelOfNestingIsUnaffected` — the path that was always correct, and whose passing hid this.
- `shiftedReadIsNotDetectableFromPositionsAlone` — passes **both** with and without the fix, kept as
  a standing argument that positions are the wrong thing to assert here. Angular's `(click)="go()"`
  was the real-world instance: it lexed `clic` into a bare four-character `VariableName` sitting on
  the right four-character range, with no error node anywhere in the tree.

## Regression surface

`parseMixed` underlies every mixed-language module and this changes coordinates, so eight modules
were run before and after (`--rerun-tasks`, JVM), counted from `build/test-results/jvmTest/*.xml`:

| module | before | after |
|---|---|---|
| `:lezer-common` | 83 | **89** |
| `:lang-html` | 32 | 32 |
| `:lang-javascript` | 39 | 39 |
| `:language` | 91 | 91 |
| `:lang-markdown` | 63 | 63 |
| `:lang-php` | 29 | 29 |
| `:lang-vue` | 0 | 0 |
| `:lang-angular` | 0 | 0 |
| **total** | **337** | **343** |

Zero failures and zero skipped in both runs. The whole `+6` delta is `MixNestedOffsetTest` in
`:lezer-common`; no existing test changed status in any module. `:lang-vue` and `:lang-angular` are
`NO-SOURCE` in both runs — that is #342 / #343 and is deliberately not addressed here.

End-to-end verification on the real modules (scratch probe, removed before commit):

```
<img [src]="url">          ExpressionAttributeValue[11,16] SingleExpression[12,15] VariableName[12,15]
<button (click)="go()">x   StatementAttributeValue[16,22] Script[17,21] ExpressionStatement[17,21]
                             CallExpression[17,21] VariableName[17,19] ArgList[19,21] ([19,20] )[20,21]
<p :class="foo">x</p>      ScriptAttributeValue[10,15] SingleExpression[11,14] VariableName[11,14]
<pppppppp :class="foo">    ScriptAttributeValue[17,22] SingleExpression[18,21] VariableName[18,21]
<p>{{ msg }}</p>           Interpolation[3,12] SingleExpression[5,10] VariableName[6,9] }}[10,12]
```

All correct, offset-invariant, no error nodes. Plain HTML, empty input and the `<template>`/
`<script>` SFC path are unchanged.

## Mutation sweep

The diff contains **no `&&` or `||`** — verified with a positive control (`Mix.kt` has 26 boolean
operators elsewhere; `git diff -U0 | grep -E '&&|\|\|'` over the added lines is empty). So the
condition-granularity sweep has nothing to enumerate, and the sweep was run at value granularity
over every constant and expression the diff introduces. Each mutant was run against
`:lezer-common`, `:lang-html`, `:lang-javascript`, `:language`, `:lang-markdown`, `:lang-php`:

| mutant | result |
|---|---|
| `Mix`: `ranges[0].from` → `0` (the original defect) | killed — 3 tests |
| `Mix`: `ranges[0].from` → `ranges[0].to` | killed — 3 tests |
| `Mix`: `ranges[0].from` → `ranges.last().from` | **survived** (see below) |
| `Mix`: root `TreeNode` index `0` → `1` | **survived — equivalent** (see below) |
| `TreeCursor`: `from = root.from` → `0` | killed — `cursorOverAnOffsetRoot…` |
| `TreeCursor`: `to = root.to` → `root.to - root.from` | killed — `cursorOverAnOffsetRoot…` |
| `TreeCursor`: secondary ctor offset `0` → `1` | killed — 3 tests |
| `TreeCursor`: `_tree = root` → zero-offset copy | killed — 3 tests |

`from = root.from` and `to = root.to` initially survived: they are the cursor's position *before it
moves*, and none of the parse fixtures nest on a top node. Since `startInner` calls
`nest(cursor, input)` on the base tree's root before moving anywhere, that position is genuinely
observable, so `cursorOverAnOffsetRootReportsDocumentCoordinatesBeforeMoving` was added to cover it
directly. Both are killed now.

Two survivors, both reported rather than papered over:

- **`ranges.last().from`** differs from `ranges[0].from` only when a *nested* parse is started with
  more than one range, i.e. an overlay-mounted mixed parse. Nothing in the repo constructs one —
  `ResolveOverlayTest` covers overlay *resolution*, not overlay parsing. Killing it needs a
  multi-range nested fixture, and building a half-faithful one (my synthetic parsers do not skip
  range gaps) seemed worse than saying so. Upstream is unambiguous that it is `ranges[0].from`.
  Happy to file the multi-range coverage gap as its own issue if you want it tracked.
- **root `TreeNode` index `0` → `1`** is an equivalent mutant. `index` is read only at
  `SyntaxTree.kt:636` and `:1034`, and both paths are guarded by a non-null `_parent`; this root has
  none. `0` is kept because upstream passes `0`.

## Checks run locally

`:lezer-common:ktlintCheck`, `spotlessCheck`, `:lezer-common:apiCheck` — all green. The two
`Unnecessary non-null assertion` warnings in `SyntaxTree.kt` are pre-existing: the same two appear on
unpatched `origin/main` (lines 692 and 1131, the latter shifted to 1138 by this diff). No new
warnings.

`python3 .github/scripts/changelog.py check --base-ref origin/main` green;
`changelog.d/341.fixed.md` added, `CHANGELOG.md` untouched.

## Scope

`Fixes #341` only. This should make #342 and #343 pass, but neither is closed here — both also carry
the zero-test-sources problem, which this PR does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117TCaHdmntXVUa9zoKvFCs
