### PR TITLE
Pin the pointer pass the focus capture depends on (#344)

### DIFF
--- a/changelog.d/344.tests.md
+++ b/changelog.d/344.tests.md
@@ -1,0 +1,9 @@
+- Pinned the pointer pass that #259's focus fix depends on (#344). The editor holds its focus
+  across a press by capturing it on the `Final` pointer pass, and that choice was load-bearing but
+  unguarded: moving the capture to `Main` or `Initial` left the entire Android instrumented suite
+  green, because every existing focus test starts from an editor that is already focused and a
+  capture taken too early still finds a focus to capture. The case that discriminates is the first
+  mouse click on an editor that is *not* focused, where the capture has to come after the gesture's
+  own focus request or there is nothing to capture and Compose's cursor auto-clear blanks the focus
+  again — #259 all over. Two instrumented tests now cover it, one clicking an editor that focus was
+  moved away from and one moving focus between two editors, and both fail under either mutation.

--- a/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/UnfocusedEditorClickTest.kt
+++ b/view/src/commonTest/kotlin/com/monkopedia/kodemirror/view/input/UnfocusedEditorClickTest.kt
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2026 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.view.input
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import com.monkopedia.kodemirror.commands.standardKeymap
+import com.monkopedia.kodemirror.state.EditorState
+import com.monkopedia.kodemirror.state.EditorStateConfig
+import com.monkopedia.kodemirror.state.asDoc
+import com.monkopedia.kodemirror.view.EditorSession
+import com.monkopedia.kodemirror.view.EditorSessionImpl
+import com.monkopedia.kodemirror.view.KodeMirror
+import com.monkopedia.kodemirror.view.keymapOf
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The **first** press on an editor that does not already hold focus.
+ *
+ * # Why this case, and not the one [PointerFocusRetentionTest] covers
+ *
+ * #259 is repaired by capturing the editor's focus for the length of a press,
+ * and the capture is taken on the `Final` pointer pass. That pass choice is the
+ * load-bearing part of the fix and nothing else in the repository pinned it:
+ * changing it to `Main` or to `Initial` left the whole Android instrumented
+ * suite green (#344).
+ *
+ * It left the suite green because every other focus test starts from an editor
+ * that is *already* focused — the editor requests focus once at composition —
+ * and a capture taken too early still finds a focus to capture in that state.
+ * The ordering only matters when there is nothing to capture yet:
+ *
+ *  * the editor's tap gesture calls `focusRequester.requestFocus()` on the
+ *    **Main** pass of the down;
+ *  * `AndroidComposeView.dispatchTouchEvent` applies
+ *    `AutoClearFocusBehavior.CursorBased` — the platform default — *after* all
+ *    of that, clearing focus because the press lands outside the 1-dp hidden
+ *    input that holds it;
+ *  * a captured focus target refuses that (non-forced) clear, so the capture is
+ *    the veto — but only if it was taken after the request.
+ *
+ * `Final` runs after every Main-pass handler in the tree, so the capture
+ * succeeds. On `Main` the capture modifier is inner to the gesture modifier and
+ * therefore sees the down *first*, before there is any focus; on `Initial` it
+ * runs earlier still. Either way `captureFocus()` returns `false`, nothing
+ * vetoes the auto-clear, and the focus the gesture has just requested is blanked
+ * — which is #259 again, on the first click.
+ *
+ * # What is asserted
+ *
+ * Concrete state on both sides of the press: focus is false before it and true
+ * after it, and the key that follows lands the cursor at an exact offset. The
+ * press at `x = 8` is two pixels into the content's 6-dp start padding, so it
+ * resolves to the first character of line 1 on any font, and `End` from there
+ * must reach **11**, the end of `"Hello world"`. A dropped key leaves the cursor
+ * where the press put it, at 0, so only an exact 11 says it arrived.
+ *
+ * The auto-clear these guard is Android's, and Android is where they discriminate
+ * — `view/build.gradle.kts` keeps `...view.input.*` out of every Android local
+ * unit test, so on that target they run instrumented only. On the other targets
+ * they are ordinary passing coverage of the same user-visible behaviour.
+ *
+ * # A note on the shape of the test bodies
+ *
+ * Every test here is a single expression whose value is the `runComposeUiTest`
+ * call, and it has to stay that way. On wasmJs that value is what the framework
+ * waits on; a body that runs the call as a statement and returns `Unit` finishes
+ * before the composition does, and the browser suite then reports the test as
+ * **passed without having evaluated a single assertion** — verified here by
+ * asserting a deliberately wrong cursor offset and watching it pass.
+ */
+@OptIn(ExperimentalTestApi::class)
+class UnfocusedEditorClickTest {
+
+    private val doc = "Hello world\nSecond line"
+
+    /** A point inside line 1 of the editor, ahead of its first character. */
+    private val pressOnLine1 = Offset(8f, 15f)
+
+    private val SessionHolder.hasFocus: Boolean
+        get() = (session as EditorSessionImpl).hasFocus
+
+    private val SessionHolder.head: Int
+        get() = session.state.selection.main.head.value
+
+    /** One editor, sized and with the density pinned the way [runEditorTest] does. */
+    @Composable
+    private fun Editor(holder: SessionHolder, height: Int) {
+        Box(Modifier.requiredSize(800.dp, height.dp)) {
+            val state = remember {
+                EditorState.create(
+                    EditorStateConfig(
+                        doc = doc.asDoc(),
+                        extensions = keymapOf(standardKeymap)
+                    )
+                )
+            }
+            val session = remember(state) { EditorSession(state) }
+            holder.session = session
+            KodeMirror(session = session)
+        }
+    }
+
+    /**
+     * Compose one editor next to a plain focusable box and hand focus to the
+     * box, so the editor starts [block] **unfocused**.
+     */
+    private fun runUnfocusedEditorTest(block: ComposeUiTest.(SessionHolder) -> Unit) =
+        SessionHolder().let { holder ->
+            val elsewhere = FocusRequester()
+            runComposeUiTest {
+                setContent {
+                    CompositionLocalProvider(
+                        LocalDensity provides Density(density = 1f, fontScale = 1f)
+                    ) {
+                        Column {
+                            Editor(holder, height = 400)
+                            Box(
+                                Modifier.requiredSize(80.dp, 40.dp)
+                                    .testTag("elsewhere")
+                                    .focusRequester(elsewhere)
+                                    .focusable()
+                            )
+                        }
+                    }
+                }
+                waitForIdle()
+                // The editor focuses itself once at composition; move that focus
+                // away so the click under test is the first one it ever sees.
+                runOnIdle { elsewhere.requestFocus() }
+                waitForIdle()
+                assertFalse(
+                    holder.hasFocus,
+                    "The test setup is wrong, not the editor: focus was moved to another " +
+                        "focusable and the editor still reports hasFocus=true, so the click " +
+                        "below is not a first click on an unfocused editor and would prove " +
+                        "nothing about when the focus capture is taken (#344)."
+                )
+                block(holder)
+            }
+        }
+
+    /**
+     * The first mouse press on an unfocused editor must focus it and keep that
+     * focus, so the key after the press is delivered.
+     */
+    @Test
+    fun firstMouseClickOnUnfocusedEditor_takesFocusAndDeliversTheKeyAfterIt() =
+        runUnfocusedEditorTest { holder ->
+            onNodeWithTag("KodeMirror").performMouseInput { click(pressOnLine1) }
+            waitForIdle()
+            assertTrue(
+                holder.hasFocus,
+                "editor lost focus on the first mouse click while unfocused: the press " +
+                    "placed the cursor at ${holder.head} and then hasFocus=false. The " +
+                    "gesture requests focus on the Main pass and Compose's cursor " +
+                    "auto-clear runs after it, so the focus capture that vetoes the " +
+                    "clear has to be taken on a later pass than the request (#344/#259)."
+            )
+
+            onNodeWithTag("KodeMirror_input").performKeyInput {
+                keyDown(Key.MoveEnd)
+                keyUp(Key.MoveEnd)
+            }
+            waitForIdle()
+            assertTrue(
+                holder.head == 11,
+                "Expected End to reach 11, the end of \"Hello world\", after the first " +
+                    "click on an unfocused editor, but the cursor is at ${holder.head}. " +
+                    "At 0 the key was never delivered — the click placed the cursor " +
+                    "there and the focus was taken away before the key arrived (#344)."
+            )
+        }
+
+    /**
+     * Two editors above one another: clicking one focuses it and unfocuses the
+     * other, in both directions.
+     *
+     * Only one of the two can hold the composition-time focus, so one of these
+     * clicks is always a first click on an unfocused editor. The pair is also
+     * the only coverage of focus moving *between* editors, which is what a
+     * capture that is taken and never released would break.
+     */
+    @Test
+    fun clickEditorAThenEditorB_focusMovesBetweenThem() =
+        Pair(SessionHolder(), SessionHolder()).let { (a, b) ->
+            runComposeUiTest {
+                setContent {
+                    CompositionLocalProvider(
+                        LocalDensity provides Density(density = 1f, fontScale = 1f)
+                    ) {
+                        Column {
+                            Editor(a, height = 200)
+                            Editor(b, height = 200)
+                        }
+                    }
+                }
+                waitForIdle()
+
+                fun clickAndAssert(
+                    index: Int,
+                    name: String,
+                    focused: SessionHolder,
+                    blurred: SessionHolder
+                ) {
+                    onAllNodesWithTag("KodeMirror")[index].performMouseInput {
+                        click(pressOnLine1)
+                    }
+                    waitForIdle()
+                    assertTrue(
+                        focused.hasFocus,
+                        "editor $name did not hold focus after a mouse click on it: the " +
+                            "click placed its cursor at ${focused.head} and then " +
+                            "hasFocus=false. A click on an editor that was not already " +
+                            "focused must leave it focused (#344/#259)."
+                    )
+                    assertFalse(
+                        blurred.hasFocus,
+                        "both editors report focus after the click on $name. Focus has to " +
+                            "move to the clicked editor, so a capture taken across a press " +
+                            "must be released when the press ends (#344)."
+                    )
+                    onAllNodesWithTag("KodeMirror_input")[index].performKeyInput {
+                        keyDown(Key.MoveEnd)
+                        keyUp(Key.MoveEnd)
+                    }
+                    waitForIdle()
+                    assertTrue(
+                        focused.head == 11,
+                        "Expected End to reach 11 in editor $name after clicking it, but " +
+                            "its cursor is at ${focused.head}. At 0 the key was never " +
+                            "delivered (#344)."
+                    )
+                }
+
+                clickAndAssert(index = 0, name = "A", focused = a, blurred = b)
+                clickAndAssert(index = 1, name = "B", focused = b, blurred = a)
+            }
+        }
+}


### PR DESCRIPTION
Fixes #344.

## The gap

#335 repaired #259 by capturing the editor's focus for the length of a pointer press, taken on
`PointerEventPass.Final`. That pass choice is load-bearing and nothing pinned it. Mutating the line
and re-running the whole Android instrumented suite left it **silently green**, which is how a
regression here would land unnoticed.

The reason it stays green is that every existing focus test starts from an editor that is
**already focused** — the editor requests focus once at composition — and a capture taken too early
still finds a focus to capture in that state. `PointerFocusRetentionTest`, the test #335 added, has
the same shape.

The case that discriminates is the **first mouse press on an editor that is not focused**: the tap
gesture calls `focusRequester.requestFocus()` on the **Main** pass of the down, and
`AndroidComposeView.dispatchTouchEvent` applies `AutoClearFocusBehavior.CursorBased` after all of
it. A capture taken on `Main` or `Initial` runs before there is anything to capture,
`captureFocus()` returns `false`, nothing vetoes the auto-clear, and the focus the gesture just
requested is blanked — #259 again, on the first click.

**The `Final` line is correct.** This is a missing test, not a production bug: no production file
is touched by this PR.

## The tests

`view/src/commonTest/.../input/UnfocusedEditorClickTest.kt`, two cases:

* **`firstMouseClickOnUnfocusedEditor_takesFocusAndDeliversTheKeyAfterIt`** — the editor is composed
  next to a plain focusable box and focus is moved to the box, so the click under test is the first
  the editor ever sees. A setup assertion fails loudly if that move did not take, because a test
  that silently starts focused reproduces the gap instead of closing it. Then a mouse click, then
  `End`.
* **`clickEditorAThenEditorB_focusMovesBetweenThem`** — two editors, clicked in both directions.
  Only one can hold the composition-time focus, so one of the two clicks is always the unfocused
  first click; the pair is also the only coverage of focus moving *between* editors, which is what a
  capture that is never released would break.

Every assertion is concrete state — `hasFocus` true/false, and an exact cursor offset. The press at
`x = 8` is two pixels into the content's 6-dp start padding, so it resolves to the first character
of line 1 on any font, and `End` from there must reach **11**, the end of `"Hello world"`. A dropped
key leaves the cursor at 0, where the press put it, so only an exact 11 says it arrived.

## Verification

`view/build.gradle.kts` excludes `com.monkopedia.kodemirror.view.input.*` from every `*UnitTest`
task, so on Android these run **instrumented only**. All counts below are read from
`build/**/TEST-*.xml` with a parser that recounts `<testcase>` elements independently of the
`<testsuite>` attributes and treats a `<failure>` element with no `message` attribute as a failure;
Gradle's own `BUILD SUCCESSFUL` / `BUILD FAILED` is quoted next to each as an independent signal.

### The mutation matrix — API 33 emulator, `:view:connectedDebugAndroidTest`

| `KodeMirror.kt:798` | executed | failed | Gradle | failing by name |
|---|---|---|---|---|
| `PointerEventPass.Final` (shipped) | 109 | **0** | `BUILD SUCCESSFUL` | — |
| `PointerEventPass.Main` | 109 | **2** | `BUILD FAILED` | both new tests |
| `PointerEventPass.Initial` | 109 | **2** | `BUILD FAILED` | both new tests |

Both mutations fail both tests, at the intended assertion:

```
editor lost focus on the first mouse click while unfocused: the press placed the cursor at 0
and then hasFocus=false. ...
editor A did not hold focus after a mouse click on it: the click placed its cursor at 0 and
then hasFocus=false. ...
```

The 107 pre-existing tests pass in all three runs — the two mutations are caught by the new
coverage and by nothing else.

**The mutation hit exactly one site.** `KodeMirror.kt` holds three `PointerEventPass` references —
`Initial` at 657 (#322's long-press loop), `Final` at 798, `Main` at 827 — and `PointerEventPass.Final`
occurs exactly once in the file. Each `sed` was anchored to line 798 and followed by
`git diff --stat` showing `1 file changed, 1 insertion(+), 1 deletion(-)` and a re-listing of all
three sites confirming 657 untouched.

### Where the tests execute

| suite | before | after | new-test XML |
|---|---|---|---|
| `:view:jvmTest` | 336 / 0 | **338 / 0** | `test-results/jvmTest/TEST-….UnfocusedEditorClickTest.xml`, `tests=2 failures=0` |
| `:view:wasmJsTest` | 303 / 0 | **305 / 0** | `test-results/wasmJsBrowserTest/TEST-….UnfocusedEditorClickTest.xml`, `tests=2 failures=0` |
| emulator | 107 / 0 | **109 / 0** | `outputs/androidTest-results/connected/…xml`, both cases present and passing |

### A negative control, because "passed" is not the same as "evaluated"

The first draft of these tests ran `runComposeUiTest` as a statement in a block body. On wasmJs that
**passes without evaluating a single assertion** — asserting a deliberately wrong cursor offset
(`head == 1234`) still reported green, while the same edit applied to `PointerFocusRetentionTest`,
which is expression-bodied, failed as it should. Every test here is now a single expression whose
value is the `runComposeUiTest` call, the wrong-offset control fails on wasmJs as expected, and the
KDoc says why the shape has to stay that way.

### The rest

`:view:apiCheck` green; **`.api` did not move** — `git status -- '*.api'` is empty. `:view:ktlintCheck`
and `spotlessCheck` green. `changelog.py check --base-ref origin/main` green.

## Noted, not caused here

`TextInputTest` is intermittently flaky on the emulator: `pluginSeesNewStateDuringUpdate` failed
once with `Expected doc 'XHello' but got 'XXHello'` and `multipleCharactersInsertSequentially` once
with `ABCHello` / `AABCHello` — a typed character delivered twice. It fired once under the shipped
`Final` and once under a mutation, in different tests, and both re-ran green; it is unrelated to
this change and to the pass choice. Filing it separately would need more than two samples to say
anything useful.

## Not covered here

#344 also lists release-path coverage for the capture (`whilePressed_captureBlocksOtherFocus`,
`afterPointerCancel_captureReleased`, multi-touch, leaving composition mid-press). The A-then-B test
guards release on the editor's own path — a leaked capture would stop editor B from ever taking
focus — but the pointer-cancel, multi-touch and detach paths are still unguarded. Kept out to hold
this PR to the one thing #344 is titled for.
