### PR TITLE
Port the JavaScript mode's parseJS grammar so JS/TS indent tracks nesting (#276)

### DIFF
--- a/changelog.d/276.fixed.md
+++ b/changelog.d/276.fixed.md
@@ -1,0 +1,17 @@
+- Ported the JavaScript mode's `parseJS` grammar, so JavaScript, TypeScript, JSON and JSON-LD
+  auto-indent now tracks nesting instead of answering a constant (#276). Only the tokenizer had
+  been ported: nothing ever pushed a lexical scope, so `state.lexical` stayed the base `"block"`
+  scope and **every line of every document indented to column 0** — measured before the fix over
+  the documents in the issue and over nested fixtures such as
+  `function f() {\n  if (x) {\n    g();\n  }\n}`, which answered `0, 0, 0, 0, 0` where CodeMirror
+  answers `0, 2, 4, 2, 0`. The continuation stack, the lexical and variable scope stacks, the
+  `vardef` and double-indent-`switch` cases of `indent`, and the `maybeoperator` conjunct of its
+  scope walk are all now in place, checked line by line against
+  `@codemirror/legacy-modes` 6.5.0 `mode/javascript.js`.
+- As a consequence the mode now emits the grammar's token styles as well: definitions, property
+  names, TypeScript type positions, contextual keywords (`as`, `from`, `implements`, …) and
+  local-variable references were previously all reported as plain variables or identifiers
+  (#276). The Pug mode, which embeds this mode for its inline JavaScript, picks the same
+  improvement up.
+- Added `JavaScriptConfig.doubleIndentSwitch` (default `true`), upstream's switch for whether a
+  `switch` body indents by two units (#276).

--- a/legacy-modes/api/android/legacy-modes.api
+++ b/legacy-modes/api/android/legacy-modes.api
@@ -1291,17 +1291,19 @@ public final class com/monkopedia/kodemirror/legacy/modes/JSLexical {
 
 public final class com/monkopedia/kodemirror/legacy/modes/JavaScriptConfig {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;)V
-	public synthetic fun <init> (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()Z
 	public final fun component5 ()Ljava/lang/Integer;
 	public final fun component6 ()Lkotlin/text/Regex;
-	public final fun copy (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;)Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;
-	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;
+	public final fun component7 ()Z
+	public final fun copy (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;Z)Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDoubleIndentSwitch ()Z
 	public final fun getJson ()Z
 	public final fun getJsonld ()Z
 	public final fun getName ()Ljava/lang/String;

--- a/legacy-modes/api/jvm/legacy-modes.api
+++ b/legacy-modes/api/jvm/legacy-modes.api
@@ -1291,17 +1291,19 @@ public final class com/monkopedia/kodemirror/legacy/modes/JSLexical {
 
 public final class com/monkopedia/kodemirror/legacy/modes/JavaScriptConfig {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;)V
-	public synthetic fun <init> (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()Z
 	public final fun component5 ()Ljava/lang/Integer;
 	public final fun component6 ()Lkotlin/text/Regex;
-	public final fun copy (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;)Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;
-	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;ILjava/lang/Object;)Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;
+	public final fun component7 ()Z
+	public final fun copy (Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;Z)Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;
+	public static synthetic fun copy$default (Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;Ljava/lang/String;ZZZLjava/lang/Integer;Lkotlin/text/Regex;ZILjava/lang/Object;)Lcom/monkopedia/kodemirror/legacy/modes/JavaScriptConfig;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDoubleIndentSwitch ()Z
 	public final fun getJson ()Z
 	public final fun getJsonld ()Z
 	public final fun getName ()Ljava/lang/String;

--- a/legacy-modes/api/legacy-modes.klib.api
+++ b/legacy-modes/api/legacy-modes.klib.api
@@ -1360,8 +1360,10 @@ final class com.monkopedia.kodemirror.legacy.modes/JSLexical { // com.monkopedia
 }
 
 final class com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig { // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig|null[0]
-    constructor <init>(kotlin/String = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Int? = ..., kotlin.text/Regex = ...) // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.<init>|<init>(kotlin.String;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Int?;kotlin.text.Regex){}[0]
+    constructor <init>(kotlin/String = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Int? = ..., kotlin.text/Regex = ..., kotlin/Boolean = ...) // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.<init>|<init>(kotlin.String;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Int?;kotlin.text.Regex;kotlin.Boolean){}[0]
 
+    final val doubleIndentSwitch // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.doubleIndentSwitch|{}doubleIndentSwitch[0]
+        final fun <get-doubleIndentSwitch>(): kotlin/Boolean // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.doubleIndentSwitch.<get-doubleIndentSwitch>|<get-doubleIndentSwitch>(){}[0]
     final val json // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.json|{}json[0]
         final fun <get-json>(): kotlin/Boolean // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.json.<get-json>|<get-json>(){}[0]
     final val jsonld // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.jsonld|{}jsonld[0]
@@ -1381,7 +1383,8 @@ final class com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig { // com.mon
     final fun component4(): kotlin/Boolean // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.component4|component4(){}[0]
     final fun component5(): kotlin/Int? // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.component5|component5(){}[0]
     final fun component6(): kotlin.text/Regex // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.component6|component6(){}[0]
-    final fun copy(kotlin/String = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Int? = ..., kotlin.text/Regex = ...): com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.copy|copy(kotlin.String;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Int?;kotlin.text.Regex){}[0]
+    final fun component7(): kotlin/Boolean // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.component7|component7(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Int? = ..., kotlin.text/Regex = ..., kotlin/Boolean = ...): com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.copy|copy(kotlin.String;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Int?;kotlin.text.Regex;kotlin.Boolean){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.monkopedia.kodemirror.legacy.modes/JavaScriptConfig.toString|toString(){}[0]

--- a/legacy-modes/src/commonMain/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptGrammar.kt
+++ b/legacy-modes/src/commonMain/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptGrammar.kt
@@ -1,0 +1,1118 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.legacy.modes
+
+import com.monkopedia.kodemirror.language.StringStream
+
+/**
+ * One entry of the parser's continuation stack (`state.cc` upstream).
+ *
+ * Combinators are compared by identity in a few places -- the scope walk in
+ * `indent` looks for [JsGrammar.poplex], [JsGrammar.maybeelse],
+ * [JsGrammar.popcontext] and the two `maybeoperator` combinators -- so each
+ * named combinator must be a single instance per mode, exactly as each is a
+ * single closure per `mkJavaScript` call upstream.
+ *
+ * [lex] marks the combinators that only rearrange lexical/variable scopes and
+ * carry no token of their own; the parse loop drains them eagerly once a
+ * token has been consumed.
+ */
+internal abstract class JsComb(val lex: Boolean = false) {
+    abstract operator fun invoke(type: String, value: String): Boolean
+}
+
+private class JsFn(lex: Boolean, private val body: (String, String) -> Boolean) : JsComb(lex) {
+    override fun invoke(type: String, value: String): Boolean = body(type, value)
+}
+
+/** A single entry in a linked list of variable names in scope. */
+internal class JsVar(val name: String, val next: JsVar?)
+
+/** A variable scope. [block] marks a block scope rather than a function scope. */
+internal class JsContext(val prev: JsContext?, val vars: JsVar?, val block: Boolean)
+
+private val jsAtomicTypes = setOf(
+    "atom",
+    "number",
+    "variable",
+    "string",
+    "regexp",
+    "this",
+    "import",
+    "jsonld-keyword"
+)
+
+private val jsEndOfExpr = Regex("[;\\}\\)\\],]")
+private val jsCloser = Regex("[\\}\\)\\]]")
+private val jsIncDec = Regex("\\+\\+|--")
+private val jsTypeArgsAhead = Regex("^([^<>]|<[^<>]*>)*>\\s*\\(")
+private val jsBlankRest = Regex("^\\s*\$")
+private val jsWordAhead = Regex("^\\s*\\w")
+private val jsIsPredicate = Regex("^\\s*\\w+\\s+is\\b")
+private val jsColonAhead = Regex("^\\s*:\\s*")
+private val jsPropAhead = Regex("^\\s*:")
+private val jsClassMemberAhead = Regex("^\\s+#?[\\w\$\\u00a1-\\uffff]")
+
+/**
+ * The `parseJS` half of CodeMirror 5's JavaScript mode, as shipped in
+ * `@codemirror/legacy-modes` 6.5.0 `mode/javascript.js`.
+ *
+ * This is the continuation-stack grammar that maintains `state.lexical`; the
+ * tokenizer and the `StreamParser` surface live in `JavaScriptLegacy.kt`.
+ * Without it every `indent` query answers the base `"block"` scope's
+ * indentation and JavaScript indentation is a constant (issue #276).
+ */
+@Suppress("TooManyFunctions", "LargeClass")
+internal class JsGrammar(
+    private val isTS: Boolean,
+    private val jsonMode: Boolean,
+    private val jsonldMode: Boolean,
+    private val findFatArrow: (StringStream, JavaScriptState) -> Unit
+) {
+    private var cxState: JavaScriptState = JavaScriptState()
+    private var cxStream: StringStream = StringStream("", TAB_SIZE_PLACEHOLDER, 0)
+    private var cxMarked: String? = null
+    private var cxCc: MutableList<JsComb> = mutableListOf()
+    private var cxStyle: String? = null
+
+    // ---- Combinator utils ----
+
+    private fun comb(body: (String, String) -> Boolean): JsComb = JsFn(false, body)
+
+    private fun lexOp(body: () -> Unit): JsComb = JsFn(true) { _, _ ->
+        body()
+        false
+    }
+
+    private fun pass(vararg c: JsComb): Boolean {
+        for (i in c.indices.reversed()) cxCc.add(c[i])
+        return false
+    }
+
+    private fun cont(vararg c: JsComb): Boolean {
+        pass(*c)
+        return true
+    }
+
+    private fun inList(name: String, list: JsVar?): Boolean {
+        var v = list
+        while (v != null) {
+            if (v.name == name) return true
+            v = v.next
+        }
+        return false
+    }
+
+    private fun inScope(state: JavaScriptState, varname: String): Boolean {
+        if (inList(varname, state.localVars)) return true
+        var c = state.context
+        while (c != null) {
+            if (inList(varname, c.vars)) return true
+            c = c.prev
+        }
+        return false
+    }
+
+    private fun register(varname: String) {
+        val state = cxState
+        cxMarked = "def"
+        val context = state.context ?: return
+        if (state.lexical.info == "var" && context.block) {
+            val newContext = registerVarScoped(varname, context)
+            if (newContext != null) {
+                state.context = newContext
+                return
+            }
+        } else if (!inList(varname, state.localVars)) {
+            state.localVars = JsVar(varname, state.localVars)
+            return
+        }
+        // Falling through means this is global; no globalVars are configured
+        // by any of the modes this file exports, so there is nothing to record.
+    }
+
+    private fun registerVarScoped(varname: String, context: JsContext?): JsContext? = when {
+        context == null -> null
+        context.block -> {
+            val inner = registerVarScoped(varname, context.prev)
+            when {
+                inner == null -> null
+                inner === context.prev -> context
+                else -> JsContext(inner, context.vars, true)
+            }
+        }
+        inList(varname, context.vars) -> context
+        else -> JsContext(context.prev, JsVar(varname, context.vars), false)
+    }
+
+    private fun isModifier(name: String): Boolean = name == "public" ||
+        name == "private" ||
+        name == "protected" ||
+        name == "abstract" ||
+        name == "readonly"
+
+    // ---- Scope combinators ----
+
+    private val defaultVars = JsVar("this", JsVar("arguments", null))
+
+    private val pushcontext = lexOp {
+        cxState.context = JsContext(cxState.context, cxState.localVars, false)
+        cxState.localVars = defaultVars
+    }
+
+    private val pushblockcontext = lexOp {
+        cxState.context = JsContext(cxState.context, cxState.localVars, true)
+        cxState.localVars = null
+    }
+
+    /** Identity-compared by `indent`; must stay a single instance. */
+    val popcontext = lexOp {
+        // Upstream dereferences `state.context` unguarded here. Every push is
+        // paired with a pop by construction, but the stack is also rebuilt from
+        // a copied state, so guard rather than throw.
+        val context = cxState.context ?: return@lexOp
+        cxState.localVars = context.vars
+        cxState.context = context.prev
+    }
+
+    private fun pushlex(type: String, info: String? = null): JsComb = lexOp {
+        val state = cxState
+        var indent = state.indented
+        if (state.lexical.type == "stat") {
+            indent = state.lexical.indented
+        } else {
+            var outer: JSLexical? = state.lexical
+            while (outer != null && outer.type == ")" && outer.align == true) {
+                indent = outer.indented
+                outer = outer.prev
+            }
+        }
+        state.lexical = JSLexical(indent, cxStream.column(), type, null, state.lexical, info)
+    }
+
+    /** Identity-compared by `indent`; must stay a single instance. */
+    val poplex = lexOp {
+        val state = cxState
+        val prev = state.lexical.prev
+        if (prev != null) {
+            if (state.lexical.type == ")") state.indented = state.lexical.indented
+            state.lexical = prev
+        }
+    }
+
+    private inner class Expect(private val wanted: String) : JsComb() {
+        override fun invoke(type: String, value: String): Boolean = when {
+            type == wanted -> cont()
+            wanted == ";" || type == "}" || type == ")" || type == "]" -> pass()
+            else -> cont(this)
+        }
+    }
+
+    private fun expect(wanted: String): JsComb = Expect(wanted)
+
+    private inner class CommaSep(
+        private val what: JsComb,
+        private val end: String,
+        private val sep: String? = null
+    ) : JsComb() {
+        private val proceed: JsComb = object : JsComb() {
+            override fun invoke(type: String, value: String): Boolean {
+                if (if (sep != null) sep.contains(type) else type == ",") {
+                    return cont(
+                        comb { t, v ->
+                            if (t == end || v == end) pass() else pass(what)
+                        },
+                        this
+                    )
+                }
+                if (type == end || value == end) return cont()
+                if (sep != null && sep.contains(";")) return pass(what)
+                return cont(expect(end))
+            }
+        }
+
+        override fun invoke(type: String, value: String): Boolean {
+            if (type == end || value == end) return cont()
+            return pass(what, proceed)
+        }
+    }
+
+    private fun commasep(what: JsComb, end: String, sep: String? = null): JsComb =
+        CommaSep(what, end, sep)
+
+    private fun contCommasep(
+        what: JsComb,
+        end: String,
+        info: String? = null,
+        vararg rest: JsComb
+    ): Boolean {
+        for (c in rest) cxCc.add(c)
+        return cont(pushlex(end, info), commasep(what, end), poplex)
+    }
+
+    // ---- Statements ----
+
+    @Suppress("CyclomaticComplexMethod", "ReturnCount", "LongMethod")
+    val statement: JsComb = comb { type, value ->
+        when {
+            type == "var" -> cont(pushlex("vardef", value), vardef, expect(";"), poplex)
+            type == "keyword a" -> cont(pushlex("form"), parenExpr, statement, poplex)
+            type == "keyword b" -> cont(pushlex("form"), statement, poplex)
+            type == "keyword d" ->
+                if (cxStream.match(jsBlankRest, consume = false) != null) {
+                    cont()
+                } else {
+                    cont(pushlex("stat"), maybeexpression, expect(";"), poplex)
+                }
+            type == "debugger" -> cont(expect(";"))
+            type == "{" -> cont(pushlex("}"), pushblockcontext, block, poplex, popcontext)
+            type == ";" -> cont()
+            type == "if" -> {
+                if (cxState.lexical.info == "else" && cxState.cc.lastOrNull() === poplex) {
+                    cxState.cc.removeAt(cxState.cc.size - 1)("", "")
+                }
+                cont(pushlex("form"), parenExpr, statement, poplex, maybeelse)
+            }
+            type == "function" -> cont(functiondef)
+            type == "for" ->
+                cont(pushlex("form"), pushblockcontext, forspec, statement, popcontext, poplex)
+            type == "class" || (isTS && value == "interface") -> {
+                cxMarked = "keyword"
+                cont(pushlex("form", if (type == "class") type else value), className, poplex)
+            }
+            type == "variable" -> tsOrPlainVariableStatement(value)
+            type == "switch" -> cont(
+                pushlex("form"),
+                parenExpr,
+                expect("{"),
+                pushlex("}", "switch"),
+                pushblockcontext,
+                block,
+                poplex,
+                poplex,
+                popcontext
+            )
+            type == "case" -> cont(expression, expect(":"))
+            type == "default" -> cont(expect(":"))
+            type == "catch" ->
+                cont(pushlex("form"), pushcontext, maybeCatchBinding, statement, poplex, popcontext)
+            type == "export" -> cont(pushlex("stat"), afterExport, poplex)
+            type == "import" -> cont(pushlex("stat"), afterImport, poplex)
+            type == "async" -> cont(statement)
+            value == "@" -> cont(expression, statement)
+            else -> pass(pushlex("stat"), expression, expect(";"), poplex)
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun tsOrPlainVariableStatement(value: String): Boolean {
+        if (isTS && value == "declare") {
+            cxMarked = "keyword"
+            return cont(statement)
+        }
+        if (isTS &&
+            (value == "module" || value == "enum" || value == "type") &&
+            cxStream.match(jsWordAhead, consume = false) != null
+        ) {
+            cxMarked = "keyword"
+            return when (value) {
+                "enum" -> cont(enumdef)
+                "type" -> cont(typename, expect("operator"), typeexpr, expect(";"))
+                else -> cont(
+                    pushlex("form"),
+                    pattern,
+                    expect("{"),
+                    pushlex("}"),
+                    block,
+                    poplex,
+                    poplex
+                )
+            }
+        }
+        if (isTS && value == "namespace") {
+            cxMarked = "keyword"
+            return cont(pushlex("form"), expression, statement, poplex)
+        }
+        if (isTS && value == "abstract") {
+            cxMarked = "keyword"
+            return cont(statement)
+        }
+        return cont(pushlex("stat"), maybelabel)
+    }
+
+    private val maybeCatchBinding: JsComb = comb { type, _ ->
+        if (type == "(") cont(funarg, expect(")")) else false
+    }
+
+    // ---- Expressions ----
+
+    val expression: JsComb = comb { type, value -> expressionInner(type, value, false) }
+
+    private val expressionNoComma: JsComb =
+        comb { type, value -> expressionInner(type, value, true) }
+
+    private val parenExpr: JsComb = comb { type, _ ->
+        if (type != "(") {
+            pass()
+        } else {
+            cont(pushlex(")"), maybeexpression, expect(")"), poplex)
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "ReturnCount")
+    private fun expressionInner(type: String, value: String, noComma: Boolean): Boolean {
+        if (cxState.fatArrowAt == cxStream.start) {
+            val body = if (noComma) arrowBodyNoComma else arrowBody
+            if (type == "(") {
+                return cont(
+                    pushcontext,
+                    pushlex(")"),
+                    commasep(funarg, ")"),
+                    poplex,
+                    expect("=>"),
+                    body,
+                    popcontext
+                )
+            } else if (type == "variable") {
+                return pass(pushcontext, pattern, expect("=>"), body, popcontext)
+            }
+        }
+        val maybeop = if (noComma) maybeoperatorNoComma else maybeoperatorComma
+        if (type in jsAtomicTypes) return cont(maybeop)
+        if (type == "function") return cont(functiondef, maybeop)
+        if (type == "class" || (isTS && value == "interface")) {
+            cxMarked = "keyword"
+            return cont(pushlex("form"), classExpression, poplex)
+        }
+        if (type == "keyword c" || type == "async") {
+            return cont(if (noComma) expressionNoComma else expression)
+        }
+        if (type == "(") return cont(pushlex(")"), maybeexpression, expect(")"), poplex, maybeop)
+        if (type == "operator" || type == "spread") {
+            return cont(if (noComma) expressionNoComma else expression)
+        }
+        if (type == "[") return cont(pushlex("]"), arrayLiteral, poplex, maybeop)
+        if (type == "{") return contCommasep(objprop, "}", null, maybeop)
+        if (type == "quasi") return pass(quasi, maybeop)
+        if (type == "new") return cont(maybeTarget(noComma))
+        return cont()
+    }
+
+    private val maybeexpression: JsComb = comb { type, _ ->
+        if (jsEndOfExpr.containsMatchIn(type)) pass() else pass(expression)
+    }
+
+    /** Identity-compared by `indent`; must stay a single instance. */
+    val maybeoperatorComma: JsComb = comb { type, value ->
+        if (type == ",") cont(maybeexpression) else maybeOperator(type, value, false)
+    }
+
+    /** Identity-compared by `indent`; must stay a single instance. */
+    val maybeoperatorNoComma: JsComb = comb { type, value -> maybeOperator(type, value, null) }
+
+    @Suppress("CyclomaticComplexMethod", "ReturnCount")
+    private fun maybeOperator(type: String, value: String, noComma: Boolean?): Boolean {
+        val me = if (noComma == false) maybeoperatorComma else maybeoperatorNoComma
+        val expr = if (noComma == false) expression else expressionNoComma
+        if (type == "=>") {
+            val body = if (noComma == true) arrowBodyNoComma else arrowBody
+            return cont(pushcontext, body, popcontext)
+        }
+        if (type == "operator") {
+            if (jsIncDec.containsMatchIn(value) || (isTS && value == "!")) return cont(me)
+            if (isTS &&
+                value == "<" &&
+                cxStream.match(jsTypeArgsAhead, consume = false) != null
+            ) {
+                return cont(pushlex(">"), commasep(typeexpr, ">"), poplex, me)
+            }
+            if (value == "?") return cont(expression, expect(":"), expr)
+            return cont(expr)
+        }
+        if (type == "quasi") return pass(quasi, me)
+        if (type == ";") return false
+        if (type == "(") return contCommasep(expressionNoComma, ")", "call", me)
+        if (type == ".") return cont(property, me)
+        if (type == "[") return cont(pushlex("]"), maybeexpression, expect("]"), poplex, me)
+        if (isTS && value == "as") {
+            cxMarked = "keyword"
+            return cont(typeexpr, me)
+        }
+        if (type == "regexp") {
+            cxMarked = "operator"
+            cxState.lastType = "operator"
+            cxStream.backUp(cxStream.pos - cxStream.start - 1)
+            return cont(expr)
+        }
+        return false
+    }
+
+    private val quasi: JsComb = comb { type, value ->
+        when {
+            type != "quasi" -> pass()
+            value.takeLast(2) != "\${" -> cont(quasi)
+            else -> cont(maybeexpression, continueQuasi)
+        }
+    }
+
+    private val continueQuasi: JsComb = comb { type, _ ->
+        if (type == "}") {
+            cxMarked = "string.special"
+            cxState.tokenize = JS_TOKENIZE_QUASI
+            cont(quasi)
+        } else {
+            false
+        }
+    }
+
+    private val arrowBody: JsComb = comb { type, _ ->
+        findFatArrow(cxStream, cxState)
+        pass(if (type == "{") statement else expression)
+    }
+
+    private val arrowBodyNoComma: JsComb = comb { type, _ ->
+        findFatArrow(cxStream, cxState)
+        pass(if (type == "{") statement else expressionNoComma)
+    }
+
+    private fun maybeTarget(noComma: Boolean): JsComb = comb { type, _ ->
+        when {
+            type == "." -> cont(if (noComma) targetNoComma else target)
+            type == "variable" && isTS ->
+                cont(maybeTypeArgs, if (noComma) maybeoperatorNoComma else maybeoperatorComma)
+            else -> pass(if (noComma) expressionNoComma else expression)
+        }
+    }
+
+    private val target: JsComb = comb { _, value ->
+        if (value == "target") {
+            cxMarked = "keyword"
+            cont(maybeoperatorComma)
+        } else {
+            false
+        }
+    }
+
+    private val targetNoComma: JsComb = comb { _, value ->
+        if (value == "target") {
+            cxMarked = "keyword"
+            cont(maybeoperatorNoComma)
+        } else {
+            false
+        }
+    }
+
+    private val maybelabel: JsComb = comb { type, _ ->
+        if (type == ":") {
+            cont(poplex, statement)
+        } else {
+            pass(maybeoperatorComma, expect(";"), poplex)
+        }
+    }
+
+    private val property: JsComb = comb { type, _ ->
+        if (type == "variable") {
+            cxMarked = "property"
+            cont()
+        } else {
+            false
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "ReturnCount")
+    private val objprop: JsComb = comb { type, value ->
+        when {
+            type == "async" -> {
+                cxMarked = "property"
+                cont(objprop)
+            }
+            type == "variable" || cxStyle == "keyword" -> {
+                cxMarked = "property"
+                if (value == "get" || value == "set") {
+                    cont(getterSetter)
+                } else {
+                    // Work around fat-arrow-detection complication for
+                    // detecting typescript typed arrow params.
+                    if (isTS && cxState.fatArrowAt == cxStream.start) {
+                        val m = cxStream.match(jsColonAhead, consume = false)
+                        if (m != null) cxState.fatArrowAt = cxStream.pos + m.value.length
+                    }
+                    cont(afterprop)
+                }
+            }
+            type == "number" || type == "string" -> {
+                cxMarked = if (jsonldMode) "property" else "$cxStyle property"
+                cont(afterprop)
+            }
+            type == "jsonld-keyword" -> cont(afterprop)
+            isTS && isModifier(value) -> {
+                cxMarked = "keyword"
+                cont(objprop)
+            }
+            type == "[" -> cont(expression, maybetype, expect("]"), afterprop)
+            type == "spread" -> cont(expressionNoComma, afterprop)
+            value == "*" -> {
+                cxMarked = "keyword"
+                cont(objprop)
+            }
+            type == ":" -> pass(afterprop)
+            else -> false
+        }
+    }
+
+    private val getterSetter: JsComb = comb { type, _ ->
+        if (type != "variable") {
+            pass(afterprop)
+        } else {
+            cxMarked = "property"
+            cont(functiondef)
+        }
+    }
+
+    private val afterprop: JsComb = comb { type, _ ->
+        when (type) {
+            ":" -> cont(expressionNoComma)
+            "(" -> pass(functiondef)
+            else -> false
+        }
+    }
+
+    private val block: JsComb = comb { type, _ ->
+        if (type == "}") cont() else pass(statement, block)
+    }
+
+    // ---- Types (TypeScript) ----
+
+    private val maybetype: JsComb = comb { type, value ->
+        when {
+            !isTS -> false
+            type == ":" -> cont(typeexpr)
+            value == "?" -> cont(maybetype)
+            else -> false
+        }
+    }
+
+    private val maybetypeOrIn: JsComb = comb { type, value ->
+        if (isTS && (type == ":" || value == "in")) cont(typeexpr) else false
+    }
+
+    private val mayberettype: JsComb = comb { type, _ ->
+        if (isTS && type == ":") {
+            if (cxStream.match(jsIsPredicate, consume = false) != null) {
+                cont(expression, isKW, typeexpr)
+            } else {
+                cont(typeexpr)
+            }
+        } else {
+            false
+        }
+    }
+
+    private val isKW: JsComb = comb { _, value ->
+        if (value == "is") {
+            cxMarked = "keyword"
+            cont()
+        } else {
+            false
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private val typeexpr: JsComb = comb { type, value ->
+        when {
+            value == "keyof" || value == "typeof" || value == "infer" || value == "readonly" -> {
+                cxMarked = "keyword"
+                cont(if (value == "typeof") expressionNoComma else typeexpr)
+            }
+            type == "variable" || value == "void" -> {
+                cxMarked = "type"
+                cont(afterType)
+            }
+            value == "|" || value == "&" -> cont(typeexpr)
+            type == "string" || type == "number" || type == "atom" -> cont(afterType)
+            type == "[" -> cont(pushlex("]"), commasep(typeexpr, "]", ","), poplex, afterType)
+            type == "{" -> cont(pushlex("}"), typeprops, poplex, afterType)
+            type == "(" -> cont(commasep(typearg, ")"), maybeReturnType, afterType)
+            type == "<" -> cont(commasep(typeexpr, ">"), typeexpr)
+            type == "quasi" -> pass(quasiType, afterType)
+            else -> false
+        }
+    }
+
+    private val maybeReturnType: JsComb = comb { type, _ ->
+        if (type == "=>") cont(typeexpr) else false
+    }
+
+    private val typeprops: JsComb = comb { type, _ ->
+        when {
+            jsCloser.containsMatchIn(type) -> cont()
+            type == "," || type == ";" -> cont(typeprops)
+            else -> pass(typeprop, typeprops)
+        }
+    }
+
+    private val typeprop: JsComb = comb { type, value ->
+        when {
+            type == "variable" || cxStyle == "keyword" -> {
+                cxMarked = "property"
+                cont(typeprop)
+            }
+            value == "?" || type == "number" || type == "string" -> cont(typeprop)
+            type == ":" -> cont(typeexpr)
+            type == "[" -> cont(expect("variable"), maybetypeOrIn, expect("]"), typeprop)
+            type == "(" -> pass(functiondecl, typeprop)
+            !jsEndOfExpr.containsMatchIn(type) -> cont()
+            else -> false
+        }
+    }
+
+    private val quasiType: JsComb = comb { type, value ->
+        when {
+            type != "quasi" -> pass()
+            value.takeLast(2) != "\${" -> cont(quasiType)
+            else -> cont(typeexpr, continueQuasiType)
+        }
+    }
+
+    private val continueQuasiType: JsComb = comb { type, _ ->
+        if (type == "}") {
+            cxMarked = "string.special"
+            cxState.tokenize = JS_TOKENIZE_QUASI
+            cont(quasiType)
+        } else {
+            false
+        }
+    }
+
+    private val typearg: JsComb = comb { type, value ->
+        when {
+            (type == "variable" && cxStream.match(jsTypeArgAhead, consume = false) != null) ||
+                value == "?" -> cont(typearg)
+            type == ":" -> cont(typeexpr)
+            type == "spread" -> cont(typearg)
+            else -> pass(typeexpr)
+        }
+    }
+
+    private val afterType: JsComb = comb { type, value ->
+        when {
+            value == "<" -> cont(pushlex(">"), commasep(typeexpr, ">"), poplex, afterType)
+            value == "|" || type == "." || value == "&" -> cont(typeexpr)
+            type == "[" -> cont(typeexpr, expect("]"), afterType)
+            value == "extends" || value == "implements" -> {
+                cxMarked = "keyword"
+                cont(typeexpr)
+            }
+            value == "?" -> cont(typeexpr, expect(":"), typeexpr)
+            else -> false
+        }
+    }
+
+    private val maybeTypeArgs: JsComb = comb { _, value ->
+        if (value == "<") {
+            cont(pushlex(">"), commasep(typeexpr, ">"), poplex, afterType)
+        } else {
+            false
+        }
+    }
+
+    private val typeparam: JsComb = comb { _, _ -> pass(typeexpr, maybeTypeDefault) }
+
+    private val maybeTypeDefault: JsComb = comb { _, value ->
+        if (value == "=") cont(typeexpr) else false
+    }
+
+    // ---- Declarations and patterns ----
+
+    private val vardef: JsComb = comb { _, value ->
+        if (value == "enum") {
+            cxMarked = "keyword"
+            cont(enumdef)
+        } else {
+            pass(pattern, maybetype, maybeAssign, vardefCont)
+        }
+    }
+
+    private val pattern: JsComb = comb { type, value ->
+        when {
+            isTS && isModifier(value) -> {
+                cxMarked = "keyword"
+                cont(pattern)
+            }
+            type == "variable" -> {
+                register(value)
+                cont()
+            }
+            type == "spread" -> cont(pattern)
+            type == "[" -> contCommasep(eltpattern, "]")
+            type == "{" -> contCommasep(proppattern, "}")
+            else -> false
+        }
+    }
+
+    private val proppattern: JsComb = comb { type, value ->
+        when {
+            type == "variable" && cxStream.match(jsPropAhead, consume = false) == null -> {
+                register(value)
+                cont(maybeAssign)
+            }
+            type == "spread" -> cont(pattern)
+            type == "}" -> pass()
+            type == "[" -> cont(expression, expect("]"), expect(":"), proppattern)
+            else -> {
+                if (type == "variable") cxMarked = "property"
+                cont(expect(":"), pattern, maybeAssign)
+            }
+        }
+    }
+
+    private val eltpattern: JsComb = comb { _, _ -> pass(pattern, maybeAssign) }
+
+    private val maybeAssign: JsComb = comb { _, value ->
+        if (value == "=") cont(expressionNoComma) else false
+    }
+
+    private val vardefCont: JsComb = comb { type, _ ->
+        if (type == ",") cont(vardef) else false
+    }
+
+    /** Identity-compared by `indent`; must stay a single instance. */
+    val maybeelse: JsComb = comb { type, value ->
+        if (type == "keyword b" && value == "else") {
+            cont(pushlex("form", "else"), statement, poplex)
+        } else {
+            false
+        }
+    }
+
+    private val forspec: JsComb = comb { type, value ->
+        when {
+            value == "await" -> cont(forspec)
+            type == "(" -> cont(pushlex(")"), forspec1, poplex)
+            else -> false
+        }
+    }
+
+    private val forspec1: JsComb = comb { type, _ ->
+        when (type) {
+            "var" -> cont(vardef, forspec2)
+            "variable" -> cont(forspec2)
+            else -> pass(forspec2)
+        }
+    }
+
+    private val forspec2: JsComb = comb { type, value ->
+        when {
+            type == ")" -> cont()
+            type == ";" -> cont(forspec2)
+            value == "in" || value == "of" -> {
+                cxMarked = "keyword"
+                cont(expression, forspec2)
+            }
+            else -> pass(expression, forspec2)
+        }
+    }
+
+    private val functiondef: JsComb = comb { type, value ->
+        when {
+            value == "*" -> {
+                cxMarked = "keyword"
+                cont(functiondef)
+            }
+            type == "variable" -> {
+                register(value)
+                cont(functiondef)
+            }
+            type == "(" -> cont(
+                pushcontext,
+                pushlex(")"),
+                commasep(funarg, ")"),
+                poplex,
+                mayberettype,
+                statement,
+                popcontext
+            )
+            isTS && value == "<" ->
+                cont(pushlex(">"), commasep(typeparam, ">"), poplex, functiondef)
+            else -> false
+        }
+    }
+
+    private val functiondecl: JsComb = comb { type, value ->
+        when {
+            value == "*" -> {
+                cxMarked = "keyword"
+                cont(functiondecl)
+            }
+            type == "variable" -> {
+                register(value)
+                cont(functiondecl)
+            }
+            type == "(" -> cont(
+                pushcontext,
+                pushlex(")"),
+                commasep(funarg, ")"),
+                poplex,
+                mayberettype,
+                popcontext
+            )
+            isTS && value == "<" ->
+                cont(pushlex(">"), commasep(typeparam, ">"), poplex, functiondecl)
+            else -> false
+        }
+    }
+
+    private val typename: JsComb = comb { type, value ->
+        when {
+            type == "keyword" || type == "variable" -> {
+                cxMarked = "type"
+                cont(typename)
+            }
+            value == "<" -> cont(pushlex(">"), commasep(typeparam, ">"), poplex)
+            else -> false
+        }
+    }
+
+    private val funarg: JsComb = comb { type, value ->
+        // Upstream's `if (value == "@") cont(expression, funarg)` has no
+        // `return`, so the pushed continuations stay and control falls through
+        // to the checks below. Kept as-is; changing it is a behaviour change.
+        if (value == "@") cont(expression, funarg)
+        when {
+            type == "spread" -> cont(funarg)
+            isTS && isModifier(value) -> {
+                cxMarked = "keyword"
+                cont(funarg)
+            }
+            isTS && type == "this" -> cont(maybetype, maybeAssign)
+            else -> pass(pattern, maybetype, maybeAssign)
+        }
+    }
+
+    private val classExpression: JsComb = comb { type, value ->
+        // Class expressions may have an optional name.
+        if (type == "variable") className(type, value) else classNameAfter(type, value)
+    }
+
+    private val className: JsComb = comb { type, value ->
+        if (type == "variable") {
+            register(value)
+            cont(classNameAfter)
+        } else {
+            false
+        }
+    }
+
+    private val classNameAfter: JsComb = comb { type, value ->
+        when {
+            value == "<" ->
+                cont(pushlex(">"), commasep(typeparam, ">"), poplex, classNameAfter)
+            value == "extends" || value == "implements" || (isTS && type == ",") -> {
+                if (value == "implements") cxMarked = "keyword"
+                cont(if (isTS) typeexpr else expression, classNameAfter)
+            }
+            type == "{" -> cont(pushlex("}"), classBody, poplex)
+            else -> false
+        }
+    }
+
+    private val classMemberModifiers = setOf("static", "get", "set")
+
+    private fun isClassMemberModifier(type: String, value: String): Boolean {
+        if (type != "variable") return false
+        val named = value in classMemberModifiers || (isTS && isModifier(value))
+        return named && cxStream.match(jsClassMemberAhead, consume = false) != null
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private val classBody: JsComb = comb { type, value ->
+        when {
+            type == "async" || isClassMemberModifier(type, value) -> {
+                cxMarked = "keyword"
+                cont(classBody)
+            }
+            type == "variable" || cxStyle == "keyword" -> {
+                cxMarked = "property"
+                cont(classfield, classBody)
+            }
+            type == "number" || type == "string" -> cont(classfield, classBody)
+            type == "[" -> cont(expression, maybetype, expect("]"), classfield, classBody)
+            value == "*" -> {
+                cxMarked = "keyword"
+                cont(classBody)
+            }
+            isTS && type == "(" -> pass(functiondecl, classBody)
+            type == ";" || type == "," -> cont(classBody)
+            type == "}" -> cont()
+            value == "@" -> cont(expression, classBody)
+            else -> false
+        }
+    }
+
+    private val classfield: JsComb = comb { type, value ->
+        when {
+            value == "!" || value == "?" -> cont(classfield)
+            type == ":" -> cont(typeexpr, maybeAssign)
+            value == "=" -> cont(expressionNoComma)
+            else -> {
+                val context = cxState.lexical.prev
+                val isInterface = context != null && context.info == "interface"
+                pass(if (isInterface) functiondecl else functiondef)
+            }
+        }
+    }
+
+    // ---- Modules ----
+
+    private val afterExport: JsComb = comb { type, value ->
+        when {
+            value == "*" -> {
+                cxMarked = "keyword"
+                cont(maybeFrom, expect(";"))
+            }
+            value == "default" -> {
+                cxMarked = "keyword"
+                cont(expression, expect(";"))
+            }
+            type == "{" -> cont(commasep(exportField, "}"), maybeFrom, expect(";"))
+            else -> pass(statement)
+        }
+    }
+
+    private val exportField: JsComb = comb { type, value ->
+        when {
+            value == "as" -> {
+                cxMarked = "keyword"
+                cont(expect("variable"))
+            }
+            type == "variable" -> pass(expressionNoComma, exportField)
+            else -> false
+        }
+    }
+
+    private val afterImport: JsComb = comb { type, _ ->
+        when (type) {
+            "string" -> cont()
+            "(" -> pass(expression)
+            "." -> pass(maybeoperatorComma)
+            else -> pass(importSpec, maybeMoreImports, maybeFrom)
+        }
+    }
+
+    private val importSpec: JsComb = comb { type, value ->
+        if (type == "{") {
+            contCommasep(importSpec, "}")
+        } else {
+            if (type == "variable") register(value)
+            if (value == "*") cxMarked = "keyword"
+            cont(maybeAs)
+        }
+    }
+
+    private val maybeMoreImports: JsComb = comb { type, _ ->
+        if (type == ",") cont(importSpec, maybeMoreImports) else false
+    }
+
+    private val maybeAs: JsComb = comb { _, value ->
+        if (value == "as") {
+            cxMarked = "keyword"
+            cont(importSpec)
+        } else {
+            false
+        }
+    }
+
+    private val maybeFrom: JsComb = comb { _, value ->
+        if (value == "from") {
+            cxMarked = "keyword"
+            cont(expression)
+        } else {
+            false
+        }
+    }
+
+    private val arrayLiteral: JsComb = comb { type, _ ->
+        if (type == "]") cont() else pass(commasep(expressionNoComma, "]"))
+    }
+
+    private val enumdef: JsComb = comb { _, _ ->
+        pass(
+            pushlex("form"),
+            pattern,
+            expect("{"),
+            pushlex("}"),
+            commasep(enummember, "}"),
+            poplex,
+            poplex
+        )
+    }
+
+    private val enummember: JsComb = comb { _, _ -> pass(pattern, maybeAssign) }
+
+    // ---- Driver ----
+
+    /**
+     * Run the continuation stack over one token, returning the style to use
+     * for it. Mirrors upstream's `parseJS`.
+     */
+    fun parseJS(
+        state: JavaScriptState,
+        style: String?,
+        type: String,
+        content: String,
+        stream: StringStream
+    ): String? {
+        val cc = state.cc
+        cxState = state
+        cxStream = stream
+        cxMarked = null
+        cxCc = cc
+        cxStyle = style
+
+        if (state.lexical.align == null) state.lexical.align = true
+
+        while (true) {
+            val combinator = if (cc.isNotEmpty()) {
+                cc.removeAt(cc.size - 1)
+            } else if (jsonMode) {
+                expression
+            } else {
+                statement
+            }
+            if (combinator(type, content)) {
+                while (cc.isNotEmpty() && cc[cc.size - 1].lex) {
+                    cc.removeAt(cc.size - 1)("", "")
+                }
+                val marked = cxMarked
+                if (!marked.isNullOrEmpty()) return marked
+                if (type == "variable" && inScope(state, content)) return "variableName.local"
+                return style
+            }
+        }
+    }
+
+    private companion object {
+        const val TAB_SIZE_PLACEHOLDER = 4
+    }
+}
+
+private val jsTypeArgAhead = Regex("^\\s*[?:]")
+
+/** [JavaScriptState.tokenize] value for the template-literal tokenizer. */
+internal const val JS_TOKENIZE_QUASI = 3

--- a/legacy-modes/src/commonMain/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptLegacy.kt
+++ b/legacy-modes/src/commonMain/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptLegacy.kt
@@ -52,6 +52,13 @@ private val jsKeywords: Map<String, JsKw> = run {
 }
 
 private val jsIsOperatorChar = Regex("[+\\-*&%=<>!?|~^@]")
+private const val JS_BRACKETS = "([{}])"
+private val jsStringDelimiter = Regex("[\"'/`]")
+private val jsTsReturnType =
+    Regex(":\\s*(?:\\w+(?:<[^>]*>|\\[\\])?|\\{[^}]*\\})\\s*\$")
+private val jsElseAhead = Regex("^\\s*else\\b")
+private val jsNoPopAfter = Regex("^[,\\.=+\\-*:?\\[\\(]")
+private val jsCaseAhead = Regex("^(?:case|default)\\b")
 private val jsIsJsonldKeyword =
     Regex("^@(context|id|value|language|type|container|list|set|reverse|index|base|vocab|graph)\"")
 
@@ -70,7 +77,13 @@ data class JavaScriptConfig(
     val jsonld: Boolean = false,
     val typescript: Boolean = false,
     val statementIndent: Int? = null,
-    val wordCharacters: Regex = Regex("[\\w\$\\u00a1-\\uffff]")
+    val wordCharacters: Regex = Regex("[\\w\$\\u00a1-\\uffff]"),
+    /**
+     * Whether the body of a `switch` is indented by two units, with `case`
+     * and `default` labels at one. Upstream's `doubleIndentSwitch`, which
+     * defaults to on.
+     */
+    val doubleIndentSwitch: Boolean = true
 )
 
 class JavaScriptState(
@@ -81,7 +94,20 @@ class JavaScriptState(
     var indented: Int = 0,
     var lexical: JSLexical = JSLexical(-2, 0, "block"),
     var fatArrowAt: Int? = null
-)
+) {
+    /**
+     * The continuation stack (`state.cc` upstream): the grammar's pending
+     * combinators, top of stack last. Internal because the combinator type is
+     * an implementation detail of the mode.
+     */
+    internal var cc: MutableList<JsComb> = mutableListOf()
+
+    /** Names bound in the innermost variable scope. */
+    internal var localVars: JsVar? = null
+
+    /** The enclosing variable scopes. */
+    internal var context: JsContext? = null
+}
 
 @Suppress("CyclomaticComplexMethod", "LongMethod", "ReturnCount", "NestedBlockDepth")
 private fun mkJavaScript(config: JavaScriptConfig): StreamParser<JavaScriptState> {
@@ -267,6 +293,73 @@ private fun mkJavaScript(config: JavaScriptConfig): StreamParser<JavaScriptState
             Regex("[,.]").containsMatchIn(firstChar)
     }
 
+    // A crude lookahead trick to notice that we are parsing the argument
+    // patterns of a fat-arrow function before hitting the arrow token. It only
+    // works if the arrow is on the same line as the arguments with no comments
+    // in between; the fallback is to only notice at the arrow itself.
+    @Suppress(
+        "CyclomaticComplexMethod",
+        "NestedBlockDepth",
+        "ReturnCount",
+        "LoopWithTooManyJumpStatements"
+    )
+    fun findFatArrow(stream: StringStream, state: JavaScriptState) {
+        if (state.fatArrowAt != null) state.fatArrowAt = null
+        var arrow = stream.string.indexOf("=>", stream.start)
+        if (arrow < 0) return
+
+        if (isTS) {
+            // Try to skip TypeScript return type declarations after the arguments.
+            // Upstream assigns the match index of the *sliced* string straight
+            // to `arrow`, which is only the same as an absolute offset when
+            // `stream.start` is 0 -- which it is on the `sol()` call path. Kept
+            // as-is so the port answers what upstream answers.
+            val m = jsTsReturnType.find(stream.string.substring(stream.start, arrow))
+            if (m != null) arrow = m.range.first
+        }
+
+        var depth = 0
+        var sawSomething = false
+        var pos = arrow - 1
+        while (pos >= 0) {
+            val ch = stream.string[pos].toString()
+            val bracket = JS_BRACKETS.indexOf(ch)
+            if (bracket in 0..2) {
+                if (depth == 0) {
+                    pos++
+                    break
+                }
+                depth--
+                if (depth == 0) {
+                    if (ch == "(") sawSomething = true
+                    break
+                }
+            } else if (bracket in 3..5) {
+                depth++
+            } else if (wordRE.containsMatchIn(ch)) {
+                sawSomething = true
+            } else if (jsStringDelimiter.containsMatchIn(ch)) {
+                while (true) {
+                    if (pos == 0) return
+                    val next = stream.string[pos - 1].toString()
+                    val beforeNext = if (pos >= 2) stream.string[pos - 2].toString() else ""
+                    if (next == ch && beforeNext != "\\") {
+                        pos--
+                        break
+                    }
+                    pos--
+                }
+            } else if (sawSomething && depth == 0) {
+                pos++
+                break
+            }
+            pos--
+        }
+        if (sawSomething && depth == 0) state.fatArrowAt = pos
+    }
+
+    val grammar = JsGrammar(isTS, jsonMode, jsonldMode) { s, st -> findFatArrow(s, st) }
+
     return object : StreamParser<JavaScriptState> {
         override val name: String get() = config.name
 
@@ -279,18 +372,25 @@ private fun mkJavaScript(config: JavaScriptConfig): StreamParser<JavaScriptState
             stringQuote = state.stringQuote,
             lastType = state.lastType,
             indented = state.indented,
-            // JSLexical is immutable data class - safe to share
+            // The lexical chain is shared by reference, exactly as upstream's
+            // default `copyState` shares it: `align` is filled in once per
+            // scope and both copies must observe the same answer.
             lexical = state.lexical,
             fatArrowAt = state.fatArrowAt
-        )
+        ).also {
+            // The continuation stack is copied (upstream slices the array);
+            // the scope lists are immutable and shared.
+            it.cc = state.cc.toMutableList()
+            it.localVars = state.localVars
+            it.context = state.context
+        }
 
         @Suppress("CyclomaticComplexMethod", "LongMethod", "ReturnCount", "NestedBlockDepth")
         override fun token(stream: StringStream, state: JavaScriptState): String? {
             if (stream.sol()) {
-                if (state.lexical.align == null) {
-                    state.lexical = state.lexical.copy(align = false)
-                }
+                if (state.lexical.align == null) state.lexical.align = false
                 state.indented = stream.indentation()
+                findFatArrow(stream, state)
             }
             if (state.tokenize != 2 && stream.eatSpace()) return null
 
@@ -358,26 +458,42 @@ private fun mkJavaScript(config: JavaScriptConfig): StreamParser<JavaScriptState
                 type
             }
 
-            return style
+            return grammar.parseJS(state, style, type, content, stream)
         }
 
+        @Suppress("CyclomaticComplexMethod", "ReturnCount", "LoopWithTooManyJumpStatements")
         override fun indent(
             state: JavaScriptState,
             textAfter: String,
             context: IndentContext
         ): Int? {
-            if (state.tokenize == 2 || state.tokenize == 3) return null
+            if (state.tokenize == 2 || state.tokenize == JS_TOKENIZE_QUASI) return null
             if (state.tokenize != 0) return 0
             val firstChar = textAfter.firstOrNull()?.toString() ?: ""
             var lexical = state.lexical
 
-            // Walk up stat/form lexical scopes
-            while ((lexical.type == "stat" || lexical.type == "form") &&
-                (
-                    firstChar == "}" ||
-                        !Regex("^[,\\.=+\\-*:?\\[(]").containsMatchIn(textAfter)
-                    )
-            ) {
+            // Kludge to prevent 'maybeelse' from blocking lexical scope pops.
+            if (!jsElseAhead.containsMatchIn(textAfter)) {
+                for (i in state.cc.indices.reversed()) {
+                    val c = state.cc[i]
+                    if (c === grammar.poplex) {
+                        lexical = lexical.prev ?: break
+                    } else if (c !== grammar.maybeelse && c !== grammar.popcontext) {
+                        break
+                    }
+                }
+            }
+
+            // Walk up stat/form lexical scopes. The `maybeoperator*` conjunct
+            // is what keeps a `stat` scope alive for a genuinely continued
+            // expression; without it every `stat` and `form` scope is popped.
+            while (lexical.type == "stat" || lexical.type == "form") {
+                val top = state.cc.lastOrNull()
+                val topIsOperator = top === grammar.maybeoperatorComma ||
+                    top === grammar.maybeoperatorNoComma
+                val continues = firstChar == "}" ||
+                    (topIsOperator && !jsNoPopAfter.containsMatchIn(textAfter))
+                if (!continues) break
                 lexical = lexical.prev ?: break
             }
 
@@ -385,12 +501,20 @@ private fun mkJavaScript(config: JavaScriptConfig): StreamParser<JavaScriptState
                 lexical.type == ")" &&
                 lexical.prev?.type == "stat"
             ) {
-                lexical = lexical.prev!!
+                lexical = lexical.prev
             }
 
             val closing = firstChar == lexical.type
 
             return when {
+                lexical.type == "vardef" ->
+                    lexical.indented + (
+                        if (state.lastType == "operator" || state.lastType == ",") {
+                            (lexical.info?.length ?: 0) + 1
+                        } else {
+                            0
+                        }
+                        )
                 lexical.type == "form" && firstChar == "{" -> lexical.indented
                 lexical.type == "form" -> lexical.indented + context.unit
                 lexical.type == "stat" ->
@@ -399,6 +523,14 @@ private fun mkJavaScript(config: JavaScriptConfig): StreamParser<JavaScriptState
                             statementIndent ?: context.unit
                         } else {
                             0
+                        }
+                        )
+                lexical.info == "switch" && !closing && config.doubleIndentSwitch ->
+                    lexical.indented + (
+                        if (jsCaseAhead.containsMatchIn(textAfter)) {
+                            context.unit
+                        } else {
+                            2 * context.unit
                         }
                         )
                 lexical.align == true -> lexical.column + (if (closing) 0 else 1)

--- a/legacy-modes/src/commonTest/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptBlankLineIndentTest.kt
+++ b/legacy-modes/src/commonTest/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptBlankLineIndentTest.kt
@@ -45,23 +45,22 @@ import kotlin.test.assertEquals
  * The tests come in two halves because the two halves carry different weight:
  *
  * * [indentQueriesAtTheStartOfEveryLine] drives the public
- *   [getIndentation] entry point. It cannot reach the faulty read on this port
- *   (see below) and so passes before and after the fix; it is here to pin the
- *   answers the boundary actually gives for blank lines.
+ *   [getIndentation] entry point; it pins the answers the boundary gives for
+ *   blank lines. Its `function f()` case answered a flat 0 until #276 ported
+ *   the lexical stack.
  * * [indentOfABlankContinuedStatementLine] and its siblings call
  *   `StreamParser.indent` -- the same method [getIndentation] ends up in, via
  *   `StreamLanguage.getIndent` -- with a [JavaScriptState] built directly.
  *   These are the tests that fail with `StringIndexOutOfBoundsException`
  *   without the fix.
  *
- * Building the state by hand is necessary rather than convenient: this port
- * does not carry CodeMirror's `cc` continuation stack, so nothing ever pushes a
- * lexical scope and `state.lexical` stays the base `"block"` scope for every
- * document. The `"stat"` branch that calls `isContinuedStatement` is therefore
- * unreachable through the parser today, which makes the crash latent rather
- * than live. [JavaScriptState] and [JSLexical] are public API, and these tests
- * hold the upstream contract for the branch so that porting the lexical stack
- * does not resurrect the crash.
+ * Building the state by hand isolates the branch: the `"stat"` scope, the
+ * `lastType` and the text after the cursor are set directly rather than
+ * arrived at through a document, so each of `isContinuedStatement`'s four
+ * disjuncts can be exercised on its own. #276 has since ported the `cc`
+ * continuation stack, so the parser does now produce `"stat"` scopes and the
+ * branch is live; [JavaScriptState] and [JSLexical] are public API and these
+ * tests hold the upstream contract for it directly.
  */
 class JavaScriptBlankLineIndentTest {
 
@@ -86,7 +85,7 @@ class JavaScriptBlankLineIndentTest {
     fun indentQueriesAtTheStartOfEveryLine() {
         assertEquals(listOf(0, 0, 0), indentsPerLine("foo()\n\n"))
         assertEquals(listOf(0, 0, 0), indentsPerLine("foo\n\n"))
-        assertEquals(listOf(0, 0, 0, 0, 0), indentsPerLine("function f() {\n  foo();\n\n}\n"))
+        assertEquals(listOf(0, 2, 2, 0, 0), indentsPerLine("function f() {\n  foo();\n\n}\n"))
         assertEquals(listOf(0, 0, 0, 0), indentsPerLine("foo();\n   \nbar()\n"))
     }
 

--- a/legacy-modes/src/commonTest/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptIndentScopeTest.kt
+++ b/legacy-modes/src/commonTest/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptIndentScopeTest.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.legacy.modes
+
+import com.monkopedia.kodemirror.language.StreamLanguage
+import com.monkopedia.kodemirror.language.StreamParser
+import com.monkopedia.kodemirror.language.getIndentUnit
+import com.monkopedia.kodemirror.language.getIndentation
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.LineNumber
+import com.monkopedia.kodemirror.state.asDoc
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Exact indent columns for nested JavaScript/TypeScript/JSON documents,
+ * measured through the public [getIndentation] boundary (issue #276).
+ *
+ * Every expected column in this file was produced by running the upstream
+ * `@codemirror/legacy-modes` 6.5.0 `mode/javascript.js` -- the module this
+ * file's subject is a port of -- over the same document with the same
+ * `indentUnit` (2) and `tabSize` (4), driving it with the real
+ * `@codemirror/language` 6.12.3 `StringStream` and the same line-by-line
+ * loop `StreamLanguage.getIndent` uses. They are upstream's answers, not
+ * this port's.
+ */
+class JavaScriptIndentScopeTest {
+
+    /** Indent column reported for the first position of each line of [code]. */
+    private fun indents(parser: StreamParser<JavaScriptState>, code: String): List<Int?> {
+        val lang = StreamLanguage.define(parser)
+        val state = EditorState.create(
+            EditorStateConfig(doc = code.asDoc(), extensions = lang.extension)
+        )
+        assertEquals(2, getIndentUnit(state), "fixtures are calibrated for indentUnit 2")
+        return (1..state.doc.lines).map { n ->
+            getIndentation(state, state.doc.line(LineNumber(n)).from)
+        }
+    }
+
+    private fun js(code: String) = indents(javaScriptLegacy, code)
+
+    /**
+     * The core of #276: three distinct nesting levels in one document.
+     * A constant answer cannot satisfy this and neither can a
+     * one-level-only implementation.
+     */
+    @Test
+    fun nestedFunctionIfBlock() {
+        assertEquals(
+            listOf(0, 2, 4, 2, 0, 0),
+            js("function f() {\n  if (x) {\n    g();\n  }\n}\n")
+        )
+    }
+
+    /** The same nesting with the input left unindented. */
+    @Test
+    fun nestedBlocksWithUnindentedInput() {
+        assertEquals(
+            listOf(0, 2, 2, 0, 0, 0),
+            js("function f() {\nif (x) {\ng();\n}\n}\n")
+        )
+    }
+
+    /** Four levels: a function containing an object containing a function. */
+    @Test
+    fun deepNesting() {
+        assertEquals(
+            listOf(0, 2, 4, 6, 4, 2, 0, 0),
+            js(
+                "function outer() {\n  var o = {\n    a: function () {\n" +
+                    "      return 1;\n    },\n  };\n}\n"
+            )
+        )
+    }
+
+    /** `switch` bodies get the double indent, and `case` labels one unit. */
+    @Test
+    fun switchDoubleIndent() {
+        assertEquals(
+            listOf(0, 2, 4, 4, 2, 4, 0, 0),
+            js("switch (x) {\ncase 1:\nfoo();\nbreak;\ndefault:\nbar();\n}\n")
+        )
+    }
+
+    /** A continued line inside an open paren aligns one past the bracket. */
+    @Test
+    fun alignsToOpenParen() {
+        assertEquals(listOf(0, 4, 0), js("foo(a,\nb)\n"))
+    }
+
+    /** A `vardef` scope indents by the length of the keyword plus one. */
+    @Test
+    fun vardefContinuationIndent() {
+        assertEquals(listOf(0, 4, 0), js("var x = 1,\ny = 2;\n"))
+    }
+
+    /** A statement continued by a trailing operator takes one unit. */
+    @Test
+    fun continuedExpression() {
+        assertEquals(listOf(0, 4, 0), js("var x = 1 +\n2;\n"))
+    }
+
+    /** `if`/`else` bodies are `form` scopes. */
+    @Test
+    fun ifElseForms() {
+        assertEquals(listOf(0, 2, 0, 2, 0), js("if (a)\nfoo();\nelse\nbar();\n"))
+    }
+
+    @Test
+    fun forLoopBody() {
+        assertEquals(listOf(0, 2, 0, 0), js("for (var i = 0; i < 10; i++) {\nfoo();\n}\n"))
+    }
+
+    @Test
+    fun classBody() {
+        assertEquals(listOf(0, 2, 4, 2, 0, 0), js("class A {\n  m() {\n    return 1;\n  }\n}\n"))
+    }
+
+    @Test
+    fun arrayLiteralBody() {
+        assertEquals(listOf(0, 2, 2, 0, 0), js("var a = [\n1,\n2\n];\n"))
+    }
+
+    @Test
+    fun tryCatchBlocks() {
+        assertEquals(listOf(0, 2, 0, 2, 0, 0), js("try {\nfoo();\n} catch (e) {\nbar();\n}\n"))
+    }
+
+    @Test
+    fun typescriptInterfaceBody() {
+        assertEquals(
+            listOf(0, 2, 0, 0),
+            indents(typescript, "interface Foo {\nbar: number;\n}\n")
+        )
+    }
+
+    @Test
+    fun jsonNestedStructure() {
+        assertEquals(
+            listOf(0, 2, 4, 4, 2, 0, 0),
+            indents(json, "{\n  \"a\": [\n    1,\n    2\n  ]\n}\n")
+        )
+    }
+
+    /**
+     * Two `if`s on one line leave two `maybeelse` continuations stacked with a
+     * `poplex` between them. Upstream's kludge walks past the `maybeelse` to
+     * run that pending `poplex` before answering; without it the outer `form`
+     * scope is still open and line 2 answers 2 instead of 0.
+     */
+    @Test
+    fun nestedSingleStatementIf() {
+        assertEquals(listOf(0, 0, 0), js("if (a) if (b) foo();\nbar();\n"))
+    }
+
+    /**
+     * A bracket opened on a continuation line of a statement takes the
+     * statement's own indentation as its base, not the indentation of the line
+     * the bracket happens to sit on.
+     */
+    @Test
+    fun bracketOpenedOnAContinuationLine() {
+        assertEquals(listOf(0, 2, 2, 0, 0), js("foo\n  .bar(\n    baz\n  )\n"))
+    }
+
+    /**
+     * Closing a `)` scope restores the enclosing indentation basis, so the
+     * block opened after it on the same line does not inherit the closing
+     * line's own indentation.
+     */
+    @Test
+    fun blockOpenedAfterAnIndentedClosingParen() {
+        assertEquals(listOf(0, 4, 2, 0, 0), js("for (;;\n  ) {\n  foo();\n}\n"))
+    }
+
+    /**
+     * A document long enough that the indent query resumes from a parser state
+     * cached on the syntax tree rather than replaying from the start. The
+     * cached state must be copied, continuation stack included, or the first
+     * query consumes the stack every later query depends on.
+     */
+    @Test
+    fun longDocumentResumingFromACachedState() {
+        val prefix = (0 until 45).joinToString("") { "var a$it = $it;\n" }
+        val expected = List(46) { 0 } + listOf(2, 4, 2, 0, 0)
+        assertEquals(
+            expected,
+            js(prefix + "function f() {\n  if (x) {\n    g();\n  }\n}\n")
+        )
+    }
+
+    /**
+     * The same, but with the cached chunk boundary falling *inside* an open
+     * function body, so the state carried on the tree has a non-empty
+     * continuation stack. Sharing that stack with the cached state instead of
+     * copying it lets the first query consume it.
+     */
+    @Test
+    fun longDocumentResumingInsideAnOpenBlock() {
+        val body = (0 until 45).joinToString("") { "  var a$it = $it;\n" }
+        val expected = listOf(0) + List(45) { 2 } + listOf(2, 4, 2, 0, 0)
+        assertEquals(
+            expected,
+            js("function f() {\n" + body + "  if (x) {\n    g();\n  }\n}\n")
+        )
+    }
+
+    // ---- The documents named in issue #276, which all answered 0 before ----
+
+    @Test
+    fun issueDocumentBlankLineAfterCall() {
+        assertEquals(listOf(0, 0, 0), js("foo()\n\n"))
+    }
+
+    @Test
+    fun issueDocumentBlankLineAfterIdentifier() {
+        assertEquals(listOf(0, 0, 0), js("foo\n\n"))
+    }
+
+    @Test
+    fun issueDocumentBlankLineAfterIf() {
+        assertEquals(listOf(0, 2, 2), js("if (x)\n\n"))
+    }
+
+    @Test
+    fun issueDocumentBlankLineAfterAssignment() {
+        assertEquals(listOf(0, 4, 4), js("var x =\n\n"))
+    }
+
+    @Test
+    fun issueDocumentBlankLineInFunctionBody() {
+        assertEquals(listOf(0, 2, 2, 0, 0), js("function f() {\n  foo();\n\n}\n"))
+    }
+
+    @Test
+    fun issueDocumentBlankLineInObjectLiteral() {
+        assertEquals(listOf(0, 2, 2, 0, 0), js("var o = {\n  a: 1,\n\n}\n"))
+    }
+
+    @Test
+    fun issueDocumentBlankLineInSwitchCase() {
+        assertEquals(listOf(0, 2, 4, 0, 0), js("switch (x) {\n  case 1:\n\n}\n"))
+    }
+
+    @Test
+    fun issueDocumentWhitespaceOnlyLine() {
+        assertEquals(listOf(0, 0, 0, 0), js("foo();\n   \nbar()\n"))
+    }
+}

--- a/legacy-modes/src/commonTest/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptTokenStyleTest.kt
+++ b/legacy-modes/src/commonTest/kotlin/com/monkopedia/kodemirror/legacy/modes/JavaScriptTokenStyleTest.kt
@@ -1,0 +1,502 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.legacy.modes
+
+import com.monkopedia.kodemirror.language.StreamParser
+import com.monkopedia.kodemirror.language.StringStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Token styles for JavaScript, TypeScript and JSON documents (issue #276).
+ *
+ * The grammar decides most of these, not the tokenizer: `"def"`,
+ * `"property"`, `"type"`, `"variableName.local"` and the `"keyword"`
+ * re-marking of contextual words all come from a combinator setting
+ * `cx.marked`, or from a name having been registered in a variable scope. A
+ * document that only checks indentation leaves nearly all of that unchecked --
+ * indentation reads `state.lexical` and nothing else -- so these tests are what
+ * hold the rest of the ported grammar in place.
+ *
+ * Every expected pair was produced by running upstream
+ * `@codemirror/legacy-modes` 6.5.0 `mode/javascript.js` over the same document
+ * with the real `@codemirror/language` 6.12.3 `StringStream`. Whitespace
+ * tokens, which carry no style, are dropped.
+ */
+class JavaScriptTokenStyleTest {
+
+    /** The (text, style) pair of every non-blank token in [code]. */
+    private fun styles(
+        parser: StreamParser<JavaScriptState>,
+        code: String
+    ): List<Pair<String, String?>> {
+        val state = parser.startState(UNIT)
+        val out = mutableListOf<Pair<String, String?>>()
+        for (line in code.split("\n")) {
+            if (line.isEmpty()) {
+                parser.blankLine(state, UNIT)
+                continue
+            }
+            val stream = StringStream(line, TAB_SIZE, UNIT)
+            while (!stream.eol()) {
+                stream.start = stream.pos
+                var style: String? = null
+                var advanced = false
+                for (attempt in 0 until MAX_TOKEN_ATTEMPTS) {
+                    style = parser.token(stream, state)
+                    if (stream.pos > stream.start) {
+                        advanced = true
+                        break
+                    }
+                }
+                check(advanced) { "stream did not advance on: $line" }
+                if (stream.current().isNotBlank()) out.add(stream.current() to style)
+            }
+        }
+        return out
+    }
+
+    /** Class names register as definitions and methods as properties. */
+    @Test
+    fun classDeclaration() {
+        assertEquals(
+            listOf(
+                "class" to "keyword",
+                "A" to "def",
+                "{" to null,
+                "m" to "property",
+                "(" to null,
+                ")" to null,
+                "{" to null,
+                "return" to "keyword",
+                "1" to "number",
+                ";" to null,
+                "}" to null,
+                "}" to null
+            ),
+            styles(
+                javaScriptLegacy,
+                "class A {\n" +
+                    "  m() {\n" +
+                    "    return 1;\n" +
+                    "  }\n" +
+                    "}\n"
+            )
+        )
+    }
+
+    /** Fat-arrow parameters are definitions and their uses are locals. */
+    @Test
+    fun arrowFunctionLocals() {
+        assertEquals(
+            listOf(
+                "const" to "keyword",
+                "f" to "def",
+                "=" to "operator",
+                "(" to null,
+                "a" to "def",
+                "," to null,
+                "b" to "def",
+                ")" to null,
+                "=>" to "operator",
+                "{" to null,
+                "return" to "keyword",
+                "a" to "variableName.local",
+                "+" to "operator",
+                "b" to "variableName.local",
+                ";" to null,
+                "}" to null,
+                ";" to null
+            ),
+            styles(
+                javaScriptLegacy,
+                "const f = (a, b) => {\n" +
+                    "return a + b;\n" +
+                    "};\n"
+            )
+        )
+    }
+
+    /** Object keys, getters and a nested function body. */
+    @Test
+    fun objectLiteralProperties() {
+        assertEquals(
+            listOf(
+                "var" to "keyword",
+                "o" to "def",
+                "=" to "operator",
+                "{" to null,
+                "a" to "property",
+                ":" to null,
+                "1" to "number",
+                "," to null,
+                "b" to "property",
+                ":" to null,
+                "function" to "keyword",
+                "(" to null,
+                ")" to null,
+                "{" to null,
+                "return" to "keyword",
+                "2" to "number",
+                ";" to null,
+                "}" to null,
+                "," to null,
+                "get" to "property",
+                "c" to "property",
+                "(" to null,
+                ")" to null,
+                "{" to null,
+                "return" to "keyword",
+                "3" to "number",
+                "}" to null,
+                "," to null,
+                "}" to null,
+                ";" to null
+            ),
+            styles(
+                javaScriptLegacy,
+                "var o = {\n" +
+                    "  a: 1,\n" +
+                    "  b: function () {\n" +
+                    "    return 2;\n" +
+                    "  },\n" +
+                    "  get c() { return 3 },\n" +
+                    "};\n"
+            )
+        )
+    }
+
+    /** Module syntax: `as`, `from`, `default` and `*` are keywords. */
+    @Test
+    fun importsAndExports() {
+        assertEquals(
+            listOf(
+                "import" to "keyword",
+                "a" to "def",
+                "," to null,
+                "{" to null,
+                "b" to "def",
+                "as" to "keyword",
+                "c" to "def",
+                "}" to null,
+                "from" to "keyword",
+                "\"m\"" to "string",
+                ";" to null,
+                "import" to "keyword",
+                "*" to "keyword",
+                "as" to "keyword",
+                "d" to "def",
+                "from" to "keyword",
+                "\"n\"" to "string",
+                ";" to null,
+                "export" to "keyword",
+                "default" to "keyword",
+                "a" to "variable",
+                ";" to null,
+                "export" to "keyword",
+                "{" to null,
+                "c" to "variable",
+                "}" to null,
+                ";" to null
+            ),
+            styles(
+                javaScriptLegacy,
+                "import a, {b as c} from \"m\";\n" +
+                    "import * as d from \"n\";\n" +
+                    "export default a;\n" +
+                    "export {c};\n"
+            )
+        )
+    }
+
+    /** Destructuring binds every name it introduces. */
+    @Test
+    fun destructuringPatterns() {
+        assertEquals(
+            listOf(
+                "var" to "keyword",
+                "{" to null,
+                "a" to "def",
+                "," to null,
+                "b" to "property",
+                ":" to null,
+                "{" to null,
+                "c" to "def",
+                "}" to null,
+                "}" to null,
+                "=" to "operator",
+                "o" to "variable",
+                "," to null,
+                "[" to null,
+                "d" to "def",
+                "," to null,
+                "e" to "def",
+                "]" to null,
+                "=" to "operator",
+                "arr" to "variable",
+                ";" to null,
+                "function" to "keyword",
+                "f" to "def",
+                "(" to null,
+                "{" to null,
+                "x" to "def",
+                "=" to "operator",
+                "1" to "number",
+                "}" to null,
+                "," to null,
+                "[" to null,
+                "y" to "def",
+                "]" to null,
+                ")" to null,
+                "{" to null,
+                "return" to "keyword",
+                "x" to "variableName.local",
+                "+" to "operator",
+                "y" to "variableName.local",
+                ";" to null,
+                "}" to null
+            ),
+            styles(
+                javaScriptLegacy,
+                "var {a, b: {c}} = o, [d, e] = arr;\n" +
+                    "function f({x = 1}, [y]) {\n" +
+                    "return x + y;\n" +
+                    "}\n"
+            )
+        )
+    }
+
+    /** A `for` head's `var` binds into the loop's block scope. */
+    @Test
+    fun forLoopLocals() {
+        assertEquals(
+            listOf(
+                "for" to "keyword",
+                "(" to null,
+                "var" to "keyword",
+                "i" to "def",
+                "=" to "operator",
+                "0" to "number",
+                ";" to null,
+                "i" to "variableName.local",
+                "<" to "operator",
+                "10" to "number",
+                ";" to null,
+                "i" to "variableName.local",
+                "++" to "operator",
+                ")" to null,
+                "{" to null,
+                "foo" to "variable",
+                "(" to null,
+                ")" to null,
+                ";" to null,
+                "}" to null
+            ),
+            styles(
+                javaScriptLegacy,
+                "for (var i = 0; i < 10; i++) {\n" +
+                    "foo();\n" +
+                    "}\n"
+            )
+        )
+    }
+
+    /** `yield` and `yield*`. */
+    @Test
+    fun generatorFunction() {
+        assertEquals(
+            listOf(
+                "function" to "keyword",
+                "*" to "keyword",
+                "g" to "def",
+                "(" to null,
+                ")" to null,
+                "{" to null,
+                "yield" to "keyword",
+                "1" to "number",
+                ";" to null,
+                "yield" to "keyword",
+                "*" to "operator",
+                "h" to "variable",
+                "(" to null,
+                ")" to null,
+                ";" to null,
+                "}" to null
+            ),
+            styles(
+                javaScriptLegacy,
+                "function* g() {\n" +
+                    "yield 1;\n" +
+                    "yield* h();\n" +
+                    "}\n"
+            )
+        )
+    }
+
+    /** Type parameters, annotations and optional parameters. */
+    @Test
+    fun typescriptGenerics() {
+        assertEquals(
+            listOf(
+                "function" to "keyword",
+                "f" to "def",
+                "<" to "operator",
+                "T" to "type",
+                "extends" to "keyword",
+                "object" to "type",
+                ">" to "operator",
+                "(" to null,
+                "a" to "def",
+                ":" to null,
+                "T" to "type",
+                "," to null,
+                "b" to "def",
+                "?" to "operator",
+                ":" to null,
+                "string" to "type",
+                ")" to null,
+                ":" to null,
+                "T" to "type",
+                "{" to null,
+                "return" to "keyword",
+                "a" to "variableName.local",
+                ";" to null,
+                "}" to null
+            ),
+            styles(
+                typescript,
+                "function f<T extends object>(a: T, b?: string): T {\n" +
+                    "return a;\n" +
+                    "}\n"
+            )
+        )
+    }
+
+    /** Modifiers, `implements`, field types and static generics. */
+    @Test
+    fun typescriptClassMembers() {
+        assertEquals(
+            listOf(
+                "class" to "keyword",
+                "C" to "def",
+                "extends" to "keyword",
+                "D" to "type",
+                "implements" to "keyword",
+                "I" to "type",
+                "{" to null,
+                "private" to "keyword",
+                "readonly" to "keyword",
+                "x" to "property",
+                ":" to null,
+                "number" to "type",
+                "=" to "operator",
+                "1" to "number",
+                ";" to null,
+                "static" to "keyword",
+                "m" to "property",
+                "<" to "operator",
+                "T" to "type",
+                ">" to "operator",
+                "(" to null,
+                "a" to "def",
+                ":" to null,
+                "T" to "type",
+                ")" to null,
+                ":" to null,
+                "void" to "type",
+                "{" to null,
+                "}" to null,
+                "}" to null
+            ),
+            styles(
+                typescript,
+                "class C extends D implements I {\n" +
+                    "private readonly x: number = 1;\n" +
+                    "static m<T>(a: T): void {}\n" +
+                    "}\n"
+            )
+        )
+    }
+
+    /** A typed arrow: the return type must not swallow the arrow. */
+    @Test
+    fun typescriptArrowReturnType() {
+        assertEquals(
+            listOf(
+                "const" to "keyword",
+                "f" to "def",
+                "=" to "operator",
+                "(" to null,
+                "a" to "def",
+                ":" to null,
+                "number" to "type",
+                ")" to null,
+                ":" to null,
+                "string" to "variable",
+                "=>" to "operator",
+                "{" to null,
+                "return" to "keyword",
+                "\"\"" to "string",
+                "+" to "operator",
+                "a" to "variableName.local",
+                ";" to null,
+                "}" to null,
+                ";" to null
+            ),
+            styles(
+                typescript,
+                "const f = (a: number): string => {\n" +
+                    "return \"\" + a;\n" +
+                    "};\n"
+            )
+        )
+    }
+
+    /** JSON keys are properties; the mode has no statement grammar. */
+    @Test
+    fun jsonDocument() {
+        assertEquals(
+            listOf(
+                "{" to null,
+                "\"a\"" to "string property",
+                ":" to null,
+                "[" to null,
+                "1" to "number",
+                "," to null,
+                "2" to "number",
+                "]" to null,
+                "}" to null
+            ),
+            styles(
+                json,
+                "{\n" +
+                    "  \"a\": [\n" +
+                    "    1,\n" +
+                    "    2\n" +
+                    "  ]\n" +
+                    "}\n"
+            )
+        )
+    }
+    private companion object {
+        const val UNIT = 2
+        const val TAB_SIZE = 4
+        const val MAX_TOKEN_ATTEMPTS = 10
+    }
+}


### PR DESCRIPTION
Fixes #276.

## What the behaviour actually was, measured

Not "indentation is sometimes wrong": **every line of every JavaScript, TypeScript, JSON and
JSON-LD document indented to column 0**, whatever the nesting. `JavaScriptLegacy.kt` ported the
tokenizer but not the grammar, so nothing ever ran `pushlex`; `state.lexical` stayed the base
`"block"` scope with `indented == -indentUnit`, and only `else -> lexical.indented + unit` in
`indent` was ever reachable.

The new tests, copied alone onto unmodified `origin/main` (d833c0b), fail 19 of 22 — and every
observed value is `0`:

```
JavaScriptIndentScopeTest[jvm] tests 22 failures 19 errors 0
  nestedFunctionIfBlock:                 expected:<[0, 2, 4, 2, 0, 0]> but was:<[0, 0, 0, 0, 0, 0]>
  deepNesting:                     expected:<[0, 2, 4, 6, 4, 2, 0, 0]> but was:<[0, 0, 0, 0, 0, 0, 0, 0]>
  switchDoubleIndent:              expected:<[0, 2, 4, 4, 2, 4, 0, 0]> but was:<[0, 0, 0, 0, 0, 0, 0, 0]>
  classBody:                             expected:<[0, 2, 4, 2, 0, 0]> but was:<[0, 0, 0, 0, 0, 0]>
  jsonNestedStructure:                expected:<[0, 2, 4, 4, 2, 0, 0]> but was:<[0, 0, 0, 0, 0, 0, 0]>
  alignsToOpenParen:                              expected:<[0, 4, 0]> but was:<[0, 0, 0]>
  vardefContinuationIndent:                       expected:<[0, 4, 0]> but was:<[0, 0, 0]>
  continuedExpression:                            expected:<[0, 4, 0]> but was:<[0, 0, 0]>
  ifElseForms:                                 expected:<[0, 2, 0, 2, 0]> but was:<[0, 0, 0, 0, 0]>
  forLoopBody:                                 expected:<[0, 2, 0, 0]> but was:<[0, 0, 0, 0]>
  arrayLiteralBody:                            expected:<[0, 2, 2, 0, 0]> but was:<[0, 0, 0, 0, 0]>
  tryCatchBlocks:                           expected:<[0, 2, 0, 2, 0, 0]> but was:<[0, 0, 0, 0, 0, 0]>
  typescriptInterfaceBody:                     expected:<[0, 2, 0, 0]> but was:<[0, 0, 0, 0]>
  nestedBlocksWithUnindentedInput:          expected:<[0, 2, 2, 0, 0, 0]> but was:<[0, 0, 0, 0, 0, 0]>
  issueDocumentBlankLineAfterIf:                  expected:<[0, 2, 2]> but was:<[0, 0, 0]>
  issueDocumentBlankLineAfterAssignment:          expected:<[0, 4, 4]> but was:<[0, 0, 0]>
  issueDocumentBlankLineInFunctionBody:        expected:<[0, 2, 2, 0, 0]> but was:<[0, 0, 0, 0, 0]>
  issueDocumentBlankLineInObjectLiteral:       expected:<[0, 2, 2, 0, 0]> but was:<[0, 0, 0, 0, 0]>
  issueDocumentBlankLineInSwitchCase:          expected:<[0, 2, 4, 0, 0]> but was:<[0, 0, 0, 0, 0]>
```

The three that passed are the three whose correct answer happens to be all zeros
(`foo()\n\n`, `foo\n\n`, `foo();\n   \nbar()\n`) — which is exactly why a "not null" assertion
would have missed this.

## What was ported

The whole of `parseJS`, not a subset:

- the `cc` continuation stack and the ~60 combinators of the grammar (statements, expressions,
  patterns, classes, modules, and the TypeScript type grammar), in a new `JavaScriptGrammar.kt`;
- `pushlex`/`poplex`, and the `Context`/`Var` variable scopes with `pushcontext`,
  `pushblockcontext`, `popcontext`, `register` and `registerVarScoped`;
- `findFatArrow`, which `state.fatArrowAt` needed and nothing was calling;
- in `indent`: the `vardef` case and the `doubleIndentSwitch` case (neither string appeared
  anywhere in the file before), the `maybeelse` scope-pop kludge, and the
  `top == maybeoperatorComma || top == maybeoperatorNoComma` conjunct of the scope walk that the
  port had dropped. Without that conjunct a `stat` scope is popped the moment one exists, which
  would have traded one wrong answer for another.

## Compared against

`@codemirror/legacy-modes` **6.5.0**, `mode/javascript.js` — the module this file is a port of,
which is itself CodeMirror 5's `mode/javascript/javascript.js` — read from the local yarn cache
and run under Node with the real `@codemirror/language` **6.12.3** `StringStream`, driven by the
same line-by-line loop `StreamLanguage.getIndent` uses (`indentUnit` 2, `tabSize` 4).

**Differential result: 77 documents, 486 indent queries and 2266 tokens (text *and* style) —
zero mismatches.** Every expected value in both new test classes is upstream's own answer taken
from that run; none was written by hand or read off this port.

## Mutation testing

Eleven mutations, each applied alone to the merged tree with the full suite re-run:

| mutation | result |
| --- | --- |
| drop the `maybeoperator*` conjunct from the scope walk | killed (2 tests) |
| drop the `maybeelse` kludge loop | killed (`nestedSingleStatementIf`) |
| drop the `vardef` branch of `indent` | killed (4 tests) |
| drop the `switch` double-indent branch | killed (2 tests) |
| drop the `lexical.align` branch | killed (2 tests) |
| make `findFatArrow` a no-op | killed (2 token-style tests) |
| make `register` skip local-variable tracking | killed (5 token-style tests) |
| make `pushlex` ignore an enclosing `"stat"` scope | killed (`bracketOpenedOnAContinuationLine`) |
| make `poplex` skip restoring `state.indented` | killed (`blockOpenedAfterAnIndentedClosingParen`) |
| revert the whole change | killed (19 tests, above) |
| **`copyState` shares the `cc` list instead of copying it** | **SURVIVED** |
| **`copyState` hands back an empty `cc`** | **SURVIVED** |

Four of these mutations survived the first suite and four fixtures were added specifically to
kill them (`nestedSingleStatementIf`, `bracketOpenedOnAContinuationLine`,
`blockOpenedAfterAnIndentedClosingParen`, and the token-style class).

**Which lines could still be deleted with no test noticing:** the `.toMutableList()` in
`copyState`. It is genuinely unobserved — a mutation that hands the resumed state an *empty*
continuation stack also survives. A probe confirmed the cached-resume branch in
`StreamLanguage.getIndent` does fire for the two long-document tests (`startState=true` for
positions past the first 512-byte chunk), so the branch is exercised; the resumed `cc` simply
does not affect the answer for any document I could construct, because `indent` reads
`state.lexical` — which is shared, not rebuilt — and only consults `cc.last()`. Copying is
upstream's behaviour (`defaultCopyState` slices arrays) and is kept as a correctness property,
not because a test demands it.

Note on this module's existing coverage: `LegacyModesSmokeTest`'s 110 tests **cannot fail**
(#239) — a parser that classifies nothing passes all of them. They are not cited as evidence
here. The 38 tests added by this PR are, as far as I can tell, the only tests in `:legacy-modes`
that can fail on a JavaScript regression.

## What was NOT ported

- **`parserConfig.localVars` / `globalVars`.** `JavaScriptConfig` has no such fields, so
  `register` never records a global and `state.globalVars` does not exist. None of the four
  exported modes sets them upstream either, so no exported behaviour differs.
- **`commasep`'s `lex.pos = (lex.pos || 0) + 1`** bookkeeping for `info == "call"` lexicals —
  dead upstream; `JSLexical.pos` is never read by anything.
- **`languageData`**: still only `commentTokens`. Upstream also publishes `indentOnInput`,
  `closeBrackets` and `wordChars`. That gap predates this PR and is unchanged by it; filed
  separately as #348.
- Two deliberate divergences, both commented in the source: `popcontext` guards a null context
  where upstream would throw, and `findFatArrow` keeps upstream's *relative* match index for the
  TypeScript return-type skip (only equal to an absolute offset on the `sol()` call path, which
  is where it matters) rather than silently "fixing" it.

Pre-existing tokenizer divergences (the inlined string/comment/quasi tokenizers as integer
states; `statementIndent` tested for null rather than truthiness) are untouched.

## Suites, before and after

| suite | before | after |
| --- | --- | --- |
| `:legacy-modes:jvmTest` | 127 | 165 |
| `:legacy-modes:wasmJsTest` | — | 165, 0 failures |
| `:language:jvmTest` | 91 | 91 |

The +38 is `JavaScriptIndentScopeTest` (27) and `JavaScriptTokenStyleTest` (11). No test was
removed. Counts read from `build/test-results/**/*.xml`, not from Gradle's exit code.

One **existing assertion changed**, by name:
`JavaScriptBlankLineIndentTest.indentQueriesAtTheStartOfEveryLine` asserted
`[0, 0, 0, 0, 0]` for `function f() {\n  foo();\n\n}\n`. That was pinning the constant this issue
is about; upstream answers `[0, 2, 2, 0, 0]` and the test now asserts that. Its other three
documents are unchanged. The class doc-comment said the parser could not produce a `"stat"`
scope — no longer true, so it was updated too. That file has no `parity:` comment, and neither
do the new files.

`Pug.kt` is the only other mode that embeds this one (for inline JavaScript); it goes through
`startState`/`copyState` and now inherits the grammar's token styles. Its only coverage is the
smoke test, which cannot fail.

## API

`:legacy-modes:apiCheck` **fails without a dump** — one intended addition,
`JavaScriptConfig.doubleIndentSwitch: Boolean = true` (upstream's knob for the branch that was
never ported). `apiDump` was run; the diff across `api/jvm`, `api/android` and the klib dump is
that field, its `component7`/`copy` and the constructor arity. **`JavaScriptState`'s new
`cc`/`localVars`/`context` are `internal` and do not appear in any dump.**

## Local verification

`:legacy-modes:jvmTest`, `:legacy-modes:wasmJsTest` (`CHROME_BIN=/usr/bin/chromium`),
`:language:jvmTest`, `:legacy-modes:apiCheck`, `ktlintCheck`, `spotlessCheck` — all green.
`changelog.py check --base-ref origin/main`: 18 fragments valid, `CHANGELOG.md` untouched.
