### PR TITLE
Run advanceStack's steps in upstream's order (#323)

### DIFF
--- a/changelog.d/323.fixed.md
+++ b/changelog.d/323.fixed.md
@@ -1,0 +1,19 @@
+- `Parse.advanceStack` now runs its steps in `@lezer/lr` 1.4.10's order and routes ambiguity forks
+  the way upstream does (#323). It called `tokens.getActions(stack)` first, unconditionally, so a
+  state with a default reduce tokenised where upstream does not — recording a wider
+  `NodeProp.lookAhead` on the resulting nodes, which is what `TreeFragment.applyChanges` consults
+  to decide how far an edit invalidates reuse. That early tokenisation was also the only reason
+  the fragment-reuse block was gated on having a main token, so reuse was refused at any position
+  the grammar cannot tokenise, where upstream reuses the cached node. And the forks of an
+  ambiguous parse were all appended to the list being iterated, where upstream sends the ones that
+  consumed input straight to the caller's stack list and keeps the original stack on the *last*
+  action rather than the first; the resulting order decides which reading survives `advance`'s
+  pruning. On a 488-case corpus of ambiguous parses checked against `@lezer/lr` 1.4.10 the port
+  disagreed on 401 and now disagrees on none.
+- `:lang-python`'s indentation `ContextTracker` is no longer declared `strict = false` (#323).
+  `@lezer/python` leaves `strict` at its default of true; with it false the token cache never
+  invalidated on an indent-context change, so a stale `dedent` was reused where a keyword should
+  have been read. It was masked by the `advanceStack` order above: on 40 files from the Python 3.14
+  standard library the port disagreed with `@lezer/python` 1.1.18 on 11 before this change (36 with
+  the `advanceStack` fix alone) and on none after. `elif`/`else` branches, dedented bodies and
+  nested functions were the visible casualties.

--- a/lang-python/src/commonMain/kotlin/com/monkopedia/kodemirror/lang/python/PythonParser.kt
+++ b/lang-python/src/commonMain/kotlin/com/monkopedia/kodemirror/lang/python/PythonParser.kt
@@ -191,8 +191,7 @@ private val trackIndent = ContextTracker(
             context
         }
     },
-    hash = { context -> context.hash },
-    strict = false
+    hash = { context -> context.hash }
 ) as ContextTracker<Any?>
 
 // External tokenizers

--- a/lang-python/src/commonTest/kotlin/com/monkopedia/kodemirror/lang/python/PythonParserTest.kt
+++ b/lang-python/src/commonTest/kotlin/com/monkopedia/kodemirror/lang/python/PythonParserTest.kt
@@ -56,10 +56,9 @@ class PythonParserTest {
         parse("r\"foo\\\"\" + r'\\\\'")
     )
 
-    // TODO: Parser produces a minor error node in format replacement with nested quotes
     @Test
     fun testNestedQuoteTypes() = assertEquals(
-        "Script(ExpressionStatement(FormatString(FormatReplacement(String),\u26A0)))",
+        "Script(ExpressionStatement(FormatString(FormatReplacement(String))))",
         parse("f\"a{'b'}c\"")
     )
 

--- a/lezer-lr/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/lr/Parse.kt
+++ b/lezer-lr/src/commonMain/kotlin/com/monkopedia/kodemirror/lezer/lr/Parse.kt
@@ -407,15 +407,18 @@ internal class Parse(
             // it will go rather than consuming more input.
             return stack.forceReduce()
         }
-        val actions = tokens.getActions(stack)
-        val main = tokens.mainToken
 
-        // Try to use a cached tree fragment
-        if (main != null && !parser.hasWrappers()) {
+        // Try to use a cached tree fragment. Upstream gates this on nothing but
+        // the presence of a fragment cursor -- it has not tokenised yet at this
+        // point, which is why reuse is still attempted at a position where no
+        // tokenizer produces a token.
+        if (!parser.hasWrappers()) {
             if (useCachedResult(stack)) return true
         }
 
-        // Default reduce (no token needed)
+        // Default reduce (no token needed). Upstream returns here without ever
+        // calling `getActions`, so a default-reduce state does not tokenise --
+        // and does not extend the recorded lookahead -- at this position.
         val defaultReduce =
             parser.stateSlot(stack.state, ParseState.DEFAULT_REDUCE)
         if (defaultReduce > 0) {
@@ -423,32 +426,30 @@ internal class Parse(
             return true
         }
 
-        if (actions.isEmpty()) return false
-
-        // Use the first action; split stacks for any alternatives
-        val action0 = actions[0]
-        val token0 = if (actions.size >= 2) actions[1] else 0
-        val end0 = if (actions.size >= 3) actions[2] else start
-
-        if (actions.size > 3) {
-            var ai = 3
-            while (ai < actions.size) {
-                val action = actions[ai]
-                val token = actions[ai + 1]
-                val end = actions[ai + 2]
-                val s = stack.split()
-                s.apply(action, token, start, end)
-                if (split != null) {
-                    split.add(s)
-                } else if (newStacks != null) {
-                    pushStackDedup(s, newStacks)
-                }
-                ai += 3
+        val actions = tokens.getActions(stack)
+        var i = 0
+        while (i < actions.size) {
+            val action = actions[i]
+            val term = actions[i + 1]
+            val end = actions[i + 2]
+            i += 3
+            if (i == actions.size || split == null || newStacks == null) {
+                stack.apply(action, term, start, end)
+                return true
+            }
+            // An ambiguity: fork the stack and take this action on the copy.
+            val localStack = stack.split()
+            localStack.apply(action, term, start, end)
+            if (localStack.pos > start) {
+                // Forked stacks that consumed input belong in the caller's
+                // output list; only the ones still at `start` are re-examined
+                // by the loop that is currently walking `split`.
+                newStacks.add(localStack)
+            } else {
+                split.add(localStack)
             }
         }
-
-        stack.apply(action0, token0, start, end0)
-        return true
+        return false
     }
 
     /**

--- a/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/AdvanceStackTest.kt
+++ b/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/AdvanceStackTest.kt
@@ -51,14 +51,17 @@ class AdvanceStackTest {
      * a lookahead 40 characters past that position while the token itself ends
      * 8 characters past it.
      *
-     * The state at that position has a default reduce, so upstream reduces
-     * without tokenising and only records the lookahead further along, from the
-     * state that genuinely needs a token — where the same scan starts eight
-     * characters later and therefore reaches 32 rather than 40 past the node.
-     * Calling `getActions` first records the wider value, and writes it into
-     * the tree as `NodeProp.lookAhead`: a node that claims to depend on more of
-     * the document than it does, which is what `TreeFragment.applyChanges`
-     * consults to decide how far an edit invalidates reuse.
+     * Both orders record the same lookahead values (41 at position 1, 49 at
+     * position 9); what differs is *where in the stack buffer* the record
+     * lands. `Stack.setLookAhead` writes it at the current buffer position, and
+     * the state at position 1 has a default reduce — so calling `getActions`
+     * first puts the record inside the node that reduce is about to build,
+     * where upstream puts it after that node. `Tree.build` reads the buffer
+     * backwards and gives a node the last record it passed, so the port's
+     * `Item` picks up the *next* position's 49 instead of its own 41: it claims
+     * to depend on 40 characters past its end rather than 32. That number is
+     * what `TreeFragment.applyChanges` consults to decide how far an edit
+     * invalidates reuse.
      *
      * `bufferLength` 1 is load-bearing: `NodeProp.lookAhead` is only kept on
      * nodes that are materialised as `Tree` objects, not on nodes packed into a

--- a/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/AdvanceStackTest.kt
+++ b/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/AdvanceStackTest.kt
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2025 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lezer.lr
+
+import com.monkopedia.kodemirror.lezer.common.NodeProp
+import com.monkopedia.kodemirror.lezer.common.NodeType
+import com.monkopedia.kodemirror.lezer.common.Tree
+import com.monkopedia.kodemirror.lezer.common.TreeFragment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Parity with `@lezer/lr` 1.4.10's `LRParse.advanceStack`
+ * (`dist/index.js:1406-1457`) for the order of its steps and the routing of
+ * split stacks.
+ *
+ * Upstream runs, in this order: the `stoppedAt` brake, fragment reuse, the
+ * default reduce (which returns), the cut-depth guard, and only then
+ * `this.tokens.getActions(stack)`. The port used to call `getActions` first,
+ * which both tokenised in states upstream never tokenises in and made the
+ * fragment-reuse block conditional on a main token upstream does not have
+ * there.
+ *
+ * Every expectation below is what `@lezer/lr` 1.4.10 itself produces for the
+ * same parser table and the same input.
+ */
+class AdvanceStackTest {
+
+    // --- 1. `getActions` is called after the default-reduce branch ---
+
+    /**
+     * The document is one `X` followed by six `Wide` tokens. Tokenising at the
+     * position after the first `X` scans [WIDE_SCAN_PEEK] characters ahead but
+     * accepts only [WIDE_SCAN_TOKEN_LENGTH] of them, so the token cache records
+     * a lookahead 40 characters past that position while the token itself ends
+     * 8 characters past it.
+     *
+     * The state at that position has a default reduce, so upstream reduces
+     * without tokenising and only records the lookahead further along, from the
+     * state that genuinely needs a token — where the same scan starts eight
+     * characters later and therefore reaches 32 rather than 40 past the node.
+     * Calling `getActions` first records the wider value, and writes it into
+     * the tree as `NodeProp.lookAhead`: a node that claims to depend on more of
+     * the document than it does, which is what `TreeFragment.applyChanges`
+     * consults to decide how far an edit invalidates reuse.
+     *
+     * `bufferLength` 1 is load-bearing: `NodeProp.lookAhead` is only kept on
+     * nodes that are materialised as `Tree` objects, not on nodes packed into a
+     * buffer.
+     */
+    @Test
+    fun defaultReduceStateDoesNotRecordLookahead() {
+        val doc = "x" + "w".repeat(48)
+        val tree = wideScanParser.configure(ParserConfig(bufferLength = 1)).parse(doc)
+        assertEquals(
+            "Program(Item(Wrap(Inner(X)))," +
+                "Item[la=32](Wrap[la=32](Inner[la=32](Wide[la=32])))," +
+                "Item[la=32](Wrap[la=32](Inner[la=32](Wide[la=32])))," +
+                "Item(Wrap(Inner(Wide))),Item(Wrap(Inner(Wide)))," +
+                "Item(Wrap(Inner(Wide))),Item(Wrap(Inner(Wide))))",
+            dumpWithLookAhead(tree),
+            "Recorded lookahead"
+        )
+        assertEquals(49, tree.length)
+    }
+
+    /**
+     * Control for [defaultReduceStateDoesNotRecordLookahead]: the same grammar
+     * and tokenizer on a document short enough that no scan ever reaches
+     * `Lookahead.MARGIN` past its token, so no lookahead is recorded on either
+     * side. Without this, the assertion above could be passing because the
+     * fixture never records anything.
+     */
+    @Test
+    fun wideScanGrammarRecordsNoLookaheadOnAShortDocument() {
+        val doc = "x" + "w".repeat(16)
+        val tree = wideScanParser.configure(ParserConfig(bufferLength = 1)).parse(doc)
+        assertEquals(
+            "Program(Item(Wrap(Inner(X))),Item(Wrap(Inner(Wide)))," +
+                "Item(Wrap(Inner(Wide))))",
+            dumpWithLookAhead(tree),
+            "Short document records no lookahead"
+        )
+        assertEquals(17, tree.length)
+    }
+
+    // --- 2. Split stacks that advanced `pos` go to the caller's list ---
+
+    /**
+     * Three `Num` tokens in a grammar that cannot decide between `X { Num }`
+     * and `Y { Num Num }` fork the parse. Upstream applies the *last* action to
+     * the stack it was given and forks the earlier ones, sending any fork that
+     * consumed input straight to the caller's `newStacks`; the port applied the
+     * *first* action to the given stack and appended every fork to the list it
+     * was iterating.
+     *
+     * Both end up with the same set of stacks, but in the opposite order, and
+     * `advance`'s pruning keeps the *last* of two stacks it considers equally
+     * good — so the order decides which of the two readings of `"1 1 1"`
+     * survives.
+     */
+    @Test
+    fun ambiguitySplitsResolveLikeUpstream() {
+        assertEquals(
+            "Program(X(Num),Y(Num,Num))",
+            treeToString(ambiguousParser.parse("1 1 1")),
+            "Ambiguous parse of three numbers"
+        )
+        assertEquals(
+            "Program(X(Num),X(Num),Y(Num,Num))",
+            treeToString(ambiguousParser.parse("1 1 1 1")),
+            "Ambiguous parse of four numbers"
+        )
+        assertEquals(
+            "Program(X(Num),Y(Num,Num))",
+            treeToString(ambiguousParser.parse("22 333 1")),
+            "Ambiguous parse of three multi-digit numbers"
+        )
+    }
+
+    /**
+     * Control for [ambiguitySplitsResolveLikeUpstream]: inputs this grammar
+     * parses without an ambiguity, which agree on either routing. They guard
+     * the fixture itself — a mis-transcribed table would make the expectations
+     * above meaningless.
+     */
+    @Test
+    fun ambiguousGrammarParsesUnambiguousInput() {
+        assertEquals("Program(X(Num))", treeToString(ambiguousParser.parse("1")))
+        assertEquals("Program(Y(Num,Num))", treeToString(ambiguousParser.parse("1 1")))
+    }
+
+    // --- 3. Fragment reuse is not gated on having tokenised ---
+
+    private val jsonSmallBuffer = jsonParser.configure(ParserConfig(bufferLength = 1))
+
+    private fun stringFragment(doc: String): List<TreeFragment> {
+        val stringType = jsonSmallBuffer.nodeSet.types.first { it.name == "String" }
+        val cached = Tree(stringType, emptyList(), emptyList(), doc.length)
+        val root = Tree(NodeType.none, listOf(cached), listOf(0), doc.length)
+        return listOf(TreeFragment(0, doc.length, root, 0))
+    }
+
+    /**
+     * `"@@@@@"` contains no token this grammar can produce, so `getActions`
+     * leaves `mainToken` null there. Upstream has not tokenised at that point
+     * at all — it reaches the fragment-reuse block first — and reuses the
+     * cached `String` node. The port's `main != null` gate, which only exists
+     * because it tokenised early, refused the reuse and dropped into error
+     * recovery instead.
+     */
+    @Test
+    fun cachedNodeIsReusedWhereNoTokenMatches() {
+        val doc = "@@@@@"
+        assertEquals(
+            "JsonText(String)",
+            treeToString(jsonSmallBuffer.parse(doc, stringFragment(doc))),
+            "Reuse at a position with no matching token"
+        )
+    }
+
+    /**
+     * Control for [cachedNodeIsReusedWhereNoTokenMatches]: without a fragment
+     * the same document is an error, so the expectation above is about reuse
+     * and not about the grammar quietly accepting `"@"`.
+     */
+    @Test
+    fun untokenizableDocumentIsAnErrorWithoutAFragment() {
+        assertEquals(
+            "JsonText(\u26A0)",
+            treeToString(jsonSmallBuffer.parse("@@@@@")),
+            "Fresh parse of an untokenizable document"
+        )
+    }
+
+    /**
+     * Control for [cachedNodeIsReusedWhereNoTokenMatches]: the same fragment
+     * over a document that *does* tokenise is reused on either side, so the
+     * fragment and the cursor are known to work and a refusal above is a
+     * decision rather than a dead path.
+     */
+    @Test
+    fun cachedNodeIsReusedWhereATokenMatches() {
+        val doc = "12345"
+        assertEquals(
+            "JsonText(Number)",
+            treeToString(jsonSmallBuffer.parse(doc)),
+            "Fresh parse reads the document as a number"
+        )
+        assertEquals(
+            "JsonText(String)",
+            treeToString(jsonSmallBuffer.parse(doc, stringFragment(doc))),
+            "Reuse at a position with a matching token"
+        )
+    }
+}
+
+/**
+ * Render [tree] as `Name[la=N](child,child)`, where `[la=N]` is the node's
+ * `NodeProp.lookAhead` when it carries one.
+ *
+ * Unlike [treeToString] this keeps every node the cursor visits, since the
+ * point of the comparison is which node the recorded lookahead lands on.
+ */
+private fun dumpWithLookAhead(tree: Tree): String {
+    val cursor = tree.cursor()
+    fun render(): String {
+        val name = if (cursor.type.isError) "\u26A0" else cursor.name
+        val lookAhead = cursor.tree?.prop(NodeProp.lookAhead)
+        val children = mutableListOf<String>()
+        if (cursor.firstChild()) {
+            do {
+                children.add(render())
+            } while (cursor.nextSibling())
+            cursor.parent()
+        }
+        return buildString {
+            append(name)
+            if (lookAhead != null) append("[la=").append(lookAhead).append("]")
+            if (children.isNotEmpty()) {
+                append("(").append(children.joinToString(",")).append(")")
+            }
+        }
+    }
+    return render()
+}

--- a/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/TestAmbiguousParser.kt
+++ b/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/TestAmbiguousParser.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lezer.lr
+
+/**
+ * A deliberately ambiguous grammar, used to exercise the split-stack handling
+ * in `Parse.advanceStack`. Built with lezer-generator from:
+ *
+ * ```
+ * @top Program { (X | Y)+ }
+ * X { Num ~amb }
+ * Y { Num ~amb Num }
+ * @tokens { Num { $[0-9]+ } space { " " } }
+ * @skip { space }
+ * ```
+ *
+ * The `~amb` markers tell the generator to keep the shift/reduce conflict on
+ * `Num` rather than resolving it, so a state in this grammar offers two
+ * actions for the same token and the parser has to fork. That is the only
+ * shape in which `advanceStack`'s split handling runs at all -- JSON, the
+ * other fixture in this module, is unambiguous and never forks.
+ */
+val ambiguousParser: LRParser = LRParser.deserialize(
+    ParserSpec(
+        version = 14,
+        states = "tOVQPOOO[QPO'#C^OOQO'#Ca'#CaQVQPOOOOQO,58z,58zOOQO-E6_-E6_",
+        stateData = "g~OWOS~ORPO~ORSORQXUQX~O",
+        goto = "aUPPVPVZTQORQRORTR",
+        nodeNames = "\u26A0 Program X Num Y",
+        maxTerm = 8,
+        skippedNodes = listOf(0),
+        repeatNodeCount = 1,
+        tokenData = "f~RQpqX!Q![^~^OW~~cPR~!Q![^",
+        tokenizers = listOf(0),
+        topRules = mapOf("Program" to listOf(0, 1)),
+        tokenPrec = 0
+    )
+)

--- a/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/TestWideScanParser.kt
+++ b/lezer-lr/src/commonTest/kotlin/com/monkopedia/kodemirror/lezer/lr/TestWideScanParser.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lezer.lr
+
+/** How far [wideScanTokenizer] looks ahead before it decides on a token. */
+const val WIDE_SCAN_PEEK: Int = 40
+
+/** How much input [wideScanTokenizer] actually consumes for a `Wide` token. */
+const val WIDE_SCAN_TOKEN_LENGTH: Int = 8
+
+private const val WIDE_TERM = 1
+private const val W_CHAR = 'w'.code
+
+/**
+ * An external tokenizer that scans much further than it consumes.
+ *
+ * Real grammars do this: `@lezer/python`'s newline/indentation tokenizers and
+ * `@lezer/css`'s external tokens all read well past the token they accept. It
+ * matters here because [TokenCache.getActions] records
+ * `stack.setLookAhead(...)` whenever a token's scan reaches more than
+ * [Lookahead.MARGIN] characters past its end, and that recorded lookahead is
+ * written into the tree as `NodeProp.lookAhead`.
+ */
+val wideScanTokenizer: ExternalTokenizer = ExternalTokenizer({ input, _ ->
+    for (i in 0 until WIDE_SCAN_PEEK) input.peek(i)
+    if (input.peek(0) == W_CHAR &&
+        input.peek(WIDE_SCAN_TOKEN_LENGTH - 1) >= 0
+    ) {
+        input.acceptToken(WIDE_TERM, WIDE_SCAN_TOKEN_LENGTH)
+    }
+})
+
+/**
+ * A grammar whose only interesting feature is a chain of unit productions
+ * above an external token, so that shifting a token is followed by several
+ * default-reduce states at the same position. Built with lezer-generator from:
+ *
+ * ```
+ * @external tokens scan from "./tok" { Wide }
+ * @top Program { Item+ }
+ * Item { Wrap }
+ * Wrap { Inner }
+ * Inner { X | Wide }
+ * @tokens { X { "x" } }
+ * ```
+ *
+ * An external tokenizer is what puts a non-zero `TOKENIZER_MASK` on those
+ * default-reduce states (`@lezer/python` has 217 such states, `@lezer/css` 93,
+ * `@lezer/javascript` 232), which is what makes it observable whether the
+ * parser tokenises there.
+ */
+val wideScanParser: LRParser = LRParser.deserialize(
+    ParserSpec(
+        version = 14,
+        states = "zOQOROOOOOP'#Ca'#CaOOOP'#C`'#C`OOOP'#C_'#C_OOOP'#Cc'#Cc" +
+            "QQOROOOOOP-E6a-E6a",
+        stateData = "Y~OPPOUPO~O",
+        goto = "kWPPPX]aPeTSOTTROTTQOTQTORUT",
+        nodeNames = "\u26A0 Wide Program Item Wrap Inner X",
+        maxTerm = 8,
+        skippedNodes = listOf(0),
+        repeatNodeCount = 1,
+        tokenData = "Z~RP#l#mU~ZOU~",
+        tokenizers = listOf(wideScanTokenizer, 0),
+        topRules = mapOf("Program" to listOf(0, 2)),
+        tokenPrec = 0
+    )
+)


### PR DESCRIPTION
Fixes #323

## What was compared against

`@lezer/lr@1.4.10` (`npm pack`ed, `dist/index.js`), specifically **`LRParse.advanceStack`,
`dist/index.js:1406-1457`**. Upstream's order is:

```js
advanceStack(stack, stacks, split) {
    let start = stack.pos, { parser } = this;
    if (this.stoppedAt != null && start > this.stoppedAt) return stack.forceReduce() ? stack : null;
    if (this.fragments) { … reuse … }                                       // 1411-1428
    let defaultReduce = parser.stateSlot(stack.state, 4);
    if (defaultReduce > 0) { stack.reduce(defaultReduce); return true; }
    if (stack.stack.length >= 8400) { while (stack.stack.length > 6000 && stack.forceReduce()) {} }
    let actions = this.tokens.getActions(stack);
    for (let i = 0; i < actions.length;) {
        let action = actions[i++], term = actions[i++], end = actions[i++];
        let last = i == actions.length || !split;
        let localStack = last ? stack : stack.split();
        let main = this.tokens.mainToken;
        localStack.apply(action, term, main ? main.start : localStack.pos, end);
        if (last) return true;
        else if (localStack.pos > start) stacks.push(localStack);
        else split.push(localStack);
    }
    return false;
}
```

The port ran `tokens.getActions(stack)` **first**, then reuse (gated on `main != null`), then the
default reduce, and then a hand-rolled action loop. Also compared: `@lezer/python@1.1.18`, which is
the version `:lang-python`'s table is transcribed from (its `states` string is byte-identical to
1.1.18's and to no other release).

## The three divergences, and what each changes

### 1. `getActions` before the default-reduce branch

- **Upstream** (`1439`): `getActions` runs only after `if (defaultReduce > 0) { … return true }`.
- **Port**: `getActions` ran unconditionally at the top.
- **What it changes**: `getActions` calls `updateCachedToken`, which can call
  `stack.setLookAhead(...)` (when a token's scan reaches more than `Lookahead.MARGIN` past its
  end). `setLookAhead` writes a `-4` record into the stack buffer *at the current buffer position*,
  and `Tree.build` turns that into `NodeProp.lookAhead`. The recorded *values* are the same either
  way — in the fixture below, 41 at position 1 and 49 at position 9 — but recording before the
  default reduce puts the record **inside** the node that reduce is about to build, where upstream
  puts it after. `Tree.build` reads the buffer backwards and hands a node the last record it
  passed, so the port's node picks up the next position's 49 instead of its own 41 and claims 40
  characters of lookahead past its end where upstream says 32. `TreeFragment.applyChanges` consults
  exactly that prop to decide how far an edit invalidates reuse.

  This is reachable in real grammars: it needs a default-reduce state with a non-zero
  `TOKENIZER_MASK`, which `@lezer/python` has 217 of, `@lezer/javascript` 232, `@lezer/css` 93 and
  `@lezer/html` 39 (the mask bits set on those states are the external tokenizers). JSON — the only
  fixture this module had — has **zero**, which is why nothing here saw it.

  New fixture `TestWideScanParser.kt`: a grammar with an external tokenizer that peeks 40 characters
  ahead and consumes 8, over a chain of unit productions. On `"x" + "w"*48`:

  ```
  @lezer/lr 1.4.10:  …,Item[la=32](Wrap[la=32](Inner[la=32](Wide[la=32]))),…
  port before:       …,Item[la=40](Wrap[la=40](Inner[la=40](Wide[la=32]))),…
  ```

### 2. The `main != null` gate on fragment reuse

- **Upstream**: the reuse block is gated on `this.fragments` alone. Upstream has no main token at
  that point *because* it has not tokenised yet — which is precisely why removing this gate
  requires divergence 1's fix. It is one mechanism seen from two sides, so it is fixed here rather
  than left for a follow-up; #333 recorded it as belonging to this issue. **#334 is unaffected** —
  it is about the missing `stream.end - from > bufferLength * 4` threshold on building the
  `FragmentCursor`, which this PR does not touch, and its text never mentions this gate.
- **What it changes**: at a position no tokenizer can read, `getActions` leaves `mainToken` null, so
  the port skipped reuse and fell into error recovery where upstream reuses the cached node.

  ```
  doc "@@@@@" with a fragment holding a String node over 0..5
  @lezer/lr 1.4.10:  JsonText(String)
  port before:       JsonText(⚠)
  ```

- The other port-only gate, **`!parser.hasWrappers()`**, also has no upstream counterpart (upstream
  wraps the parse *around* an inner `Parse` that still reuses fragments). **Left alone and
  unchanged** — it is not part of this issue and nothing here measures it.

### 3. The action loop: which stack keeps the original, and where forks go

- **Upstream**: applies the **last** action to the stack it was given and forks the earlier ones;
  a fork that moved `pos` goes to `stacks` (the caller's `newStacks`), one that did not goes to
  `split` (the list being iterated).
- **Port**: applied the **first** action to the given stack, forked the rest, and appended *every*
  fork to `split`.
- **What it changes**: the same set of stacks reaches `newStacks`, in the opposite order.
  `advance`'s pruning removes the *earlier* of two stacks it rates equal, and `recovering`'s
  `sortByDescending { score }` is stable, so the order decides which reading of an ambiguous parse
  survives. New fixture `TestAmbiguousParser.kt` (`X { Num ~amb }` / `Y { Num ~amb Num }`):

  ```
  input "1 1 1"
  @lezer/lr 1.4.10:  Program(X(Num),Y(Num,Num))
  port before:       Program(Y(Num,Num),X(Num))
  ```

**Not fixed here:** upstream's `Rec.CutDepth` / `Rec.CutTo` guard between the default reduce and
`getActions` is still absent — that is #327, deliberately untouched.

## The `:lang-python` change, and why it cannot be separated

Fixing divergence 1 turned **8 `:lang-python` tests red**. It is not a regression in the fix; it
uncovered a second, independent porting bug that the wrong order was masking.

`@lezer/python`'s `trackIndent` does not pass `strict`, and `@lezer/lr`'s `ContextTracker`
defaults it to `true` (`this.strict = spec.strict !== false`). The port declared
`strict = false`. With `strict` false the stack's context hash is pinned to 0, so
`TokenCache.getActions`'s cache-validity test (`token.context != context`) never fires on an
indent-context change and a stale `dedent` is reused where a keyword should be read. Upstream's
order re-tokenised at a state the port reached only after the extra early tokenisation had
refreshed the cache, so the two bugs cancelled.

Proof of the causal chain, run in JS: `@lezer/lr@1.4.10` + `@lezer/python@1.1.18` **patched to
`strict: false`** produces, for `"if a: b()\n\nif 1 + 3:\n  pass\nelif 55 < 2:\n  pass\nelse:\n  pass"`:

```
Script(IfStatement(…),⚠(elif),AssignStatement(BinaryExpression(Number,CompareOp,Number),TypeDef(:,⚠)),PassStatement(pass),⚠(else),⚠(:),PassStatement(pass))
```

— which is exactly what this port produced with the `advanceStack` fix and `strict = false`.
Unpatched upstream produces the correct `elif`/`else` tree.

Measured on 40 files from the Python 3.14 standard library (`/usr/lib/python3.14/*.py`, ≤25 KB, no
tabs), against `@lezer/python@1.1.18` + `@lezer/lr@1.4.10` with a serializer that filters the same
anonymous nodes `:lang-python`'s `treeToString` does:

| | `strict = false` (port today) | `strict` default (upstream) |
| --- | --- | --- |
| `advanceStack` as on `main` | **11 / 40 differ** | 0 / 40 |
| `advanceStack` fixed | **36 / 40 differ** | **0 / 40** |

So `main` mis-parses 11 of 40 real Python files today — dedented bodies, `elif`/`else` branches and
nested functions lose their structure — and the pair takes that to zero. The dependency runs one
way: the `advanceStack` fix must not ship without the tracker fix (36/40 wrong if it does), while
the tracker fix stands on its own (0/40 either side of it). It is bundled here because this PR is
what makes it mandatory, and because splitting it would put this branch's CI red until the other
landed.

`PythonParserTest.testNestedQuoteTypes` changes with the tracker fix (it is green with the tracker
fix alone, on `main`'s `advanceStack`). It carried a `// TODO: Parser produces a minor error node in
format replacement with nested quotes` and asserted that stray `⚠`; `@lezer/python@1.1.18` produces
`FormatString(FormatReplacement({,String,}))` — no error node — so the expectation and the TODO are
both retired. That is the only expectation this PR edits.

Every `strict` flag in the repo was checked against its upstream grammar: `lang-javascript`
(`false`) and `lang-html` (`false`) match, `lang-go` and `lang-sass` (unset) match, `lang-xml`
(`false`) matches. **`lang-yaml` does not** — `@lezer/yaml@1.0.4` leaves `strict` unset and the port
declares `strict = false`. Its 20 tests pass either way and nothing here measures it, so it is filed
separately rather than bundled.

## Red-first

The three new fixtures and `AdvanceStackTest` alone, on unmodified `origin/main` production code —
**217 tests, 3 failed**:

```
AdvanceStackTest[jvm] > ambiguitySplitsResolveLikeUpstream[jvm] FAILED
    org.junit.ComparisonFailure: Ambiguous parse of three numbers expected:<Program([X(Num),Y(Num,]Num))> but was:<Program([Y(Num,Num),X(]Num))>
AdvanceStackTest[jvm] > defaultReduceStateDoesNotRecordLookahead[jvm] FAILED
    org.junit.ComparisonFailure: Recorded lookahead expected:<...(Inner(X))),Item[la=[32](Wrap[la=32](Inner[la=32]](Wide[la=32]))),Ite...> but was:<...(Inner(X))),Item[la=[40](Wrap[la=40](Inner[la=40]](Wide[la=32]))),Ite...>
AdvanceStackTest[jvm] > cachedNodeIsReusedWhereNoTokenMatches[jvm] FAILED
    org.junit.ComparisonFailure: Reuse at a position with no matching token expected:<JsonText([String])> but was:<JsonText([⚠])>
217 tests completed, 3 failed
```

The four controls passed in that same run, and they are what stop the three above from being
vacuous:

- `wideScanGrammarRecordsNoLookaheadOnAShortDocument` — the same grammar and tokenizer on a document
  too short for any scan to reach `Lookahead.MARGIN`; no lookahead is recorded on either side, so
  the fixture is not simply always printing `[la=…]`.
- `ambiguousGrammarParsesUnambiguousInput` — `"1"` and `"1 1"` agree on either routing, guarding the
  transcribed table itself.
- `untokenizableDocumentIsAnErrorWithoutAFragment` — `"@@@@@"` really is unparseable, so the reuse
  expectation is not the grammar quietly accepting `"@"`.
- `cachedNodeIsReusedWhereATokenMatches` — the same fragment over `"12345"` *is* reused on both
  sides, so the refusal above is a decision and not a dead cursor.

Each "port before" value is byte-identical to what a copy of upstream `dist/index.js`, patched to
the port's ordering and gate, produces for the same case — an independent check that the JS model
of the port used throughout this PR is faithful.

## Mutation — four independent reverts

Each applied alone to the fixed `advanceStack`, `:lezer-lr:jvmTest`, **217 tests** each time:

| revert | failing test(s) |
| --- | --- |
| `getActions` back above the reuse block (no gate) | `defaultReduceStateDoesNotRecordLookahead` (1 failed) |
| the whole pre-fix ordering: `getActions` first **and** the `main != null` gate | `defaultReduceStateDoesNotRecordLookahead`, `cachedNodeIsReusedWhereNoTokenMatches` (2 failed) |
| every fork routed to `split` | `ambiguitySplitsResolveLikeUpstream`, `ambiguousGrammarParsesUnambiguousInput` (2 failed) |
| first action kept on `stack`, upstream routing retained | `ambiguitySplitsResolveLikeUpstream` (1 failed) |

No revert left the suite green. The gate cannot be reverted *without* the ordering — that is the
entanglement — so its guard is the delta between rows 1 and 2. Row 3 also reddens the control,
which is honest: that routing changes `"1 1"` too.

A fifth revert, for the bundled tracker change: putting `strict = false` back, with `advanceStack`
fixed, turns **8 `:lang-python` tests red** (5 `PythonIndentTest`, 3 `PythonParserTest`) — that is
how the second bug was found. Reverting the `advanceStack` ordering while keeping the tracker fix
leaves `:lang-python` green at 41/41, which is the asymmetry described above.

### Which lines survive deletion untested

Two, both reported rather than removed:

- `split == null || newStacks == null` in the `last` condition (upstream's `!split`). Deleting the
  whole short-circuit, or just the redundant `newStacks == null` half, leaves **217 tests green**.
  It is upstream's own guard for the `advanceFully(stack, null, null)` caller, and reaching it needs
  an ambiguity during error recovery, which no test in this repo constructs.
- The `!parser.hasWrappers()` gate, which predates this PR and is deliberately untouched.

Upstream's `main ? main.start : localStack.pos` is *not* transcribed; the port passes `start`. They
are provably identical — `InputStream.reset(pos, token)` sets `token.start = pos`, and `getActions`
only reuses a cached token when `token.start == stack.pos` — so writing the elvis would add a branch
no test could ever separate.

## Observable vs fidelity, and a fatal probe

- **Divergence 1 is observable** on a grammar whose default-reduce states tokenise (219 → 0 diffs
  below), and **latent on single-language corpora**: instrumenting upstream's own `advanceStack` in
  JS, the port's order makes **134 lookahead records at a different buffer position** across 119
  Python standard-library files and **0 tree differences** result. On JSON it cannot fire at all —
  zero of JSON's 12 default-reduce states have a tokenizer mask.
- **Divergence 3's fork branch is unreachable in the rest of this module.** Made **fatal** (the
  branch throwing when taken) and the whole suite re-run: **220 tests, 3 failed**, and the three are
  exactly the ambiguous-grammar tests — the negative control that proves the probe fires. Every
  other test, including the 1,400-case JSON incremental differential and the 1,190-case wide-scan
  differential, passed, i.e. never forked. That is why this was invisible until an ambiguous fixture
  existed.
- **Divergence 2 is observable** (`JsonText(String)` vs `JsonText(⚠)`) and changes nothing on the
  JSON corpus, whose diff report is byte-identical before and after.

## Differential against real upstream

Every expectation is produced by running `@lezer/lr@1.4.10` itself on the same table.

| corpus | cases | diffs before | diffs after |
| --- | --- | --- | --- |
| JSON incremental (#333's, `TreeFragment.applyChanges` two-generation) | 1,400 | 15 | **15** (byte-identical report) |
| ambiguous grammar, well-formed input | 488 | 401 | **0** |
| ambiguous grammar, malformed input | 365 | 31 | **7** |
| wide-scan grammar (`bufferLength` 1 and 1024) | 1,190 | 219 | **0** |
| Python 3.14 stdlib files vs `@lezer/python@1.1.18` | 40 | 11 | **0** |

The JSON count of 15 is #338's known pre-existing error-recovery divergence set, unchanged
case-for-case. The 7 residual ambiguous diffs are the same class — every one is on input containing
characters the grammar cannot tokenise (`a`, `!`); **no well-formed case differs**. Net on that
corpus the recovery diffs also drop, 31 → 7.

## Verification

- `:lezer-lr:jvmTest` — **210 before, 217 after**, 0 failures. The seven added are exactly the seven
  `AdvanceStackTest` cases named above; no existing test changed, was renamed or removed (verified
  by diffing the full testcase-name lists from `build/test-results/jvmTest/*.xml`, not by the delta).
- `:lezer-lr:wasmJsBrowserTest` 217 tests / `:lang-python:wasmJsBrowserTest` 41 tests, 0 failures
  (13 result XMLs read).
- Dependent modules from `build/test-results/jvmTest/*.xml`, measured from the merge base
  `3c663304` on both sides: **834 before / 841 after**, +7 all in `:lezer-lr` by name, 0 failures.
  `:lezer-common` 83, `:language` 91, `lang-cpp` 30, `lang-css` 16, `lang-go` 46, `lang-html` 32,
  `lang-java` 33, `lang-javascript` 39, `lang-json` 31, `lang-markdown` 63, `lang-php` 29,
  `lang-python` 41, `lang-rust` 32, `lang-sass` 25, `lang-xml` 13, `lang-yaml` 20. `lang-python`
  stays at 41 — one expectation edited, none added or dropped.
- `:lezer-lr:apiCheck` and `:lang-python:apiCheck` green; **no `.api` or `.klib.api` file moved**
  (`advanceStack` and `trackIndent` are private).
- `:lezer-lr:ktlintCheck`, `:lezer-lr:spotlessCheck`, `:lang-python:ktlintCheck`,
  `:lang-python:spotlessCheck` green (all four gate `check` per #319).
- `changelog.py check --base-ref origin/main` — 19 fragments valid, `CHANGELOG.md` untouched.
- All instrumentation removed before this PR; `println`/`PROBE` grep over `lezer-lr/src` and
  `lang-python/src` is empty, positive-controlled against files where the same pattern does match.

## Seen, not bundled

- **#327** (`Rec.CutDepth` / `Rec.CutTo` stack-depth cut, between the default reduce and
  `getActions`) is untouched.
- **#334** (the missing `bufferLength * 4` threshold on building the `FragmentCursor`) is untouched
  and needs no amendment: it is about `Parse.init`, not about the `main != null` call-site gate this
  PR removes.
- **`lang-yaml`'s `strict = false`** contradicts `@lezer/yaml@1.0.4`, exactly as `lang-python`'s did.
  Filed as #346; no test in this repo currently distinguishes it, so it is not touched here.
- `lezer-common/.../SyntaxTree.kt` is untouched.
