### PR TITLE
Let lang-yaml's indentation tracker keep upstream's strict default (#257)

### DIFF
--- a/changelog.d/257.fixed.md
+++ b/changelog.d/257.fixed.md
@@ -1,0 +1,9 @@
+- `:lang-yaml`'s indentation `ContextTracker` no longer declares `strict = false` (#257).
+  `@lezer/yaml` 1.0.4 leaves `strict` at `@lezer/lr`'s default of true; with it false the stack's
+  context hash is pinned to 0 and `Stack.close` stops writing `NodeProp.contextHash`, so
+  `Parse.useCachedResult` had nothing to compare and reused a cached node whatever block depth it
+  was parsed under. Re-indenting a line then spliced a subtree back in at the wrong nesting — an
+  incremental reparse of an F-Droid metadata file swallowed two top-level keys into the mapping
+  above them. Over 16,470 single-edit incremental reparses of 915 indentation-heavy YAML documents
+  the incremental tree disagreed with a fresh parse of the same text 153 times before this change
+  and 6 times after; whole-document parses are unaffected either way.

--- a/lang-yaml/src/commonMain/kotlin/com/monkopedia/kodemirror/lang/yaml/YamlParser.kt
+++ b/lang-yaml/src/commonMain/kotlin/com/monkopedia/kodemirror/lang/yaml/YamlParser.kt
@@ -125,8 +125,7 @@ private val indentation = ContextTracker(
             context
         }
     },
-    hash = { context -> context.hash },
-    strict = false
+    hash = { context -> context.hash }
 ) as ContextTracker<Any?>
 
 private fun three(input: InputStream, ch: Int, off: Int = 0): Boolean = input.peek(off) == ch &&

--- a/lang-yaml/src/commonTest/kotlin/com/monkopedia/kodemirror/lang/yaml/YamlIncrementalReuseTest.kt
+++ b/lang-yaml/src/commonTest/kotlin/com/monkopedia/kodemirror/lang/yaml/YamlIncrementalReuseTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 Jason Monk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Originally based on CodeMirror 6 by Marijn Haverbeke, licensed under MIT.
+ * See NOTICE file for details.
+ */
+package com.monkopedia.kodemirror.lang.yaml
+
+import com.monkopedia.kodemirror.lezer.common.ChangedRange
+import com.monkopedia.kodemirror.lezer.common.TreeFragment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * The indentation [com.monkopedia.kodemirror.lezer.lr.ContextTracker] must keep
+ * `strict` at its default of true, as `@lezer/yaml` 1.0.4 does.
+ *
+ * A non-strict tracker pins the stack's context hash to 0 and stops
+ * `Stack.close` writing `NodeProp.contextHash` on to the nodes it builds, so
+ * `Parse.useCachedResult` has nothing to compare and reuses a cached node
+ * whatever indentation context it was parsed under. Re-indenting a line then
+ * lets a subtree parsed at one block depth be spliced back in at another.
+ */
+class YamlIncrementalReuseTest {
+
+    private val doc = """
+AntiFeatures:
+    en-US: App depends on Reddit.
+Categories:
+License: GPL-3.0-only
+RepoType: git
+Builds:
+  - versionName: 1.0.4
+    versionCode: 5
+    commit: 770905d77eac8bb960502769b591c492c70d6b86
+    target: android-15
+  - versionName: 1.0.4.1
+    versionCode: 6
+    commit: 85d946af7a9a
+    target: android-15
+  - versionName: 1.0.5
+    versionCode: 7
+    commit: d1.0.5
+    target: android-15
+  - versionName: 1.0.6
+    versionCode: 8
+    commit: d1.0.6
+    target: android-15
+  - versionName: 1.0.7
+    versionCode: 9
+    commit: d1.0.7
+    target: android-15
+  - versionName: 1.0.9
+    versionCode: 11
+    commit: d1.0.9
+    target: android-15
+  - versionName: 1.1.0
+    versionCode: 12
+    commit: d1.1.0
+    target: android-15
+  - versionName: 1.1.1
+    versionCode: 13
+    commit: d1.1.1
+  - versionName: 1.1.2
+    versionCode: 14
+    commit: d1.1.2
+  - versionName: 1.1.3
+    versionCode: 15
+    commit: d1.1.3
+  - versionName: 1.1.4
+    versionCode: 16
+    commit: d1.1.4
+  - versionName: 1.2.0
+    versionCode: 17
+    commit: d1.2.0
+  - versionName: 1.2.1
+    versionCode: 18
+ArchivePolicy: 0
+""".removePrefix("\n")
+
+    /** The edit: indent the trailing top-level `ArchivePolicy` line by four. */
+    private val editFrom = doc.lastIndexOf("ArchivePolicy")
+    private val edited = doc.substring(0, editFrom) + "    " + doc.substring(editFrom)
+
+    private fun reparse(): String {
+        val fragments = TreeFragment.applyChanges(
+            TreeFragment.addTree(yamlParser.parse(doc)),
+            listOf(ChangedRange(editFrom, doc.length, editFrom, edited.length))
+        )
+        return treeToString(yamlParser.parse(edited, fragments))
+    }
+
+    /**
+     * The tree `@lezer/yaml` 1.0.4 produces for [edited], both from scratch and
+     * incrementally: five top-level pairs, the second of which (`Categories:`)
+     * has no value, and a `Builds` sequence of seven four-field items followed
+     * by six three-field ones.
+     */
+    private val expected: String = run {
+        val pair = "Pair(Key(Literal),Literal)"
+        val item4 = "Item(BlockMapping($pair,$pair,$pair,$pair))"
+        val item3 = "Item(BlockMapping($pair,$pair,$pair))"
+        val builds = List(7) { item4 }.joinToString(",") + "," + List(6) { item3 }.joinToString(",")
+        "Stream(Document(BlockMapping(" +
+            "Pair(Key(Literal),BlockMapping($pair))," +
+            "Pair(Key(Literal))," +
+            "$pair,$pair," +
+            "Pair(Key(Literal),BlockSequence($builds))" +
+            ")))"
+    }
+
+    @Test
+    fun reindentingATailLineDoesNotRestructureTheReusedHead() = assertEquals(expected, reparse())
+
+    /**
+     * Control: the same document parsed from scratch, with no fragments in
+     * play. This holds either side of the tracker change, so the failure above
+     * comes from fragment reuse and not from the grammar or the expectation.
+     */
+    @Test
+    fun freshParseOfTheEditedDocumentMatchesUpstream() =
+        assertEquals(expected, treeToString(yamlParser.parse(edited)))
+
+    /**
+     * Control: the edit really does restructure the document, so the two trees
+     * above are not trivially the same one.
+     */
+    @Test
+    fun theEditChangesTheTree() = assertNotEquals(expected, treeToString(yamlParser.parse(doc)))
+}


### PR DESCRIPTION
Part of #257 — the `lang-yaml` half. `:lang-python`'s was fixed in #347; the other four sites
(html, javascript, xml, and the unset ones) already match upstream, so #257 stays open.

## The change

```diff
-    hash = { context -> context.hash },
-    strict = false
+    hash = { context -> context.hash }
```

`@lezer/yaml` 1.0.4 (`dist/index.cjs:74-97`) passes `start`, `reduce`, `shift` and `hash` and no
`strict`; `@lezer/lr` 1.4.10 defaults it to true (`this.strict = spec.strict !== false`,
`dist/index.js:1581`). The port declared it false.

## Was `lang-yaml` actually affected, or is this fidelity?

**Affected — but on a different path than `lang-python`.** I measured rather than assuming, and the
answer split in two:

* **Whole-document parses: unaffected.** 915 indentation-heavy YAML documents parsed from scratch
  and diffed against real `@lezer/yaml` 1.0.4 — tree shape, every node's `from`/`to`, and
  `tree.length` — give **1 positional divergence before the change and the same 1 after**
  (`synth:s15-empty-values.yaml`, an empty `BlockSequence` `Item` at 39-39 vs 36-36; background,
  unrelated to `strict`). `lang-python`'s 11-of-40 came through `TokenCache.getActions`'s
  `token.context != context` test, and YAML's two context-reading tokenizers that matter there
  (`newlines`, `blockMark`) are both declared `contextual: true`, so they re-tokenise regardless of
  the hash. That path is genuinely inert here.

* **Incremental reparses: corrupted, and this fixes it.** The live mechanism is the other pair of
  `strict` uses: `Stack.close` skips `emitContext()`, so no `NodeProp.contextHash` is written on the
  nodes, and `Parse.useCachedResult`'s `(cached.prop(NodeProp.contextHash) ?: 0) == cxHash` guard is
  skipped as well. A cached node is then reused whatever block depth it was parsed under.

## Differential: 915-document corpus, 16,470 single-edit incremental reparses

Each document is parsed, one edit is applied, `TreeFragment.applyChanges` builds fragments from the
first tree, and the incremental reparse is compared with a fresh parse of the same final text —
upstream's own invariant, and what CodeMirror relies on for every keystroke.

| | diffs | of those, error-free on both sides | trials that reused ≥1 node | nodes reused |
| --- | --- | --- | --- | --- |
| `strict = false` (`main`) | **153 / 16,470** | 43 | 6,193 | 14,084 |
| `strict` default | **6 / 16,470** | 1 | 6,006 | 13,300 |

The fix is not "reuse less": 6,006 of the trials still reuse and 13,300 nodes still come from
fragments (−5.6%), i.e. the guard rejects context-mismatched nodes specifically.

**Background, separated:** the residual **6** are all one file, `libuv`'s
`.github/workflows/CI-unix.yml`, all at the same divergence offset 754, under five different edits —
a single pre-existing incremental divergence, not a `strict` effect (one of the six is in the
before-list too). That is this corpus's analogue of the ~15 JSON error-recovery divergences #338
records. Base diffs span 22 distinct files; the residual spans 1.

## Confirmed from upstream's side too

Running the same protocol entirely in JS on real `@lezer/lr` 1.4.10 + `@lezer/yaml` 1.0.4, 41
documents / 8,285 trials, with `useNode` instrumented to count reuse:

| `@lezer/lr` | incremental ≠ fresh | nodes reused |
| --- | --- | --- |
| unmodified (`strict` default true) | **325** | 25,887 |
| `dist/index.js:1581` patched to `this.strict = false` | **1,185** | 31,338 |

So forcing the port's flag on to upstream's own code multiplies its incremental divergences 3.6×.
The flag is causal independent of this port.

*(Upstream declines to build a `FragmentCursor` at all below `bufferLength * 4` ≈ 4 KB —
`dist/index.js:1278`, the threshold #334 records as missing here — so this run is restricted to
documents over 4,200 characters, where upstream really does reuse. On the ~1 KB unit-test fixture
below, upstream reuses **0** nodes and cannot show the bug at all; that is #334's gap, not this
one's, and it is untouched.)*

## The corpus, and why it can exercise the mechanism

915 documents. A flat corpus would have proved nothing, so selection scored on indentation
structure — a file needs ≥3 distinct indent columns, a max indent ≥4, and scores on distinct indent
levels, sequence items nested under mappings, block scalars, and dedent events — over 9,344
`.yml`/`.yaml` files found on this machine, content-deduplicated. What came through: GitHub Actions
workflows (deep `jobs:`→`steps:`→`with:` nesting, `run: |` block literals, constant
dedent-then-reindent), F-Droid `metadata/*.yml` (long `Builds:` sequences of heterogeneous
mappings), OpenAPI/JSON-Schema specs (`rest-api.yml`, 14 indent levels, max indent 26), esphome
device configs, `goodcheck.yml`.

Plus 15 hand-written stress documents targeting exactly what the tracker touches:
`s01-nested-map-dedent`, `s02-seq-under-map`, `s03-block-literal-indicators` (`|2`, `|3`, `>-` —
the `BlockLiteralHeader` branch that builds a `type_Lit` context), `s04-dedent-reindent-cycle`,
`s05-flow-in-block`, `s06-multi-doc` (`---`/`...`), `s07-anchors-tags`, `s08-explicit-keys` (`? :`),
`s09-comments-blanks`, `s10-quoted-multiline`, `s11-deep-then-shallow` (six levels down, all the
way back), `s12-seq-of-seq`, `s13-literal-in-seq`, `s14-mixed-indent-widths` (3/5/6-space steps),
`s15-empty-values`.

The five edit kinds per document all move indentation, because that is the only thing the context
hash can catch: `indent+` (insert 1-2 spaces at a line start), `indent-`, `replaceLine`,
`deleteLine`, and `shift±2` — re-indenting a whole block, its opening line plus every deeper line,
in one range, which is what pressing Tab on a selection does.

## Red-first

`YamlIncrementalReuseTest`, three tests, on unmodified `origin/main` production code —
**26 tests, 1 failed** (26 = the module's 20 plus this file's 3 plus the 3 measurement harnesses
that were in the tree at that moment and are not part of this PR):

```
YamlIncrementalReuseTest[jvm] > reindentingATailLineDoesNotRestructureTheReusedHead[jvm] FAILED
    org.junit.ComparisonFailure:
    expected:<...ey(Literal),Literal)[)),Pair(Key(Literal)),Pair(Key(Literal),Literal]),Pair(...>
     but was:<...ey(Literal),Literal)[,Pair(Key(Literal)),Pair(Key(Literal),Literal))]),Pair(...>
```

The fixture is a real F-Droid metadata file, delta-debugged down to 1,106 characters; the edit
indents its trailing top-level `ArchivePolicy: 0` by four spaces. Before the change the reused head
swallows `Categories:` and `License:` into the `AntiFeatures:` mapping above them — two top-level
keys move a level down. Around a kilobyte is the floor for this: a node is only reusable if
`Tree.build` gave it its own `Tree` rather than packing it into a `TreeBuffer`, which needs more
than `bufferLength` buffer slots.

Two controls, green on both sides, are what stop that from being vacuous:

- `freshParseOfTheEditedDocumentMatchesUpstream` — the same document parsed from scratch, no
  fragments, same expectation. It holds before and after, so the failure is the fragment path and
  not the grammar or a wrong expectation.
- `theEditChangesTheTree` — the edit really does restructure the document, so the two trees are not
  trivially the same one.

The expectation is not the port's own output: it is what `@lezer/yaml` 1.0.4 produces for the edited
text, both fresh and incrementally (JS run, byte-identical to the string asserted).

## Mutation

Putting `strict = false` back with the test in place is the red-first run above: 1 failed,
`reindentingATailLineDoesNotRestructureTheReusedHead`, and the two controls stay green.

## Verification

- `:lang-yaml:jvmTest` — **20 before, 23 after**, 0 failures. The three added are exactly
  `YamlIncrementalReuseTest`'s; no existing test renamed, removed or edited (checked by diffing the
  full testcase-name lists out of `build/test-results/jvmTest/*.xml`, not by the delta).
- `:lezer-lr:jvmTest` **217 → 217**, `:language:jvmTest` **91 → 91**, 0 failures, name lists
  identical. Both sides measured from `origin/main` (`b23779a5`).
- `:lang-yaml:wasmJsBrowserTest` — **23 tests, 0 failures** (2 result XMLs read).
- `:lang-yaml:apiCheck` green; **no `.api` or `.klib.api` file moved** — `indentation` is private.
- `:lang-yaml:ktlintCheck` and `:lang-yaml:spotlessCheck` green (both gate `check` since #319).
- `changelog.py check --base-ref origin/main` green; `changelog.d/257.fixed.md` added,
  `CHANGELOG.md` untouched.
- All instrumentation removed before this PR: the reuse counter lived in a scratch copy of
  `Parse.kt` and the harnesses in `lang-yaml/src/jvmTest/`, both reverted. `grep` for
  `KmReuseProbe|KM257|println(` over `lang-yaml/src` and `lezer-lr/src` is empty, positive-controlled
  against `grep strict lang-yaml/src`, which matches.
- Every count above was read out of `build/test-results/**/*.xml`, and every measurement rerun with
  `--rerun`/`--rerun-tasks` after an earlier `UP-TO-DATE` no-op was caught silently reusing results.

## Seen, not bundled

- **#334** — upstream's `stream.end - from > parser.bufferLength * 4` threshold on building the
  `FragmentCursor` is still missing here, so this port reuses fragments on documents where upstream
  would not. Untouched; it is why the unit fixture cannot be reproduced against upstream JS.
- The one background positional divergence on `synth:s15-empty-values.yaml` (empty `BlockSequence`
  `Item` at 36-36 where `@lezer/yaml` says 39-39) and the six `CI-unix.yml` incremental divergences
  that survive this fix are both pre-existing and outside this change. Filed as #363 and #364.
- `:lezer-lr` and `:lang-python` are untouched, as is `CHANGELOG.md`.
